### PR TITLE
Do not send the non existing user information on add person on study

### DIFF
--- a/src/app/(dashboard)/etudes/[id]/(contributor)/contributeur/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(contributor)/contributeur/page.tsx
@@ -21,7 +21,7 @@ const StudyView = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id, session.user.organizationId as string)
+  const study = await getStudyById(id, session.user.organizationId)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(contributor)/contributeur/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(contributor)/contributeur/page.tsx
@@ -21,7 +21,7 @@ const StudyView = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id)
+  const study = await getStudyById(id, session.user.organizationId as string)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/cadrage/ajouter-contributeur/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/cadrage/ajouter-contributeur/page.tsx
@@ -20,7 +20,7 @@ const NewStudyContributor = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id)
+  const study = await getStudyById(id, session.user.organizationId as string)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/cadrage/ajouter-contributeur/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/cadrage/ajouter-contributeur/page.tsx
@@ -20,7 +20,7 @@ const NewStudyContributor = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id, session.user.organizationId as string)
+  const study = await getStudyById(id, session.user.organizationId)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/cadrage/ajouter/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/cadrage/ajouter/page.tsx
@@ -20,7 +20,7 @@ const NewStudyRight = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id, session.user.organizationId as string)
+  const study = await getStudyById(id, session.user.organizationId)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/cadrage/ajouter/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/cadrage/ajouter/page.tsx
@@ -20,7 +20,7 @@ const NewStudyRight = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id)
+  const study = await getStudyById(id, session.user.organizationId as string)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/cadrage/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/cadrage/page.tsx
@@ -1,6 +1,6 @@
 import NotFound from '@/components/pages/NotFound'
 import StudyRightsPage from '@/components/pages/StudyRights'
-import { getStudyByWithAnonymousUsersOrganization } from '@/db/study'
+import { getStudyById } from '@/db/study'
 import { auth } from '@/services/auth'
 import { canReadStudyDetail } from '@/services/permissions/study'
 import { UUID } from 'crypto'
@@ -22,7 +22,7 @@ const StudyRights = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyByWithAnonymousUsersOrganization(id, session.user.organizationId as string)
+  const study = await getStudyById(id, session.user.organizationId as string)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/cadrage/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/cadrage/page.tsx
@@ -22,7 +22,7 @@ const StudyRights = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id, session.user.organizationId as string)
+  const study = await getStudyById(id, session.user.organizationId)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/cadrage/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/cadrage/page.tsx
@@ -1,6 +1,6 @@
 import NotFound from '@/components/pages/NotFound'
 import StudyRightsPage from '@/components/pages/StudyRights'
-import { getStudyById } from '@/db/study'
+import { getStudyByWithAnonymousUsersOrganization } from '@/db/study'
 import { auth } from '@/services/auth'
 import { canReadStudyDetail } from '@/services/permissions/study'
 import { UUID } from 'crypto'
