### PR TITLE
feat: link emission source to study site

### DIFF
--- a/prisma/migrations/20241209095246_link_source_to_site/migration.sql
+++ b/prisma/migrations/20241209095246_link_source_to_site/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `site_id` to the `study_emission_sources` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "study_emission_sources" ADD COLUMN     "site_id" TEXT NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "study_emission_sources" ADD CONSTRAINT "study_emission_sources_site_id_fkey" FOREIGN KEY ("site_id") REFERENCES "StudySite"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema/study.prisma
+++ b/prisma/schema/study.prisma
@@ -119,6 +119,9 @@ model StudyEmissionSource {
   emissionFactorId String?         @map("emission_factor_id")
   emissionFactor   EmissionFactor? @relation(fields: [emissionFactorId], references: [id])
 
+  siteId String    @map("site_id")
+  site   StudySite @relation(fields: [siteId], references: [id])
+
   value                        Float?
   reliability                  Int?
   technicalRepresentativeness  Int?                @map("technical_representativeness")
@@ -166,6 +169,7 @@ model StudySite {
   siteId String @map("site_id")
   site   Site   @relation(fields: [siteId], references: [id])
 
-  etp Int
-  ca  Float
+  etp                 Int
+  ca                  Float
+  StudyEmissionSource StudyEmissionSource[]
 }

--- a/src/components/pages/StudyPosts.tsx
+++ b/src/components/pages/StudyPosts.tsx
@@ -10,6 +10,7 @@ import Breadcrumbs from '../breadcrumbs/Breadcrumbs'
 import SubPosts from '../study/SubPosts'
 import StudyPostsBlock from '../study/buttons/StudyPostsBlock'
 import StudyPostInfography from '../study/infography/StudyPostInfography'
+import SelectStudySite from '../study/site/SelectStudySite'
 
 interface Props {
   post: Post
@@ -30,7 +31,9 @@ const StudyPostsPage = ({ post, study, user }: Props) => {
           { label: study.name, link: `/etudes/${study.id}` },
         ]}
       />
-      <Block title={study.name} as="h1" />
+      <Block title={study.name} as="h1">
+        <SelectStudySite study={study} />
+      </Block>
       <StudyPostsBlock post={post} study={study} display={showInfography} setDisplay={setShowInfography}>
         {showInfography && <StudyPostInfography study={study} />}
         <SubPosts post={post} study={study} user={user} withoutDetail={false} />

--- a/src/components/study/NewEmissionSource.tsx
+++ b/src/components/study/NewEmissionSource.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/navigation'
 import { FocusEvent, KeyboardEvent, useCallback, useState } from 'react'
 import styles from './NewEmissionSource.module.css'
+import { getStudySite } from './site/useStudySite'
 
 interface Props {
   study: FullStudy
@@ -35,6 +36,7 @@ const NewEmissionSource = ({ study, subPost, caracterisations }: Props) => {
           name: event.target.value,
           subPost,
           studyId: study.id,
+          siteId: getStudySite(study.id),
           caracterisation: caracterisations.length === 1 ? caracterisations[0] : undefined,
         })
         if (!result) {

--- a/src/components/study/site/SelectStudySite.tsx
+++ b/src/components/study/site/SelectStudySite.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { FullStudy } from '@/db/study'
+import { FormControl, InputLabel, MenuItem, Select } from '@mui/material'
+import { useTranslations } from 'next-intl'
+import { useEffect } from 'react'
+import useStudySite from './useStudySite'
+
+interface Props {
+  study: FullStudy
+  allowAll?: boolean
+}
+
+const SelectStudySite = ({ study, allowAll }: Props) => {
+  const t = useTranslations('study.organization')
+  const { site, setSite } = useStudySite(study.id)
+
+  useEffect(() => {
+    if (!site && !allowAll) {
+      setSite(study.sites[0].id)
+    }
+  }, [allowAll])
+
+  return (
+    <FormControl>
+      <InputLabel id="study-site-select">{t('site')}</InputLabel>
+      <Select
+        labelId="study-site-select"
+        label={t('site')}
+        value={site}
+        onChange={(event) => setSite(event.target.value)}
+        disabled={study.sites.length === 1 || allowAll}
+      >
+        {allowAll && <MenuItem value={''}>{t('all')}</MenuItem>}
+        {study.sites.map((site) => (
+          <MenuItem key={site.id} value={site.id}>
+            {site.site.name}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  )
+}
+
+export default SelectStudySite

--- a/src/components/study/site/useStudySite.ts
+++ b/src/components/study/site/useStudySite.ts
@@ -1,0 +1,19 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export const getStudySite = (studyId: string) => window.localStorage.getItem(`studySite-${studyId}`) || ''
+
+export default function useStudySite(studyId: string) {
+  const [site, setSite] = useState<string>('')
+
+  useEffect(() => {
+    setSite(getStudySite(studyId))
+  }, [studyId])
+
+  useEffect(() => {
+    window.localStorage.setItem(`studySite-${studyId}`, site)
+  }, [site])
+
+  return { site, setSite }
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -175,6 +175,8 @@
       "new": "Add an emission source..."
     },
     "organization": {
+      "site": "Site",
+      "allSites": "All sites",
       "noSites": "There are no sites configured for the organization",
       "addSite": "Create a site",
       "title": "Which organization is concerned by the study?",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -173,6 +173,8 @@
       "new": "Ajouter une source d'émission..."
     },
     "organization": {
+      "site": "Site",
+      "allSites": "Tous les sites",
       "noSites": "Il n'y a pas de sites configurés sur l'organisation",
       "addSite": "Creer un site",
       "title": "Quelle organisation est concernée par l'étude ?",

--- a/src/services/permissions/emissionSource.ts
+++ b/src/services/permissions/emissionSource.ts
@@ -5,7 +5,7 @@ import { canReadStudy } from './study'
 
 export const canCreateEmissionSource = async (
   user: User,
-  emissionSource: Pick<StudyEmissionSource, 'studyId' | 'subPost'> & { emissionFactorId?: string | null },
+  emissionSource: Pick<StudyEmissionSource, 'studyId' | 'subPost' | 'siteId'> & { emissionFactorId?: string | null },
   study?: FullStudy,
 ) => {
   const dbStudy = study || (await getStudyById(emissionSource.studyId))
@@ -14,6 +14,10 @@ export const canCreateEmissionSource = async (
   }
 
   if (!(await canReadStudy(user, dbStudy))) {
+    return false
+  }
+
+  if (!dbStudy.sites.find((site) => site.id === emissionSource.siteId)) {
     return false
   }
 

--- a/src/services/serverFunctions/emissionSource.command.ts
+++ b/src/services/serverFunctions/emissionSource.command.ts
@@ -5,6 +5,7 @@ export const CreateEmissionSourceCommandValidation = z.object({
   name: z.string().trim().min(1, 'name'),
   subPost: z.nativeEnum(SubPost),
   studyId: z.string(),
+  siteId: z.string(),
   caracterisation: z.nativeEnum(EmissionSourceCaracterisation).optional(),
 })
 

--- a/src/services/serverFunctions/emissionSource.ts
+++ b/src/services/serverFunctions/emissionSource.ts
@@ -17,7 +17,7 @@ import {
 } from '../permissions/emissionSource'
 import { CreateEmissionSourceCommand, UpdateEmissionSourceCommand } from './emissionSource.command'
 
-export const createEmissionSource = async ({ studyId, ...command }: CreateEmissionSourceCommand) => {
+export const createEmissionSource = async ({ studyId, siteId, ...command }: CreateEmissionSourceCommand) => {
   const session = await auth()
   if (!session || !session.user) {
     return NOT_AUTHORIZED
@@ -28,12 +28,13 @@ export const createEmissionSource = async ({ studyId, ...command }: CreateEmissi
     return NOT_AUTHORIZED
   }
 
-  if (!(await canCreateEmissionSource(user, { studyId, ...command }))) {
+  if (!(await canCreateEmissionSource(user, { studyId, siteId, ...command }))) {
     return NOT_AUTHORIZED
   }
 
   await createEmissionSourceOnStudy({
     ...command,
+    site: { connect: { id: siteId } },
     study: { connect: { id: studyId } },
   })
 }


### PR DESCRIPTION
concerns #157 

Uniquement la gestion de l'appartenance d'une source d'emission à un site
RAF :
Les onglets de resultats par site

note: le local storage et le hook est legerement revu dans la PR suivante pour le useCase allowAll