### PR TITLE
Feat/41 fe history

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "axios": "^1.7.7",
     "bcryptjs": "^2.4.3",
     "classnames": "^2.5.1",
+    "commander": "^12.1.0",
     "dayjs": "^1.11.13",
     "ejs": "^3.1.10",
     "fuse.js": "^7.0.0",

--- a/prisma/migrations/20241121075531_add_emission_factor_import_version/migration.sql
+++ b/prisma/migrations/20241121075531_add_emission_factor_import_version/migration.sql
@@ -1,0 +1,19 @@
+-- AlterTable
+ALTER TABLE "emission_factors" ADD COLUMN     "version_id" TEXT;
+
+-- CreateTable
+CREATE TABLE "emission_factor_import_version" (
+    "id" TEXT NOT NULL,
+    "intern_id" TEXT NOT NULL,
+    "source" "Import" NOT NULL,
+    "name" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "emission_factor_import_version_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "emission_factor_import_version_source_intern_id_key" ON "emission_factor_import_version"("source", "intern_id");
+
+-- AddForeignKey
+ALTER TABLE "emission_factors" ADD CONSTRAINT "emission_factors_version_id_fkey" FOREIGN KEY ("version_id") REFERENCES "emission_factor_import_version"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/migrations/20241121081037_add_emision_factor_version_id_in_study/migration.sql
+++ b/prisma/migrations/20241121081037_add_emision_factor_version_id_in_study/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `version_id` to the `studies` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "studies" ADD COLUMN     "version_id" TEXT NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "studies" ADD CONSTRAINT "studies_version_id_fkey" FOREIGN KEY ("version_id") REFERENCES "emission_factor_import_version"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema/emissionFactor.prisma
+++ b/prisma/schema/emissionFactor.prisma
@@ -75,11 +75,27 @@ enum SubPost {
   TraitementDesEmballagesEnFinDeVie
 }
 
+model EmissionFactorImportVersion {
+  id        String   @id @default(uuid())
+  internId  String   @map("intern_id")
+  source    Import
+  name      String
+  createdAt DateTime @default(now()) @map("created_at")
+
+  emissionFactors EmissionFactor[]
+
+  @@unique([source, internId])
+  @@map("emission_factor_import_version")
+}
+
 model EmissionFactor {
   id                  String               @id @default(uuid())
   createdAt           DateTime             @default(now()) @map("created_at")
   updatedAt           DateTime             @default(now()) @map("updated_at")
   emissionFactorParts EmissionFactorPart[]
+
+  versionId String?                      @map("version_id")
+  version   EmissionFactorImportVersion? @relation(fields: [versionId], references: [id])
 
   importedFrom   Import        @map("imported_from")
   importedId     String?       @map("imported_id")

--- a/prisma/schema/emissionFactor.prisma
+++ b/prisma/schema/emissionFactor.prisma
@@ -83,6 +83,7 @@ model EmissionFactorImportVersion {
   createdAt DateTime @default(now()) @map("created_at")
 
   emissionFactors EmissionFactor[]
+  Study           Study[]
 
   @@unique([source, internId])
   @@map("emission_factor_import_version")

--- a/prisma/schema/study.prisma
+++ b/prisma/schema/study.prisma
@@ -43,6 +43,9 @@ model Study {
   emissionSources StudyEmissionSource[]
   contributors    Contributors[]
 
+  versionId String                      @map("version_id")
+  version   EmissionFactorImportVersion @relation(fields: [versionId], references: [id])
+
   @@map("studies")
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -156,6 +156,7 @@ const users = async () => {
           level: faker.helpers.enumValue(Level),
           name: faker.lorem.words({ min: 2, max: 5 }),
           organizationId: creator.organizationId,
+          versionId: emissionFactorsImportVersion.id,
           emissionSources: {
             createMany: {
               data: faker.helpers.arrayElements(subPosts, { min: 1, max: subPosts.length }).flatMap((subPost) =>
@@ -187,6 +188,7 @@ const users = async () => {
       level: faker.helpers.enumValue(Level),
       name: faker.lorem.words({ min: 2, max: 5 }),
       organizationId: defaultUser.organizationId,
+      versionId: emissionFactorsImportVersion.id,
       emissionSources: {
         createMany: {
           data: faker.helpers.arrayElements(subPosts, { min: 1, max: subPosts.length }).flatMap((subPost) =>

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -16,6 +16,7 @@ const users = async () => {
   await prisma.studyEmissionSource.deleteMany()
   await prisma.contributors.deleteMany()
   await prisma.study.deleteMany()
+  await prisma.emissionFactorImportVersion.deleteMany()
 
   await prisma.site.deleteMany()
   await prisma.user.deleteMany()
@@ -136,6 +137,10 @@ const users = async () => {
         isActive: true,
       },
     ],
+  })
+
+  const emissionFactorsImportVersion = await prisma.emissionFactorImportVersion.create({
+    data: { source: Import.BaseEmpreinte, name: '1', internId: 'Base_Carbone_V1.csv' },
   })
 
   const subPosts = Object.keys(SubPost)

--- a/src/components/study/new/Form.tsx
+++ b/src/components/study/new/Form.tsx
@@ -130,7 +130,7 @@ const NewStudyForm = ({ organization, user, usersEmail }: Props) => {
         <Button type="submit" disabled={form.formState.isSubmitting} data-testid="new-study-create-button">
           {t('create')}
         </Button>
-        {error && <p>{error}</p>}
+        {error && <p>{t(`error.${error}`)}</p>}
       </Form>
     </Block>
   )

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -83,6 +83,10 @@
         "endDate": "Please select a study end date",
         "endDateBeforStartDate": "The end date must be after the start date",
         "level": "Please select the type of Carbon Assessment"
+      },
+      "error": {
+        "default": "Something went wrong ...",
+        "noActiveVersion_BaseEmpreinte": "No active version for BaseEmpreinte. Please contact support"
       }
     },
     "post": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -83,6 +83,10 @@
         "endDate": "Veuillez selectionner une date de fin d'étude",
         "endDateBeforStartDate": "La date de fin doit etre superieur à la date de début",
         "level": "Veuillez selectionner le type de Bilan Carbone"
+      },
+      "error": {
+        "default": "Une erreur s'est produite ...",
+        "noActiveVersion_BaseEmpreinte": "Aucune version active de Base Empreinte. Veuillez contacter le support."
       }
     },
     "post": {

--- a/src/services/serverFunctions/study.ts
+++ b/src/services/serverFunctions/study.ts
@@ -7,6 +7,7 @@ import {
   NewStudyRightCommand,
 } from './study.command'
 import { auth } from '../auth'
+import { prismaClient } from '@/db/client'
 import {
   createContributorOnStudy,
   createStudy,
@@ -15,7 +16,7 @@ import {
   updateStudy,
   updateUserOnStudy,
 } from '@/db/study'
-import { ControlMode, Export, Prisma, StudyRole, SubPost } from '@prisma/client'
+import { ControlMode, Export, Import, Prisma, StudyRole, SubPost } from '@prisma/client'
 import { NOT_AUTHORIZED } from '../permissions/check'
 import {
   canAddContributorOnStudy,
@@ -58,10 +59,20 @@ export const createStudyCommand = async ({
     })
   }
 
+  const activeVersion = await prismaClient.emissionFactorImportVersion.findFirst({
+    where: { source: Import.BaseEmpreinte },
+    orderBy: { createdAt: 'desc' },
+  })
+
+  if (!activeVersion) {
+    return { success: false, message: `noActiveVersion_${Import.BaseEmpreinte}` }
+  }
+
   const study = {
     ...command,
     createdBy: { connect: { id: session.user.id } },
     organization: { connect: { id: organizationId } },
+    version: { connect: { id: activeVersion.id } },
     isPublic: command.isPublic === 'true',
     allowedUsers: {
       createMany: { data: rights },
@@ -87,7 +98,7 @@ export const createStudyCommand = async ({
     return { success: true, id: createdStudy.id }
   } catch (e) {
     console.error(e)
-    return { success: false, message: 'Something went wrong...' }
+    return { success: false, message: 'default' }
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2768,6 +2768,11 @@ combined-stream@^1.0.8, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^12.1.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-12.1.0.tgz#01423b36f501259fdaac4d0e4d60c96c991585d3"
+  integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
+
 commander@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"


### PR DESCRIPTION
#41

- Ajout de la table version (id, name (= 23.4), source (= BaseEmpreinte), idInterne (= Base_Carbone_V23.4.csv), createdAt)
- Ajout de versionId aux table emission_factor et study
- Ajout d'un paramètre -n ou --name au script d'import des FE pour préciser le nom de l'import