@@ -22,7 +22,7 @@ const StudyRights = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id)
+  const study = await getStudyByWithAnonymousUsersOrganization(id, session.user.organizationId as string)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/comptabilisation/resultats/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/comptabilisation/resultats/page.tsx
@@ -21,7 +21,7 @@ const ResultatsPages = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id)
+  const study = await getStudyById(id, session.user.organizationId as string)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/comptabilisation/resultats/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/comptabilisation/resultats/page.tsx
@@ -21,7 +21,7 @@ const ResultatsPages = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id, session.user.organizationId as string)
+  const study = await getStudyById(id, session.user.organizationId)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/comptabilisation/saisie-des-donnees/[post]/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/comptabilisation/saisie-des-donnees/[post]/page.tsx
@@ -26,7 +26,7 @@ const StudyPost = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id, session.user.organizationId as string)
+  const study = await getStudyById(id, session.user.organizationId)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/comptabilisation/saisie-des-donnees/[post]/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/comptabilisation/saisie-des-donnees/[post]/page.tsx
@@ -26,7 +26,7 @@ const StudyPost = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id)
+  const study = await getStudyById(id, session.user.organizationId as string)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/comptabilisation/saisie-des-donnees/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/comptabilisation/saisie-des-donnees/page.tsx
@@ -25,7 +25,7 @@ const DataEntry = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id)
+  const study = await getStudyById(id, session.user.organizationId as string)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/comptabilisation/saisie-des-donnees/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/comptabilisation/saisie-des-donnees/page.tsx
@@ -25,7 +25,7 @@ const DataEntry = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id, session.user.organizationId as string)
+  const study = await getStudyById(id, session.user.organizationId)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/page.tsx
@@ -21,7 +21,7 @@ const StudyView = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id, session.user.organizationId as string)
+  const study = await getStudyById(id, session.user.organizationId)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/page.tsx
@@ -21,7 +21,7 @@ const StudyView = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id)
+  const study = await getStudyById(id, session.user.organizationId as string)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/perimetre/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/perimetre/page.tsx
@@ -20,7 +20,7 @@ const StudyPerimeter = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id)
+  const study = await getStudyById(id, session.user.organizationId as string)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/perimetre/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/perimetre/page.tsx
@@ -20,7 +20,7 @@ const StudyPerimeter = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id, session.user.organizationId as string)
+  const study = await getStudyById(id, session.user.organizationId)
 
   if (!study) {
     return <NotFound />

--- a/src/components/study/rights/NewStudyRightDialog.tsx
+++ b/src/components/study/rights/NewStudyRightDialog.tsx
@@ -20,8 +20,7 @@ const NewStudyRightDialog = ({ status, decline, accept }: Props) => {
       <DialogTitle id="new-study-right-dialog-title">{t('title')}</DialogTitle>
       <DialogContent>
         <DialogContentText id="new-study-right-dialog-description">
-          {status === NewStudyRightStatus.OtherOrganization && t('otherOrganization')}
-          {status === NewStudyRightStatus.NonExisting && t('nonExisting')}
+          {status === NewStudyRightStatus.ReaderOnly && t('readerOnly')}
         </DialogContentText>
       </DialogContent>
       <DialogActions>

--- a/src/components/study/rights/NewStudyRightDialog.tsx
+++ b/src/components/study/rights/NewStudyRightDialog.tsx
@@ -20,6 +20,7 @@ const NewStudyRightDialog = ({ status, decline, accept }: Props) => {
       <DialogTitle id="new-study-right-dialog-title">{t('title')}</DialogTitle>
       <DialogContent>
         <DialogContentText id="new-study-right-dialog-description">
+          {status === NewStudyRightStatus.OtherOrganization && t('otherOrganization')}
           {status === NewStudyRightStatus.ReaderOnly && t('readerOnly')}
         </DialogContentText>
       </DialogContent>

--- a/src/components/study/rights/NewStudyRightDialog.tsx
+++ b/src/components/study/rights/NewStudyRightDialog.tsx
@@ -21,7 +21,8 @@ const NewStudyRightDialog = ({ status, decline, accept }: Props) => {
       <DialogContent>
         <DialogContentText id="new-study-right-dialog-description">
           {status === NewStudyRightStatus.OtherOrganization && t('otherOrganization')}
-          {status === NewStudyRightStatus.ReaderOnly && t('readerOnly')}
+          {(status === NewStudyRightStatus.ReaderOnly || status === NewStudyRightStatus.InternReader) &&
+            t('readerOnly')}
         </DialogContentText>
       </DialogContent>
       <DialogActions>

--- a/src/components/study/rights/NewStudyRightDialog.tsx
+++ b/src/components/study/rights/NewStudyRightDialog.tsx
@@ -20,7 +20,8 @@ const NewStudyRightDialog = ({ status, decline, accept }: Props) => {
       <DialogTitle id="new-study-right-dialog-title">{t('title')}</DialogTitle>
       <DialogContent>
         <DialogContentText id="new-study-right-dialog-description">
-          {status === NewStudyRightStatus.OtherOrganization && t('otherOrganization')}
+          {(status === NewStudyRightStatus.OtherOrganization || status === NewStudyRightStatus.ReaderOnly) &&
+            t('otherOrganization')}
           {(status === NewStudyRightStatus.ReaderOnly || status === NewStudyRightStatus.InternReader) &&
             t('readerOnly')}
         </DialogContentText>

--- a/src/components/study/rights/NewStudyRightForm.tsx
+++ b/src/components/study/rights/NewStudyRightForm.tsx
@@ -49,7 +49,9 @@ const NewStudyRightForm = ({ study, user, users }: Props) => {
 
   const saveRight = async (command: NewStudyRightCommand) => {
     const result = await newStudyRight(
-      status === NewStudyRightStatus.ReaderOnly ? { ...command, role: StudyRole.Reader } : command,
+      status === NewStudyRightStatus.ReaderOnly || status === NewStudyRightStatus.InternReader
+        ? { ...command, role: StudyRole.Reader }
+        : command,
     )
 
     setStatus(undefined)
@@ -65,7 +67,11 @@ const NewStudyRightForm = ({ study, user, users }: Props) => {
     const status = await getNewStudyRightStatus(command.email, command.role, study.level)
     if (status === NewStudyRightStatus.Valid) {
       await saveRight(command)
-    } else if (status === NewStudyRightStatus.OtherOrganization || status === NewStudyRightStatus.ReaderOnly) {
+    } else if (
+      status === NewStudyRightStatus.OtherOrganization ||
+      status === NewStudyRightStatus.ReaderOnly ||
+      status === NewStudyRightStatus.InternReader
+    ) {
       setStatus(status)
     } else {
       setError(error)

--- a/src/components/study/rights/NewStudyRightForm.tsx
+++ b/src/components/study/rights/NewStudyRightForm.tsx
@@ -15,7 +15,7 @@ import { Role, StudyRole } from '@prisma/client'
 import { User } from 'next-auth'
 import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/navigation'
-import { SyntheticEvent, useCallback, useMemo, useState } from 'react'
+import { SyntheticEvent, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import NewStudyRightDialog from './NewStudyRightDialog'
 
@@ -31,7 +31,6 @@ const NewStudyRightForm = ({ study, user, users }: Props) => {
   const tRole = useTranslations('study.role')
 
   const [error, setError] = useState('')
-  const [externalUserWarning, setExternalUserWarning] = useState(false)
   const [status, setStatus] = useState<NewStudyRightStatus>()
 
   const form = useForm<NewStudyRightCommand>({
@@ -44,21 +43,8 @@ const NewStudyRightForm = ({ study, user, users }: Props) => {
     },
   })
 
-  const checkIfUserIsExternalUser = useCallback(
-    (value: string | null) => {
-      setExternalUserWarning(false)
-      const validEmail = NewStudyRightCommandValidation.shape.email.safeParse(value)
-      if (validEmail.success && !users.some((user) => user.email === validEmail.data)) {
-        setExternalUserWarning(true)
-      }
-    },
-    [users, setExternalUserWarning, NewStudyRightCommandValidation],
-  )
-
   const onEmailChange = (_: SyntheticEvent, value: string | null) => {
     form.setValue('email', value || '')
-    form.clearErrors('email')
-    checkIfUserIsExternalUser(value)
   }
 
   const saveRight = async (command: NewStudyRightCommand) => {
@@ -76,10 +62,10 @@ const NewStudyRightForm = ({ study, user, users }: Props) => {
   }
 
   const onSubmit = async (command: NewStudyRightCommand) => {
-    const status = await getNewStudyRightStatus(command.email, study.level, command.role)
+    const status = await getNewStudyRightStatus(command.email, command.role, study.level)
     if (status === NewStudyRightStatus.Valid) {
       await saveRight(command)
-    } else if (status === NewStudyRightStatus.ReaderOnly) {
+    } else if (status === NewStudyRightStatus.OtherOrganization || status === NewStudyRightStatus.ReaderOnly) {
       setStatus(status)
     } else {
       setError(error)
@@ -117,7 +103,6 @@ const NewStudyRightForm = ({ study, user, users }: Props) => {
           label={t('email')}
           onInputChange={onEmailChange}
           freeSolo
-          helperText={externalUserWarning ? t('validation.externalWarning') : ''}
         />
         <FormSelect
           control={form.control}

--- a/src/components/study/rights/NewStudyRightForm.tsx
+++ b/src/components/study/rights/NewStudyRightForm.tsx
@@ -49,8 +49,10 @@ const NewStudyRightForm = ({ study, user, users }: Props) => {
 
   const saveRight = async (command: NewStudyRightCommand) => {
     const result = await newStudyRight(
-      status === NewStudyRightStatus.NonExisting ? { ...command, role: StudyRole.Reader } : command,
+      status === NewStudyRightStatus.ReaderOnly ? { ...command, role: StudyRole.Reader } : command,
     )
+    console.log('result', result)
+
     setStatus(undefined)
     if (result) {
       setError(result)
@@ -61,10 +63,10 @@ const NewStudyRightForm = ({ study, user, users }: Props) => {
   }
 
   const onSubmit = async (command: NewStudyRightCommand) => {
-    const status = await getNewStudyRightStatus(command.email)
-    if (status === NewStudyRightStatus.SameOrganization) {
+    const status = await getNewStudyRightStatus(command.email, command.role)
+    if (status === NewStudyRightStatus.Valid) {
       await saveRight(command)
-    } else if (status === NewStudyRightStatus.OtherOrganization || status === NewStudyRightStatus.NonExisting) {
+    } else if (status === NewStudyRightStatus.ReaderOnly) {
       setStatus(status)
     } else {
       setError(error)

--- a/src/components/study/rights/NewStudyRightForm.tsx
+++ b/src/components/study/rights/NewStudyRightForm.tsx
@@ -51,7 +51,6 @@ const NewStudyRightForm = ({ study, user, users }: Props) => {
     const result = await newStudyRight(
       status === NewStudyRightStatus.ReaderOnly ? { ...command, role: StudyRole.Reader } : command,
     )
-    console.log('result', result)
 
     setStatus(undefined)
     if (result) {

--- a/src/components/study/rights/SelectStudyRole.tsx
+++ b/src/components/study/rights/SelectStudyRole.tsx
@@ -45,7 +45,7 @@ const SelectStudyRole = ({ user, rowUser, studyId, studyLevel, studyOrganization
       (currentRole === StudyRole.Validator &&
         userRole !== StudyRole.Validator &&
         (user.role !== Role.ADMIN || user.organizationId !== studyOrganizationId)) ||
-      'readerOnly' in rowUser,
+      ('readerOnly' in rowUser && rowUser.readerOnly),
     [currentRole, rowUser, studyLevel, user, userRole],
   )
 

--- a/src/components/study/rights/SelectStudyRole.tsx
+++ b/src/components/study/rights/SelectStudyRole.tsx
@@ -3,7 +3,7 @@
 import { FullStudy } from '@/db/study'
 import { changeStudyRole } from '@/services/serverFunctions/study'
 import { MenuItem, Select, SelectChangeEvent } from '@mui/material'
-import { Role, StudyRole } from '@prisma/client'
+import { Level, Role, StudyRole } from '@prisma/client'
 import { User } from 'next-auth'
 import { useTranslations } from 'next-intl'
 import { useEffect, useState } from 'react'
@@ -31,16 +31,19 @@ const SelectStudyRole = ({ user, rowUser, studyId, currentRole, userRole }: Prop
     }
   }
 
+  const isDisabled =
+    user.email === rowUser.email ||
+    (currentRole === StudyRole.Validator && userRole !== StudyRole.Validator && user.role !== Role.ADMIN) ||
+    !rowUser.organizationId ||
+    (user.organizationId !== rowUser.organizationId && rowUser.level === Level.Initial)
+
   return (
     <Select
       className="w100"
       data-testid="select-study-role"
       value={role}
       onChange={selectNewRole}
-      disabled={
-        user.email === rowUser.email ||
-        (currentRole === StudyRole.Validator && userRole !== StudyRole.Validator && user.role !== Role.ADMIN)
-      }
+      disabled={isDisabled}
     >
       {Object.keys(StudyRole)
         .filter((role) => role !== StudyRole.Validator || user.role === Role.ADMIN || userRole === StudyRole.Validator)

--- a/src/components/study/rights/StudyRightsTable.tsx
+++ b/src/components/study/rights/StudyRightsTable.tsx
@@ -38,6 +38,7 @@ const StudyRightsTable = ({ user, study, userRoleOnStudy }: Props) => {
               currentRole={role}
               rowUser={context.row.original.user}
               studyId={study.id}
+              studyLevel={study.level}
             />
           )
         },

--- a/src/components/study/rights/StudyRightsTable.tsx
+++ b/src/components/study/rights/StudyRightsTable.tsx
@@ -39,6 +39,7 @@ const StudyRightsTable = ({ user, study, userRoleOnStudy }: Props) => {
               rowUser={context.row.original.user}
               studyId={study.id}
               studyLevel={study.level}
+              studyOrganizationId={study.organizationId}
             />
           )
         },

--- a/src/db/study.ts
+++ b/src/db/study.ts
@@ -128,34 +128,31 @@ export const getStudiesByUserAndOrganization = async (user: User, organizationId
 }
 
 export const getStudyById = async (id: string, organizationId: string) => {
-  return prismaClient.study
-    .findUnique({
-      where: { id },
-      include: fullStudyInclude,
-    })
-    .then((study) => {
-      if (!study) {
-        return null
-      }
-      return {
-        ...study,
-        allowedUsers: study.allowedUsers.map((allowedUser) => {
-          const readerOnly =
-            !allowedUser.user.organizationId || !getAllowedLevels(allowedUser.user.level).includes(study.level)
-          return allowedUser.user.organizationId === organizationId
-            ? allowedUser
-            : {
-                ...allowedUser,
-                user: {
-                  ...allowedUser.user,
-                  organizationId: null,
-                  level: null,
-                  ...(readerOnly ? { readerOnly: true } : {}),
-                },
-              }
-        }),
-      }
-    })
+  const study = await prismaClient.study.findUnique({
+    where: { id },
+    include: fullStudyInclude,
+  })
+  if (!study) {
+    return null
+  }
+  return {
+    ...study,
+    allowedUsers: study.allowedUsers.map((allowedUser) => {
+      const readerOnly =
+        !allowedUser.user.organizationId || !getAllowedLevels(allowedUser.user.level).includes(study.level)
+      return allowedUser.user.organizationId === organizationId
+        ? allowedUser
+        : {
+            ...allowedUser,
+            user: {
+              ...allowedUser.user,
+              organizationId: undefined,
+              level: undefined,
+              readerOnly: readerOnly ? true : undefined,
+            },
+          }
+    }),
+  }
 }
 
 export type FullStudy = Exclude<AsyncReturnType<typeof getStudyById>, null>

--- a/src/db/study.ts
+++ b/src/db/study.ts
@@ -64,6 +64,7 @@ const fullStudyInclude = {
         select: {
           email: true,
           organizationId: true,
+          level: true,
         },
       },
       role: true,

--- a/src/db/study.ts
+++ b/src/db/study.ts
@@ -132,6 +132,22 @@ export const getStudyById = async (id: string) => {
     include: fullStudyInclude,
   })
 }
+
+export const getStudyByWithAnonymousUsersOrganization = async (id: string, organizationId: string) => {
+  return getStudyById(id).then((study) => {
+    if (!study) {
+      return null
+    }
+    return {
+      ...study,
+      allowedUsers: study.allowedUsers.map((allowedUser) =>
+        allowedUser.user.organizationId === organizationId
+          ? allowedUser
+          : { ...allowedUser, user: { ...allowedUser.user, organizationId: null } },
+      ),
+    }
+  })
+}
 export type FullStudy = Exclude<AsyncReturnType<typeof getStudyById>, null>
 
 export const createUserOnStudy = async (right: Prisma.UserOnStudyCreateInput) =>

--- a/src/db/study.ts
+++ b/src/db/study.ts
@@ -127,7 +127,7 @@ export const getStudiesByUserAndOrganization = async (user: User, organizationId
   })
 }
 
-export const getStudyById = async (id: string, organizationId: string) => {
+export const getStudyById = async (id: string, organizationId: string | null) => {
   const study = await prismaClient.study.findUnique({
     where: { id },
     include: fullStudyInclude,
@@ -140,7 +140,7 @@ export const getStudyById = async (id: string, organizationId: string) => {
     allowedUsers: study.allowedUsers.map((allowedUser) => {
       const readerOnly =
         !allowedUser.user.organizationId || !getAllowedLevels(allowedUser.user.level).includes(study.level)
-      return allowedUser.user.organizationId === organizationId
+      return organizationId && allowedUser.user.organizationId === organizationId
         ? allowedUser
         : {
             ...allowedUser,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -212,7 +212,7 @@
         },
         "dialog": {
           "title": "Are you sure you want to add this person to your study?",
-          "otherOrganization": "They are a BC+ user within another organization than yours.",
+          "otherOrganization": "They are not within your organization.",
           "readerOnly": "The person does not match the necessary conditions for this role. You will only be able to give them access to the study with READ or contribution rights. An email will be sent to them to give access to the study.",
           "accept": "Yes",
           "decline": "No"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -213,7 +213,7 @@
         "dialog": {
           "title": "Are you sure you want to add this person to your study?",
           "otherOrganization": "They are not within your organization.",
-          "readerOnly": "The person does not match the necessary conditions for this role. You will only be able to give them access to the study with READ or contribution rights. An email will be sent to them to give access to the study.",
+          "readerOnly": "They not match the necessary conditions for this role. You will only be able to give them access to the study with READ or contribution rights. An email will be sent to them to give access to the study.",
           "accept": "Yes",
           "decline": "No"
         }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -212,6 +212,7 @@
         },
         "dialog": {
           "title": "Are you sure you want to add this person to your study?",
+          "otherOrganization": "They are a BC+ user within another organization than yours.",
           "readerOnly": "The person does not match the necessary conditions for this role. You will only be able to give them access to the study with READ or contribution rights. An email will be sent to them to give access to the study.",
           "accept": "Yes",
           "decline": "No"

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -207,7 +207,8 @@
         "validation": {
           "email": "Please use a valid email",
           "emailRequired": "Please enter an email",
-          "role": "Please select a role"
+          "role": "Please select a role",
+          "externalWarning": "Warning, the person is not part of your organization"
         },
         "dialog": {
           "title": "Are you sure you want to add this person to your study?",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -211,8 +211,7 @@
         },
         "dialog": {
           "title": "Are you sure you want to add this person to your study?",
-          "otherOrganization": "They are a BC+ user within another organization than yours.",
-          "nonExisting": "They are not a BC+ user, so you will only be able to give them access to the study with read or contribution rights. An email will be sent to them to give access to the study.",
+          "readerOnly": "The person does not match the necessary conditions for this role. You will only be able to give them access to the study with READ or contribution rights. An email will be sent to them to give access to the study.",
           "accept": "Yes",
           "decline": "No"
         }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -205,7 +205,8 @@
         "validation": {
           "email": "Veuillez utiliser un email valide",
           "emailRequired": "Veuillez entrer un email",
-          "role": "Veuillez sélectionner un droit"
+          "role": "Veuillez sélectionner un droit",
+          "externalWarning": "Attention, cette personne ne fait pas partie de votre organisation"
         },
         "dialog": {
           "title": "Êtes-vous sûr de vouloir ajouter cette personne à votre étude ?",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -211,7 +211,7 @@
         "dialog": {
           "title": "Êtes-vous sûr de vouloir ajouter cette personne à votre étude ?",
           "otherOrganization": "Elle ne fait pas partie de votre organisation.",
-          "readerOnly": "La personne ne réunit pas les conditions nécessaires pour l'ajouter avec ce rôle. Vous ne pourrez donc lui donner un accès à l'étude qu'avec les droits de LECTURE ou de contribution. Un mail lui sera envoyé pour lui donner accès à l'étude.",
+          "readerOnly": "Elle ne réunit pas les conditions nécessaires pour l'ajouter avec ce rôle. Vous ne pourrez donc lui donner un accès à l'étude qu'avec les droits de LECTURE ou de contribution. Un mail lui sera envoyé pour lui donner accès à l'étude.",
           "accept": "Oui",
           "decline": "Non"
         }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -208,9 +208,8 @@
           "role": "Veuillez sélectionner un droit"
         },
         "dialog": {
-          "title": "Êtes-vous sûr de vouloir ajouter cette personne à votre étude ?",
-          "otherOrganization": "Elle est utilisatrice du BC+ au sein d'une autre organisation que la votre.",
-          "nonExisting": "Elle n'est pas utilisatrice du BC+, vous ne pourrez donc lui donner un accès à l'étude qu'avec les droits de lecture ou de contribution. Un mail lui sera envoyé pour lui donner accès à l'étude.",
+          "title": "Êtes-vous sûr de vouloir ajouter cette personne à votre étude ?",
+          "readerOnly": "La personne ne réunit pas les conditions nécessaires pour l'ajouter avec ce rôle. Vous ne pourrez donc lui donner un accès à l'étude qu'avec les droits de LECTURE ou de contribution. Un mail lui sera envoyé pour lui donner accès à l'étude.",
           "accept": "Oui",
           "decline": "Non"
         }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -210,6 +210,7 @@
         },
         "dialog": {
           "title": "Êtes-vous sûr de vouloir ajouter cette personne à votre étude ?",
+          "otherOrganization": "Elle est utilisatrice du BC+ au sein d'une autre organisation que la votre.",
           "readerOnly": "La personne ne réunit pas les conditions nécessaires pour l'ajouter avec ce rôle. Vous ne pourrez donc lui donner un accès à l'étude qu'avec les droits de LECTURE ou de contribution. Un mail lui sera envoyé pour lui donner accès à l'étude.",
           "accept": "Oui",
           "decline": "Non"

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -210,7 +210,7 @@
         },
         "dialog": {
           "title": "Êtes-vous sûr de vouloir ajouter cette personne à votre étude ?",
-          "otherOrganization": "Elle est utilisatrice du BC+ au sein d'une autre organisation que la votre.",
+          "otherOrganization": "Elle ne fait pas partie de votre organisation.",
           "readerOnly": "La personne ne réunit pas les conditions nécessaires pour l'ajouter avec ce rôle. Vous ne pourrez donc lui donner un accès à l'étude qu'avec les droits de LECTURE ou de contribution. Un mail lui sera envoyé pour lui donner accès à l'étude.",
           "accept": "Oui",
           "decline": "Non"

--- a/src/services/permissions/emissionSource.ts
+++ b/src/services/permissions/emissionSource.ts
@@ -8,7 +8,7 @@ export const canCreateEmissionSource = async (
   emissionSource: Pick<StudyEmissionSource, 'studyId' | 'subPost'> & { emissionFactorId?: string | null },
   study?: FullStudy,
 ) => {
-  const dbStudy = study || (await getStudyById(emissionSource.studyId))
+  const dbStudy = study || (await getStudyById(emissionSource.studyId, user.organizationId as string))
   if (!dbStudy) {
     return false
   }

--- a/src/services/permissions/emissionSource.ts
+++ b/src/services/permissions/emissionSource.ts
@@ -8,7 +8,7 @@ export const canCreateEmissionSource = async (
   emissionSource: Pick<StudyEmissionSource, 'studyId' | 'subPost'> & { emissionFactorId?: string | null },
   study?: FullStudy,
 ) => {
-  const dbStudy = study || (await getStudyById(emissionSource.studyId, user.organizationId as string))
+  const dbStudy = study || (await getStudyById(emissionSource.studyId, user.organizationId))
   if (!dbStudy) {
     return false
   }

--- a/src/services/serverFunctions/emissionSource.ts
+++ b/src/services/serverFunctions/emissionSource.ts
@@ -57,7 +57,7 @@ export const updateEmissionSource = async ({
   }
   const data = { ...command, emissionFactor: emissionFactorId ? { connect: { id: emissionFactorId } } : undefined }
 
-  const study = await getStudyById(emissionSource.studyId, user.organizationId as string)
+  const study = await getStudyById(emissionSource.studyId, user.organizationId)
   if (!study || !(await canUpdateEmissionSource(user, emissionSource, data, study))) {
     return NOT_AUTHORIZED
   }
@@ -84,7 +84,7 @@ export const deleteEmissionSource = async (emissionSourceId: string) => {
   if (!user || !emissionSource) {
     return NOT_AUTHORIZED
   }
-  const study = await getStudyById(emissionSource.studyId, user.organizationId as string)
+  const study = await getStudyById(emissionSource.studyId, user.organizationId)
 
   if (!study || !(await canDeleteEmissionSource(user, study))) {
     return NOT_AUTHORIZED

--- a/src/services/serverFunctions/emissionSource.ts
+++ b/src/services/serverFunctions/emissionSource.ts
@@ -57,7 +57,7 @@ export const updateEmissionSource = async ({
   }
   const data = { ...command, emissionFactor: emissionFactorId ? { connect: { id: emissionFactorId } } : undefined }
 
-  const study = await getStudyById(emissionSource.studyId)
+  const study = await getStudyById(emissionSource.studyId, user.organizationId as string)
   if (!study || !(await canUpdateEmissionSource(user, emissionSource, data, study))) {
     return NOT_AUTHORIZED
   }
@@ -84,7 +84,7 @@ export const deleteEmissionSource = async (emissionSourceId: string) => {
   if (!user || !emissionSource) {
     return NOT_AUTHORIZED
   }
-  const study = await getStudyById(emissionSource.studyId)
+  const study = await getStudyById(emissionSource.studyId, user.organizationId as string)
 
   if (!study || !(await canDeleteEmissionSource(user, study))) {
     return NOT_AUTHORIZED

--- a/src/services/serverFunctions/study.ts
+++ b/src/services/serverFunctions/study.ts
@@ -135,7 +135,7 @@ const getStudyRightsInformations = async (studyId: string) => {
     return null
   }
 
-  const studyWithRights = await getStudyById(studyId, session.user.organizationId as string)
+  const studyWithRights = await getStudyById(studyId, session.user.organizationId)
 
   if (!studyWithRights) {
     return null
@@ -206,7 +206,7 @@ export const newStudyRight = async (right: NewStudyRightCommand) => {
   }
 
   const [studyWithRights, newUser] = await Promise.all([
-    getStudyById(right.studyId, session.user.organizationId as string),
+    getStudyById(right.studyId, session.user.organizationId),
     getUserByEmail(right.email),
   ])
 
@@ -247,7 +247,7 @@ export const changeStudyRole = async (studyId: string, email: string, studyRole:
   }
 
   const [studyWithRights, user] = await Promise.all([
-    getStudyById(studyId, session.user.organizationId as string),
+    getStudyById(studyId, session.user.organizationId),
     getUserByEmail(email),
   ])
 
@@ -269,7 +269,7 @@ export const newStudyContributor = async ({ email, post, subPost, ...command }: 
   }
 
   const [studyWithRights, user] = await Promise.all([
-    getStudyById(command.studyId, session.user.organizationId as string),
+    getStudyById(command.studyId, session.user.organizationId),
     getUserByEmail(email),
   ])
 

--- a/src/services/serverFunctions/study.ts
+++ b/src/services/serverFunctions/study.ts
@@ -196,7 +196,9 @@ export const getNewStudyRightStatus = async (email: string, role: StudyRole, stu
       : NewStudyRightStatus.ReaderOnly
   }
 
-  return NewStudyRightStatus.Valid
+  return getAllowedLevels(newUser.level).includes(studyLevel)
+    ? NewStudyRightStatus.Valid
+    : NewStudyRightStatus.InternReader
 }
 
 export const newStudyRight = async (right: NewStudyRightCommand) => {

--- a/src/services/serverFunctions/study.ts
+++ b/src/services/serverFunctions/study.ts
@@ -194,9 +194,7 @@ export const getNewStudyRightStatus = async (email: string, role: StudyRole) => 
   }
 
   if (newUser.organizationId !== session.user.organizationId) {
-    // TODO : check if the organization has an up-to-date licence
-    console.log('level : ', newUser.level)
-
+    // TODO : check if the organization has an up-to-date licences
     return newUser.level === Level.Initial ? NewStudyRightStatus.ReaderOnly : NewStudyRightStatus.Valid
   }
 

--- a/src/services/serverFunctions/study.ts
+++ b/src/services/serverFunctions/study.ts
@@ -23,7 +23,7 @@ import {
   canCreateStudy,
 } from '../permissions/study'
 import { subPostsByPost } from '../posts'
-import { NewStudyRightStatus } from '../study'
+import { getAllowedLevels, NewStudyRightStatus } from '../study'
 import {
   ChangeStudyDatesCommand,
   ChangeStudyLevelCommand,
@@ -178,7 +178,7 @@ export const changeStudyDates = async ({ studyId, ...command }: ChangeStudyDates
   await updateStudy(studyId, command)
 }
 
-export const getNewStudyRightStatus = async (email: string, role: StudyRole) => {
+export const getNewStudyRightStatus = async (email: string, studyLevel: Level, role: StudyRole) => {
   const session = await auth()
   if (!session || !session.user) {
     return NOT_AUTHORIZED
@@ -195,7 +195,9 @@ export const getNewStudyRightStatus = async (email: string, role: StudyRole) => 
 
   if (newUser.organizationId !== session.user.organizationId) {
     // TODO : check if the organization has an up-to-date licences
-    return newUser.level === Level.Initial ? NewStudyRightStatus.ReaderOnly : NewStudyRightStatus.Valid
+    return newUser.level && getAllowedLevels(studyLevel).includes(newUser.level)
+      ? NewStudyRightStatus.Valid
+      : NewStudyRightStatus.ReaderOnly
   }
 
   return NewStudyRightStatus.Valid

--- a/src/services/study.ts
+++ b/src/services/study.ts
@@ -16,6 +16,7 @@ const getQuality = (quality: ReturnType<typeof getQualityRating>, t: ReturnType<
 
 export enum NewStudyRightStatus {
   Valid,
+  OtherOrganization,
   ReaderOnly,
 }
 

--- a/src/services/study.ts
+++ b/src/services/study.ts
@@ -21,11 +21,11 @@ export enum NewStudyRightStatus {
 
 export const getAllowedLevels = (level: Level | null) => {
   switch (level) {
-    case Level.Advanced:
+    case Level.Initial:
       return [Level.Initial]
     case Level.Standard:
       return [Level.Initial, Level.Standard]
-    case Level.Initial:
+    case Level.Advanced:
       return [Level.Initial, Level.Standard, Level.Advanced]
     default:
       return []

--- a/src/services/study.ts
+++ b/src/services/study.ts
@@ -15,9 +15,8 @@ const getQuality = (quality: ReturnType<typeof getQualityRating>, t: ReturnType<
 }
 
 export enum NewStudyRightStatus {
-  SameOrganization,
-  OtherOrganization,
-  NonExisting,
+  Valid,
+  ReaderOnly,
 }
 
 export const getAllowedLevels = (level: Level | null) => {

--- a/src/services/study.ts
+++ b/src/services/study.ts
@@ -16,6 +16,7 @@ const getQuality = (quality: ReturnType<typeof getQualityRating>, t: ReturnType<
 
 export enum NewStudyRightStatus {
   Valid,
+  InternReader,
   OtherOrganization,
   ReaderOnly,
 }

--- a/src/tests/end-to-end/app/study-rights.cy.ts
+++ b/src/tests/end-to-end/app/study-rights.cy.ts
@@ -55,25 +55,25 @@ describe('Create study', () => {
     cy.getByTestId('study-rights-email').type('bc-admin-1@yopmail.com')
 
     cy.getByTestId('study-rights-role').click()
-    cy.get('[data-value="Reader"]').click()
+    cy.get('[data-value="Editor"]').click()
 
     cy.getByTestId('study-rights-create-button').click()
     cy.getByTestId('new-study-right-dialog-accept').click()
     cy.wait('@create')
 
-    cy.getByTestId('study-rights-table-line').eq(0).contains('bc-admin-1@yopmail.comLecteur')
+    cy.getByTestId('study-rights-table-line').eq(0).contains('bc-admin-1@yopmail.comÉditeur')
     cy.getByTestId('study-rights-table-line')
       .eq(0)
       .within(() => {
         cy.get('input').should('not.be.disabled')
         cy.get('.MuiSelect-select').click()
       })
-    cy.get('[data-value="Editor"]').click()
+    cy.get('[data-value="Validator"]').click()
     cy.wait('@update')
 
     cy.reload()
 
-    cy.getByTestId('study-rights-table-line').eq(0).contains('bc-admin-1@yopmail.comÉditeur')
+    cy.getByTestId('study-rights-table-line').eq(0).contains('bc-admin-1@yopmail.comValidateur')
     cy.getByTestId('study-rights-table-line')
       .eq(0)
       .within(() => {
@@ -104,12 +104,97 @@ describe('Create study', () => {
     cy.getByTestId('study-rights-table-line')
       .eq(1)
       .within(() => {
-        cy.get('input').should('not.be.disabled')
+        cy.get('input').should('be.disabled')
       })
     cy.getByTestId('study-rights-table-line')
       .eq(0)
       .within(() => {
         cy.get('input').should('be.disabled')
+      })
+  })
+
+  it('should receive a warning message when set an unauthorized role', () => {
+    cy.login()
+
+    cy.visit('/etudes/creer')
+    cy.getByTestId('organization-sites-checkbox').first().click()
+    cy.getByTestId('new-study-organization-button').click()
+
+    cy.getByTestId('new-study-name').should('be.visible').type('Study with unauthorized rights')
+    cy.getByTestId('new-validator-name').click()
+    cy.get('[data-option-index="1"]').click()
+
+    cy.getByTestId('new-study-endDate').within(() => {
+      cy.get('input').type(dayjs().add(1, 'y').format('DD/MM/YYYY'))
+    })
+    cy.getByTestId('new-study-level').click()
+    cy.get('[data-value="Initial"]').click()
+    cy.getByTestId('new-study-create-button').click()
+
+    cy.getByTestId('study-cadrage-link').click()
+
+    cy.getByTestId('study-rights-table-line').contains('bc-default-0@yopmail.comValidateur')
+    cy.getByTestId('study-rights-table-line').within(() => {
+      cy.get('input').should('be.disabled')
+    })
+
+    cy.getByTestId('study-rights-change-button').click()
+
+    cy.getByTestId('study-rights-email').should('be.visible')
+    cy.getByTestId('study-rights-email').type('bc-cr-default-0@yopmail.com')
+    cy.getByTestId('study-rights-role').click()
+    cy.get('[data-value="Editor"]').click()
+
+    cy.getByTestId('study-rights-create-button').click()
+    cy.getByTestId('new-study-right-dialog-accept').should('be.visible')
+    cy.getByTestId('new-study-right-dialog-accept').click()
+    cy.wait('@create')
+
+    cy.getByTestId('study-rights-table-line').eq(0).contains('bc-cr-default-0@yopmail.comLecteur')
+    cy.getByTestId('study-rights-table-line')
+      .eq(0)
+      .within(() => {
+        cy.get('input').should('be.disabled')
+      })
+
+    cy.getByTestId('study-rights-change-button').click()
+
+    cy.getByTestId('study-rights-email').should('be.visible')
+    cy.getByTestId('study-rights-email').type('external@yopmail.com')
+
+    cy.getByTestId('study-rights-role').click()
+    cy.get('[data-value="Validator"]').click()
+
+    cy.getByTestId('study-rights-create-button').click()
+    cy.getByTestId('new-study-right-dialog-accept').should('be.visible')
+    cy.getByTestId('new-study-right-dialog-accept').click()
+    cy.wait('@create')
+
+    cy.getByTestId('study-rights-table-line').eq(2).contains('external@yopmail.comLecteur')
+    cy.getByTestId('study-rights-table-line')
+      .eq(2)
+      .within(() => {
+        cy.get('input').should('be.disabled')
+      })
+
+    cy.getByTestId('study-rights-change-button').click()
+
+    cy.getByTestId('study-rights-email').should('be.visible')
+    cy.getByTestId('study-rights-email').type('bc-admin-2@yopmail.com')
+
+    cy.getByTestId('study-rights-role').click()
+    cy.get('[data-value="Validator"]').click()
+
+    cy.getByTestId('study-rights-create-button').click()
+    cy.getByTestId('new-study-right-dialog-accept').should('be.visible')
+    cy.getByTestId('new-study-right-dialog-accept').click()
+    cy.wait('@create')
+
+    cy.getByTestId('study-rights-table-line').eq(0).contains('bc-admin-2@yopmail.comValidateur')
+    cy.getByTestId('study-rights-table-line')
+      .eq(0)
+      .within(() => {
+        cy.get('input').should('not.be.disabled')
       })
   })
 })

--- a/src/tests/end-to-end/app/study-rights.cy.ts
+++ b/src/tests/end-to-end/app/study-rights.cy.ts
@@ -104,6 +104,44 @@ describe('Create study', () => {
     cy.getByTestId('study-rights-table-line')
       .eq(1)
       .within(() => {
+        cy.get('input').should('not.be.disabled')
+      })
+    cy.getByTestId('study-rights-table-line')
+      .eq(0)
+      .within(() => {
+        cy.get('input').should('be.disabled')
+      })
+
+    cy.url().then((link) => {
+      cy.logout()
+      cy.login()
+      cy.visit(link)
+    })
+    cy.getByTestId('study-rights-table-line')
+      .eq(0)
+      .within(() => {
+        cy.get('input').should('not.be.disabled')
+        cy.get('.MuiSelect-select').click()
+      })
+    cy.get('[data-value="Editor"]').click()
+    cy.wait('@update')
+
+    cy.url().then((link) => {
+      cy.logout()
+      cy.login('bc-admin-1@yopmail.com', 'password-1')
+      cy.visit(link)
+    })
+
+    cy.getByTestId('select-study-role').should('have.length', 3)
+
+    cy.getByTestId('study-rights-table-line')
+      .eq(2)
+      .within(() => {
+        cy.get('input').should('not.be.disabled')
+      })
+    cy.getByTestId('study-rights-table-line')
+      .eq(1)
+      .within(() => {
         cy.get('input').should('be.disabled')
       })
     cy.getByTestId('study-rights-table-line')
@@ -114,7 +152,7 @@ describe('Create study', () => {
   })
 
   it('should receive a warning message when set an unauthorized role', () => {
-    cy.login()
+    cy.login('bc-default-1@yopmail.com', 'password-1')
 
     cy.visit('/etudes/creer')
     cy.getByTestId('organization-sites-checkbox').first().click()
@@ -128,12 +166,12 @@ describe('Create study', () => {
       cy.get('input').type(dayjs().add(1, 'y').format('DD/MM/YYYY'))
     })
     cy.getByTestId('new-study-level').click()
-    cy.get('[data-value="Initial"]').click()
+    cy.get('[data-value="Standard"]').click()
     cy.getByTestId('new-study-create-button').click()
 
     cy.getByTestId('study-cadrage-link').click()
 
-    cy.getByTestId('study-rights-table-line').contains('bc-default-0@yopmail.comValidateur')
+    cy.getByTestId('study-rights-table-line').contains('bc-default-1@yopmail.comValidateur')
     cy.getByTestId('study-rights-table-line').within(() => {
       cy.get('input').should('be.disabled')
     })


### PR DESCRIPTION
#186 

Manque le check sur la licence (pas encore implémentée niveau organisation)

Propositions de changement des messages (mettre en évidence le changement de droit). Ce message n'est affiché que si le droit initialement sélectionné n'est pas lecteur :
---
- otherOrganization: "They are not within your organization.",
- readerOnly: "If they do not match the necessary conditions for this role, you will only be able to give them access to this study only with READ or contribution rights. An email will be sent to them to give access to the study.",
---
- otherOrganization: "Elle ne fait pas partie de votre organisation."
- readerOnly: "Si elle ne réunit pas les conditions nécessaires pour l'ajouter avec ce rôle, vous ne pourrez donc lui donner un accès qu'à cette étude et avec les droits de LECTURE ou de contribution. Un mail lui sera envoyé pour lui donner accès à l'étude."
---

Scénario réalisés :
- Ajout d'une personne hors organisation, avec les droits de lecteur -> otherOrganization
- Ajout d'une personne hors organisation, avec les droits editeur/validateur  -> otherOrganization + readerOnly
- Ajout d'une personne membre de l'organisation, dont on sait qu'elle n'a pas le niveau pour l'étude -> on force le rôle à Lecteur et on désactive le selecteur de rôles

Pour les membres hors orga, on fait le check à la création de l'étude (et on corrige éventuellement le rôle attribué). Ainsi, on ne fait aucune distinction entre les comptes et les externes, ce qui permet de ne plus donner d'indication