### PR TITLE
Fix/165 study graphs

### DIFF
--- a/src/components/home/UserView.module.css
+++ b/src/components/home/UserView.module.css
@@ -1,6 +1,7 @@
 .container {
   display: flex;
   gap: 1rem;
+
   @media screen and (max-width: 60rem) {
     flex-direction: column-reverse;
   }

--- a/src/components/home/UserView.tsx
+++ b/src/components/home/UserView.tsx
@@ -1,12 +1,12 @@
 import { getUserOrganizations } from '@/db/user'
-import classNames from 'classnames'
 import { User } from 'next-auth'
 import { Suspense } from 'react'
 import Actualities from '../actuality/Actualities'
+import Block from '../base/Block'
 import Organizations from '../organization/OrganizationsContainer'
 import ResultsContainerForUser from '../study/results/ResultsContainerForUser'
 import Studies from '../study/StudiesContainer'
-import styles from './styles.module.css'
+import styles from './UserView.module.css'
 
 interface Props {
   user: User
@@ -17,15 +17,19 @@ const UserView = async ({ user }: Props) => {
   const isCR = organizations.find((organization) => organization.id === user.organizationId)?.isCR
 
   return (
-    <div className="flex-col">
+    <>
       <Suspense>
-        <ResultsContainerForUser user={user} mainStudyOrganizationId={user.organizationId} />
+        <Block>
+          <ResultsContainerForUser user={user} mainStudyOrganizationId={user.organizationId} />
+        </Block>
       </Suspense>
-      <div className={classNames(styles.container, 'w100')}>
-        <Actualities />
-        {isCR ? <Organizations organizations={organizations} /> : <Studies user={user} />}
-      </div>
-    </div>
+      <Block>
+        <div className={styles.container}>
+          <Actualities />
+          {isCR ? <Organizations organizations={organizations} /> : <Studies user={user} />}
+        </div>
+      </Block>
+    </>
   )
 }
 

--- a/src/components/home/UserView.tsx
+++ b/src/components/home/UserView.tsx
@@ -19,7 +19,7 @@ const UserView = async ({ user }: Props) => {
   return (
     <div className="flex-col">
       <Suspense>
-        <ResultsContainerForUser user={user} />
+        <ResultsContainerForUser user={user} mainStudyOrganizationId={user.organizationId} />
       </Suspense>
       <div className={classNames(styles.container, 'w100')}>
         <Actualities />

--- a/src/components/home/UserView.tsx
+++ b/src/components/home/UserView.tsx
@@ -18,11 +18,13 @@ const UserView = async ({ user }: Props) => {
 
   return (
     <>
-      <Suspense>
-        <Block>
-          <ResultsContainerForUser user={user} mainStudyOrganizationId={user.organizationId} />
-        </Block>
-      </Suspense>
+      {user.organizationId && (
+        <Suspense>
+          <Block>
+            <ResultsContainerForUser user={user} mainStudyOrganizationId={user.organizationId} />
+          </Block>
+        </Suspense>
+      )}
       <Block>
         <div className={styles.container}>
           <Actualities />

--- a/src/components/pages/Organization.tsx
+++ b/src/components/pages/Organization.tsx
@@ -25,7 +25,7 @@ const OrganizationPage = ({ organizations, user }: Props) => {
       <OrganizationInfo organization={organizations[0]} user={user} />
       <Block>
         <Suspense>
-          <ResultsContainerForUser user={user} />
+          <ResultsContainerForUser user={user} mainStudyOrganizationId={organizations[0].id} />
         </Suspense>
         <Studies user={user} organizationId={organizations[0].id} />
       </Block>

--- a/src/components/pages/Organization.tsx
+++ b/src/components/pages/Organization.tsx
@@ -27,6 +27,8 @@ const OrganizationPage = ({ organizations, user }: Props) => {
         <Suspense>
           <ResultsContainerForUser user={user} mainStudyOrganizationId={organizations[0].id} />
         </Suspense>
+      </Block>
+      <Block>
         <Studies user={user} organizationId={organizations[0].id} />
       </Block>
     </>

--- a/src/components/study/results/Result.tsx
+++ b/src/components/study/results/Result.tsx
@@ -18,8 +18,6 @@ interface Props {
   site: string
 }
 
-const sort = (arr: string[]) => arr.sort((a, b) => a.length - b.length)
-
 const Result = ({ study, by, site }: Props) => {
   const t = useTranslations('results')
   const tExport = useTranslations('study.export')
@@ -32,7 +30,7 @@ const Result = ({ study, by, site }: Props) => {
 
   const selectorOptions = Object.values(Post)
 
-  const xAxis = useMemo(() => sort(by === 'Post' ? Object.values(Post) : subPostsByPost[post]), [post, by])
+  const xAxis = useMemo(() => (by === 'Post' ? Object.values(Post) : subPostsByPost[post]), [post, by])
 
   const yData = useMemo(() => {
     const computedResults = computeResultsByPost(study, tPost, site)

--- a/src/components/study/results/Result.tsx
+++ b/src/components/study/results/Result.tsx
@@ -17,6 +17,19 @@ interface Props {
   site: string
 }
 
+const postXAxisList = [
+  Post.Energies,
+  Post.DechetsDirects,
+  Post.IntrantsBienEtMatieres,
+  Post.IntrantsServices,
+  Post.AutresEmissionsNonEnergetiques,
+  Post.Fret,
+  Post.Deplacements,
+  Post.Immobilisations,
+  Post.UtilisationEtDependance,
+  Post.FinDeVie,
+]
+
 const Result = ({ study, by, site }: Props) => {
   const t = useTranslations('results')
   const tExport = useTranslations('study.export')
@@ -29,7 +42,7 @@ const Result = ({ study, by, site }: Props) => {
 
   const selectorOptions = Object.values(Post)
 
-  const xAxis = useMemo(() => (by === 'Post' ? Object.values(Post) : subPostsByPost[post]), [post, by])
+  const xAxis = useMemo(() => (by === 'Post' ? postXAxisList : subPostsByPost[post]), [post, by])
 
   const yData = useMemo(() => {
     const computedResults = computeResultsByPost(study, tPost, site)
@@ -97,7 +110,7 @@ const Result = ({ study, by, site }: Props) => {
   }
 
   return (
-    <div className="">
+    <>
       <h3 className="mb1">{t(`by${by}`)}</h3>
       {by === 'SubPost' && (
         <div className="flex mb1">
@@ -116,7 +129,7 @@ const Result = ({ study, by, site }: Props) => {
       <div style={{ height: dynamicHeight }}>
         <canvas data-testid={`study-${by}-chart`} ref={canvasRef} />
       </div>
-    </div>
+    </>
   )
 }
 

--- a/src/components/study/results/Result.tsx
+++ b/src/components/study/results/Result.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import Box from '@/components/base/Box'
 import Button from '@/components/base/Button'
 import { FullStudy } from '@/db/study'
 import { Post, subPostsByPost } from '@/services/posts'
@@ -98,7 +97,7 @@ const Result = ({ study, by, site }: Props) => {
   }
 
   return (
-    <Box className="grow flex-col">
+    <div className="grow flex-col">
       <h4 className="mb1">{t(`by${by}`)}</h4>
       {by === 'SubPost' && (
         <div className="flex mb1">
@@ -117,7 +116,7 @@ const Result = ({ study, by, site }: Props) => {
       <div style={{ height: dynamicHeight }}>
         <canvas data-testid={`study-${by}-chart`} ref={canvasRef} />
       </div>
-    </Box>
+    </div>
   )
 }
 

--- a/src/components/study/results/Result.tsx
+++ b/src/components/study/results/Result.tsx
@@ -97,8 +97,8 @@ const Result = ({ study, by, site }: Props) => {
   }
 
   return (
-    <div className="grow flex-col">
-      <h4 className="mb1">{t(`by${by}`)}</h4>
+    <div className="">
+      <h3 className="mb1">{t(`by${by}`)}</h3>
       {by === 'SubPost' && (
         <div className="flex mb1">
           <Select className="mr-2 grow" value={post} onChange={(e) => setPost(e.target.value as Post)}>

--- a/src/components/study/results/ResultsContainer.module.css
+++ b/src/components/study/results/ResultsContainer.module.css
@@ -1,17 +1,37 @@
 .studyName {
-  font-size: 1.5rem;
-  font-weight: bold;
+  text-align: center;
+  margin-bottom: 1rem;
 }
 
 .container {
+  position: relative;
   border-radius: 1rem;
-  gap: 1rem;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(500px, 1fr) 1);
+  display: flex;
+  justify-content: space-between;
+  @media screen and (max-width: 60rem) {
+    flex-direction: column;
+    gap: 1rem;
+  }
+}
+
+.separatorContainer {
+  position: relative;
+  display: flex;
+  align-items: center;
+  @media screen and (max-width: 60rem) {
+    display: none;
+  }
 }
 
 .separator {
+  width: 1px;
   height: 80%;
-  align-self: center;
   background-color: var(--neutral-30);
+}
+
+.graph {
+  width: calc(50% - 1rem);
+  @media screen and (max-width: 60rem) {
+    width: 100%;
+  }
 }

--- a/src/components/study/results/ResultsContainer.module.css
+++ b/src/components/study/results/ResultsContainer.module.css
@@ -1,6 +1,17 @@
+.studyName {
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
 .container {
   border-radius: 1rem;
   gap: 1rem;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(500px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(500px, 1fr) 1);
+}
+
+.separator {
+  height: 80%;
+  align-self: center;
+  background-color: var(--neutral-30);
 }

--- a/src/components/study/results/ResultsContainerForStudy.tsx
+++ b/src/components/study/results/ResultsContainerForStudy.tsx
@@ -1,5 +1,5 @@
+import Box from '@/components/base/Box'
 import { FullStudy } from '@/db/study'
-import classNames from 'classnames'
 import Result from './Result'
 import styles from './ResultsContainer.module.css'
 
@@ -10,12 +10,20 @@ interface Props {
 
 const ResultsContainerForStudy = ({ study, site }: Props) => {
   return (
-    <div className="pb1">
-      <div className={classNames(styles.container, 'wrap')}>
-        <Result study={study} by="Post" site={site} />
-        <Result study={study} by="SubPost" site={site} />
+    <Box>
+      <h2 className={styles.studyName}>{study.name}</h2>
+      <div className={styles.container}>
+        <div className={styles.graph}>
+          <Result study={study} by="Post" site={site} />
+        </div>
+        <div className={styles.separatorContainer}>
+          <div className={styles.separator} />
+        </div>
+        <div className={styles.graph}>
+          <Result study={study} by="SubPost" site={site} />
+        </div>
       </div>
-    </div>
+    </Box>
   )
 }
 

--- a/src/components/study/results/ResultsContainerForUser.tsx
+++ b/src/components/study/results/ResultsContainerForUser.tsx
@@ -1,5 +1,6 @@
 'use server'
 
+import Box from '@/components/base/Box'
 import { getMainStudy } from '@/db/study'
 import { canReadStudy } from '@/services/permissions/study'
 import classNames from 'classnames'
@@ -18,10 +19,14 @@ const ResultsContainerForUser = async ({ user, mainStudyOrganizationId }: Props)
 
   return showResults ? (
     <div className="pb1">
-      <div className={classNames(styles.container, 'wrap')}>
-        <Result study={study} by="Post" site="all" />
-        <Result study={study} by="SubPost" site="all" />
-      </div>
+      <Box>
+        <div className={classNames(styles.studyName, 'grow justify-center mb-2')}>{study.name}</div>
+        <div className={classNames(styles.container)}>
+          <Result study={study} by="Post" site="all" />
+          <div className={styles.separator} />
+          <Result study={study} by="SubPost" site="all" />
+        </div>
+      </Box>
     </div>
   ) : null
 }

--- a/src/components/study/results/ResultsContainerForUser.tsx
+++ b/src/components/study/results/ResultsContainerForUser.tsx
@@ -9,10 +9,11 @@ import styles from './ResultsContainer.module.css'
 
 interface Props {
   user: User
+  mainStudyOrganizationId: string | null
 }
 
-const ResultsContainerForUser = async ({ user }: Props) => {
-  const study = await getMainStudy(user)
+const ResultsContainerForUser = async ({ user, mainStudyOrganizationId }: Props) => {
+  const study = await getMainStudy(user, mainStudyOrganizationId)
   const showResults = study && (await canReadStudy(user, study))
 
   return showResults ? (

--- a/src/components/study/results/ResultsContainerForUser.tsx
+++ b/src/components/study/results/ResultsContainerForUser.tsx
@@ -7,11 +7,11 @@ import ResultsContainerForStudy from './ResultsContainerForStudy'
 
 interface Props {
   user: User
-  mainStudyOrganizationId: string | null
+  mainStudyOrganizationId: string
 }
 
 const ResultsContainerForUser = async ({ user, mainStudyOrganizationId }: Props) => {
-  const study = await getMainStudy(user, mainStudyOrganizationId)
+  const study = await getMainStudy(mainStudyOrganizationId)
   const showResults = study && (await canReadStudy(user, study))
 
   return showResults ? <ResultsContainerForStudy study={study} site="all" /> : null

--- a/src/components/study/results/ResultsContainerForUser.tsx
+++ b/src/components/study/results/ResultsContainerForUser.tsx
@@ -1,12 +1,9 @@
 'use server'
 
-import Box from '@/components/base/Box'
 import { getMainStudy } from '@/db/study'
 import { canReadStudy } from '@/services/permissions/study'
-import classNames from 'classnames'
 import { User } from 'next-auth'
-import Result from './Result'
-import styles from './ResultsContainer.module.css'
+import ResultsContainerForStudy from './ResultsContainerForStudy'
 
 interface Props {
   user: User
@@ -17,18 +14,7 @@ const ResultsContainerForUser = async ({ user, mainStudyOrganizationId }: Props)
   const study = await getMainStudy(user, mainStudyOrganizationId)
   const showResults = study && (await canReadStudy(user, study))
 
-  return showResults ? (
-    <div className="pb1">
-      <Box>
-        <div className={classNames(styles.studyName, 'grow justify-center mb-2')}>{study.name}</div>
-        <div className={classNames(styles.container)}>
-          <Result study={study} by="Post" site="all" />
-          <div className={styles.separator} />
-          <Result study={study} by="SubPost" site="all" />
-        </div>
-      </Box>
-    </div>
-  ) : null
+  return showResults ? <ResultsContainerForStudy study={study} site="all" /> : null
 }
 
 export default ResultsContainerForUser

--- a/src/db/study.ts
+++ b/src/db/study.ts
@@ -90,16 +90,12 @@ const fullStudyInclude = {
   exports: { select: { type: true } },
 } satisfies Prisma.StudyInclude
 
-export const getMainStudy = async (user: User) => {
-  const userOrganizations = await getUserOrganizations(user.email)
+export const getMainStudy = async (user: User, organizationId: string | null) => {
+  if (!organizationId) {
+    return null
+  }
   return prismaClient.study.findFirst({
-    where: {
-      OR: [
-        { organizationId: { in: userOrganizations.map((organization) => organization.id) } },
-        { allowedUsers: { some: { userId: user.id } } },
-        { contributors: { some: { userId: user.id } } },
-      ],
-    },
+    where: { organizationId },
     include: fullStudyInclude,
     orderBy: { startDate: 'desc' },
   })

--- a/src/db/study.ts
+++ b/src/db/study.ts
@@ -90,16 +90,12 @@ const fullStudyInclude = {
   exports: { select: { type: true } },
 } satisfies Prisma.StudyInclude
 
-export const getMainStudy = async (user: User, organizationId: string | null) => {
-  if (!organizationId) {
-    return null
-  }
-  return prismaClient.study.findFirst({
+export const getMainStudy = async (organizationId: string) =>
+  prismaClient.study.findFirst({
     where: { organizationId },
     include: fullStudyInclude,
     orderBy: { startDate: 'desc' },
   })
-}
 
 export const getStudiesByUser = async (user: User) => {
   const userOrganizations = await getUserOrganizations(user.email)

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -279,7 +279,7 @@
       "allPost": "All posts",
       "allSubPost": "All sub posts",
       "Energies": "Energies",
-      "AutresEmissionsNonEnergetiques": "Other non-energy emissions",
+      "AutresEmissionsNonEnergetiques": "Other direct emissions",
       "IntrantsBienEtMatieres": "Goods and materials inputs",
       "IntrantsServices": "Service inputs",
       "DechetsDirects": "Direct waste",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -277,7 +277,7 @@
       "allPost": "Tout les postes",
       "allSubPost": "Tout les sous postes",
       "Energies": "Énergies",
-      "AutresEmissionsNonEnergetiques": "Autres émissions non énergétiques",
+      "AutresEmissionsNonEnergetiques": "Autres émissions directes",
       "IntrantsBienEtMatieres": "Intrants bien et matières",
       "IntrantsServices": "Intrants services",
       "DechetsDirects": "Déchets directs",

--- a/src/services/posts.ts
+++ b/src/services/posts.ts
@@ -2,10 +2,10 @@ import { SubPost } from '@prisma/client'
 
 export enum Post {
   Energies = 'Energies',
-  DechetsDirects = 'DechetsDirects',
+  AutresEmissionsNonEnergetiques = 'AutresEmissionsNonEnergetiques',
   IntrantsBienEtMatieres = 'IntrantsBienEtMatieres',
   IntrantsServices = 'IntrantsServices',
-  AutresEmissionsNonEnergetiques = 'AutresEmissionsNonEnergetiques',
+  DechetsDirects = 'DechetsDirects',
   Fret = 'Fret',
   Deplacements = 'Deplacements',
   Immobilisations = 'Immobilisations',
@@ -21,14 +21,12 @@ export const subPostsByPost: Record<Post, SubPost[]> = {
     SubPost.ReseauxDeFroid,
     SubPost.Electricite,
   ],
-  [Post.DechetsDirects]: [
-    SubPost.DechetsDEmballagesEtPlastiques,
-    SubPost.DechetsOrganiques,
-    SubPost.DechetsOrduresMenageres,
-    SubPost.DechetsDangereux,
-    SubPost.DechetsBatiments,
-    SubPost.DechetsFuitesOuEmissionsNonEnergetiques,
-    SubPost.EauxUsees,
+  [Post.AutresEmissionsNonEnergetiques]: [
+    SubPost.Agriculture,
+    SubPost.EmissionsLieesAuChangementDAffectationDesSolsCas,
+    SubPost.EmissionsLieesALaProductionDeFroid,
+    SubPost.EmissionsLieesAuxProcedesIndustriels,
+    SubPost.AutresEmissionsNonEnergetiques,
   ],
   [Post.IntrantsBienEtMatieres]: [
     SubPost.MetauxPlastiquesEtVerre,
@@ -41,12 +39,14 @@ export const subPostsByPost: Record<Post, SubPost[]> = {
     SubPost.BiensEtMatieresEnApprocheMonetaire,
   ],
   [Post.IntrantsServices]: [SubPost.AchatsDeServices, SubPost.UsagesNumeriques, SubPost.ServicesEnApprocheMonetaire],
-  [Post.AutresEmissionsNonEnergetiques]: [
-    SubPost.Agriculture,
-    SubPost.EmissionsLieesAuChangementDAffectationDesSolsCas,
-    SubPost.EmissionsLieesALaProductionDeFroid,
-    SubPost.EmissionsLieesAuxProcedesIndustriels,
-    SubPost.AutresEmissionsNonEnergetiques,
+  [Post.DechetsDirects]: [
+    SubPost.DechetsDEmballagesEtPlastiques,
+    SubPost.DechetsOrganiques,
+    SubPost.DechetsOrduresMenageres,
+    SubPost.DechetsDangereux,
+    SubPost.DechetsBatiments,
+    SubPost.DechetsFuitesOuEmissionsNonEnergetiques,
+    SubPost.EauxUsees,
   ],
   [Post.Fret]: [SubPost.FretEntrant, SubPost.FretInterne, SubPost.FretSortant],
   [Post.Deplacements]: [

--- a/src/services/posts.ts
+++ b/src/services/posts.ts
@@ -2,10 +2,10 @@ import { SubPost } from '@prisma/client'
 
 export enum Post {
   Energies = 'Energies',
-  AutresEmissionsNonEnergetiques = 'AutresEmissionsNonEnergetiques',
+  DechetsDirects = 'DechetsDirects',
   IntrantsBienEtMatieres = 'IntrantsBienEtMatieres',
   IntrantsServices = 'IntrantsServices',
-  DechetsDirects = 'DechetsDirects',
+  AutresEmissionsNonEnergetiques = 'AutresEmissionsNonEnergetiques',
   Fret = 'Fret',
   Deplacements = 'Deplacements',
   Immobilisations = 'Immobilisations',
@@ -21,12 +21,14 @@ export const subPostsByPost: Record<Post, SubPost[]> = {
     SubPost.ReseauxDeFroid,
     SubPost.Electricite,
   ],
-  [Post.AutresEmissionsNonEnergetiques]: [
-    SubPost.Agriculture,
-    SubPost.EmissionsLieesAuChangementDAffectationDesSolsCas,
-    SubPost.EmissionsLieesALaProductionDeFroid,
-    SubPost.EmissionsLieesAuxProcedesIndustriels,
-    SubPost.AutresEmissionsNonEnergetiques,
+  [Post.DechetsDirects]: [
+    SubPost.DechetsDEmballagesEtPlastiques,
+    SubPost.DechetsOrganiques,
+    SubPost.DechetsOrduresMenageres,
+    SubPost.DechetsDangereux,
+    SubPost.DechetsBatiments,
+    SubPost.DechetsFuitesOuEmissionsNonEnergetiques,
+    SubPost.EauxUsees,
   ],
   [Post.IntrantsBienEtMatieres]: [
     SubPost.MetauxPlastiquesEtVerre,
@@ -39,14 +41,12 @@ export const subPostsByPost: Record<Post, SubPost[]> = {
     SubPost.BiensEtMatieresEnApprocheMonetaire,
   ],
   [Post.IntrantsServices]: [SubPost.AchatsDeServices, SubPost.UsagesNumeriques, SubPost.ServicesEnApprocheMonetaire],
-  [Post.DechetsDirects]: [
-    SubPost.DechetsDEmballagesEtPlastiques,
-    SubPost.DechetsOrganiques,
-    SubPost.DechetsOrduresMenageres,
-    SubPost.DechetsDangereux,
-    SubPost.DechetsBatiments,
-    SubPost.DechetsFuitesOuEmissionsNonEnergetiques,
-    SubPost.EauxUsees,
+  [Post.AutresEmissionsNonEnergetiques]: [
+    SubPost.Agriculture,
+    SubPost.EmissionsLieesAuChangementDAffectationDesSolsCas,
+    SubPost.EmissionsLieesALaProductionDeFroid,
+    SubPost.EmissionsLieesAuxProcedesIndustriels,
+    SubPost.AutresEmissionsNonEnergetiques,
   ],
   [Post.Fret]: [SubPost.FretEntrant, SubPost.FretInterne, SubPost.FretSortant],
   [Post.Deplacements]: [

--- a/src/services/results/beges.ts
+++ b/src/services/results/beges.ts
@@ -139,7 +139,12 @@ export const computeBegesResult = (
       ? study.emissionSources
       : study.emissionSources.filter((emissionSource) => emissionSource.site.id === site)
   emissionSources.forEach((emissionSource) => {
-    if (emissionSource.emissionFactor === null || !emissionSource.value || emissionSource.caracterisation === null) {
+    if (
+      emissionSource.emissionFactor === null ||
+      !emissionSource.value ||
+      emissionSource.caracterisation === null ||
+      !emissionSource.validated
+    ) {
       return
     }
 

--- a/src/services/results/consolidated.ts
+++ b/src/services/results/consolidated.ts
@@ -22,15 +22,15 @@ export const computeResultsByPost = (study: FullStudy, tPost: (key: string) => s
     .map((post) => {
       const subPosts = subPostsByPost[post]
         .map((subPost) => {
-          const emissionSources = siteEmissionSources.filter((emissionSource) => emissionSource.subPost === subPost)
+          const emissionSources = siteEmissionSources.filter(
+            (emissionSource) => emissionSource.subPost === subPost && emissionSource.validated,
+          )
           return {
             post: subPost,
             value: emissionSources.reduce(
               (acc, emission) =>
                 acc +
-                (!emission.value || !emission.emissionFactor || !emission.validated
-                  ? 0
-                  : emission.value * emission.emissionFactor.totalCo2),
+                (!emission.value || !emission.emissionFactor ? 0 : emission.value * emission.emissionFactor.totalCo2),
               0,
             ),
             numberOfEmissionSource: emissionSources.length,

--- a/src/services/results/consolidated.ts
+++ b/src/services/results/consolidated.ts
@@ -28,7 +28,9 @@ export const computeResultsByPost = (study: FullStudy, tPost: (key: string) => s
             value: emissionSources.reduce(
               (acc, emission) =>
                 acc +
-                (!emission.value || !emission.emissionFactor ? 0 : emission.value * emission.emissionFactor.totalCo2),
+                (!emission.value || !emission.emissionFactor || !emission.validated
+                  ? 0
+                  : emission.value * emission.emissionFactor.totalCo2),
               0,
             ),
             numberOfEmissionSource: emissionSources.length,


### PR DESCRIPTION
#165 Suite aux retours de Gabriel en staging : 
- On ne veut plus afficher les émissions des sources non validées sur les graphs : Le comportement est étendu aux infographies et résultats (vu avec Chloé)
- Changement de l'ordre des postes dans les graphs
- Changement de l'étude principale : On récupère la dernière étude de l'organisation (user.organizationId pour les utilisateurs normaux, organization.id pour les page d'accueil des organisations)
- Ajout du nom de l'étude pour éviter les doutes sur l'étude affichée