### PR TITLE
Do not send the non existing user information on add person on study

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -171,6 +171,20 @@ const users = async () => {
       },
     ],
   })
+  await prisma.user.createManyAndReturn({
+    data: [
+      {
+        email: 'untrained@yopmail.com',
+        firstName: faker.person.firstName(),
+        lastName: faker.person.lastName(),
+        password: await signPassword('password'),
+        level: Level.Initial,
+        organizationId: regularOrganizations[1].id,
+        role: Role.DEFAULT,
+        isActive: true,
+      },
+    ],
+  })
 
   const emissionFactorsImportVersion = await prisma.emissionFactorImportVersion.create({
     data: { source: Import.BaseEmpreinte, name: '1', internId: 'Base_Carbone_V1.csv' },

--- a/src/app/(dashboard)/etudes/[id]/(contributor)/contributeur/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(contributor)/contributeur/page.tsx
@@ -21,7 +21,7 @@ const StudyView = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id)
+  const study = await getStudyById(id, session.user.organizationId)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/cadrage/ajouter-contributeur/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/cadrage/ajouter-contributeur/page.tsx
@@ -20,7 +20,7 @@ const NewStudyContributor = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id)
+  const study = await getStudyById(id, session.user.organizationId)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/cadrage/ajouter/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/cadrage/ajouter/page.tsx
@@ -20,7 +20,7 @@ const NewStudyRight = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id)
+  const study = await getStudyById(id, session.user.organizationId)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/cadrage/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/cadrage/page.tsx
@@ -22,7 +22,7 @@ const StudyRights = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id)
+  const study = await getStudyById(id, session.user.organizationId)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/comptabilisation/resultats/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/comptabilisation/resultats/page.tsx
@@ -21,7 +21,7 @@ const ResultatsPages = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id)
+  const study = await getStudyById(id, session.user.organizationId)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/comptabilisation/saisie-des-donnees/[post]/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/comptabilisation/saisie-des-donnees/[post]/page.tsx
@@ -26,7 +26,7 @@ const StudyPost = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id)
+  const study = await getStudyById(id, session.user.organizationId)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/comptabilisation/saisie-des-donnees/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/comptabilisation/saisie-des-donnees/page.tsx
@@ -20,7 +20,7 @@ const DataEntry = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id)
+  const study = await getStudyById(id, session.user.organizationId)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/page.tsx
@@ -21,7 +21,7 @@ const StudyView = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id)
+  const study = await getStudyById(id, session.user.organizationId)
 
   if (!study) {
     return <NotFound />

--- a/src/app/(dashboard)/etudes/[id]/(organization)/perimetre/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/perimetre/page.tsx
@@ -20,7 +20,7 @@ const StudyPerimeter = async (props: Props) => {
     return <NotFound />
   }
 
-  const study = await getStudyById(id)
+  const study = await getStudyById(id, session.user.organizationId)
 
   if (!study) {
     return <NotFound />

--- a/src/components/study/rights/NewStudyRightDialog.tsx
+++ b/src/components/study/rights/NewStudyRightDialog.tsx
@@ -1,27 +1,26 @@
 import Button from '@/components/base/Button'
-import { NewStudyRightStatus } from '@/services/study'
 import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@mui/material'
 import { useTranslations } from 'next-intl'
 
 interface Props {
+  otherOrganization: boolean
   rightsWarning: boolean
-  status?: NewStudyRightStatus
   decline: () => void
   accept: () => void
 }
-const NewStudyRightDialog = ({ rightsWarning, status, decline, accept }: Props) => {
+const NewStudyRightDialog = ({ otherOrganization, rightsWarning, decline, accept }: Props) => {
   const t = useTranslations('study.rights.new.dialog')
 
   return (
     <Dialog
-      open={status !== undefined}
+      open={otherOrganization}
       aria-labelledby="new-study-right-dialog-title"
       aria-describedby="new-study-right-dialog-description"
     >
       <DialogTitle id="new-study-right-dialog-title">{t('title')}</DialogTitle>
       <DialogContent>
         <DialogContentText id="new-study-right-dialog-description">
-          {status === NewStudyRightStatus.OtherOrganization && t('otherOrganization')}
+          {t('otherOrganization')}
           {rightsWarning && t('rightsWarning')}
         </DialogContentText>
       </DialogContent>

--- a/src/components/study/rights/NewStudyRightDialog.tsx
+++ b/src/components/study/rights/NewStudyRightDialog.tsx
@@ -4,16 +4,17 @@ import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } 
 import { useTranslations } from 'next-intl'
 
 interface Props {
+  rightsWarning: boolean
   status?: NewStudyRightStatus
   decline: () => void
   accept: () => void
 }
-const NewStudyRightDialog = ({ status, decline, accept }: Props) => {
+const NewStudyRightDialog = ({ rightsWarning, status, decline, accept }: Props) => {
   const t = useTranslations('study.rights.new.dialog')
 
   return (
     <Dialog
-      open={!!status}
+      open={status !== undefined}
       aria-labelledby="new-study-right-dialog-title"
       aria-describedby="new-study-right-dialog-description"
     >
@@ -21,7 +22,7 @@ const NewStudyRightDialog = ({ status, decline, accept }: Props) => {
       <DialogContent>
         <DialogContentText id="new-study-right-dialog-description">
           {status === NewStudyRightStatus.OtherOrganization && t('otherOrganization')}
-          {status === NewStudyRightStatus.NonExisting && t('nonExisting')}
+          {rightsWarning && t('rightsWarning')}
         </DialogContentText>
       </DialogContent>
       <DialogActions>

--- a/src/components/study/rights/NewStudyRightDialog.tsx
+++ b/src/components/study/rights/NewStudyRightDialog.tsx
@@ -26,7 +26,9 @@ const NewStudyRightDialog = ({ rightsWarning, status, decline, accept }: Props) 
         </DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button onClick={decline}>{t('decline')}</Button>
+        <Button onClick={decline} data-testid="new-study-right-dialog-decline">
+          {t('decline')}
+        </Button>
         <Button onClick={accept} data-testid="new-study-right-dialog-accept">
           {t('accept')}
         </Button>

--- a/src/components/study/rights/NewStudyRightForm.tsx
+++ b/src/components/study/rights/NewStudyRightForm.tsx
@@ -8,7 +8,7 @@ import { getOrganizationUsers } from '@/db/organization'
 import { FullStudy } from '@/db/study'
 import { getNewStudyRightStatus, newStudyRight } from '@/services/serverFunctions/study'
 import { NewStudyRightCommand, NewStudyRightCommandValidation } from '@/services/serverFunctions/study.command'
-import { NewStudyRightStatus } from '@/services/study'
+import { getAllowedLevels, NewStudyRightStatus } from '@/services/study'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { MenuItem } from '@mui/material'
 import { Role, StudyRole } from '@prisma/client'
@@ -31,6 +31,7 @@ const NewStudyRightForm = ({ study, user, users }: Props) => {
   const tRole = useTranslations('study.role')
 
   const [error, setError] = useState('')
+  const [readerOnly, setReaderOnly] = useState(false)
   const [status, setStatus] = useState<NewStudyRightStatus>()
 
   const form = useForm<NewStudyRightCommand>({
@@ -45,12 +46,23 @@ const NewStudyRightForm = ({ study, user, users }: Props) => {
 
   const onEmailChange = (_: SyntheticEvent, value: string | null) => {
     form.setValue('email', value || '')
+    if (value) {
+      manageChangedEmail(value)
+    }
+  }
+
+  const manageChangedEmail = (email: string) => {
+    const organizationUser = users.find((user) => user.email === email)
+    if (!organizationUser || getAllowedLevels(organizationUser.level).includes(study.level)) {
+      setReaderOnly(false)
+    } else {
+      setReaderOnly(true)
+      form.setValue('role', StudyRole.Reader)
+    }
   }
 
   const saveRight = async (command: NewStudyRightCommand) => {
-    const result = await newStudyRight(
-      status === NewStudyRightStatus.NonExisting ? { ...command, role: StudyRole.Reader } : command,
-    )
+    const result = await newStudyRight(command)
     setStatus(undefined)
     if (result) {
       setError(result)
@@ -61,13 +73,14 @@ const NewStudyRightForm = ({ study, user, users }: Props) => {
   }
 
   const onSubmit = async (command: NewStudyRightCommand) => {
-    const status = await getNewStudyRightStatus(command.email)
-    if (status === NewStudyRightStatus.SameOrganization) {
+    const right = await getNewStudyRightStatus()
+    if (right) {
+      setError(right)
+    }
+    if (users.some((user) => user.email === command.email)) {
       await saveRight(command)
-    } else if (status === NewStudyRightStatus.OtherOrganization || status === NewStudyRightStatus.NonExisting) {
-      setStatus(status)
     } else {
-      setError(error)
+      setStatus(NewStudyRightStatus.OtherOrganization)
     }
   }
 
@@ -82,6 +95,18 @@ const NewStudyRightForm = ({ study, user, users }: Props) => {
         value: user.email,
       })),
     [users],
+  )
+
+  const allowedRoles = useMemo(
+    () =>
+      Object.keys(StudyRole).filter(
+        (role) =>
+          (user.role === Role.ADMIN ||
+            (userRoleOnStudy && userRoleOnStudy.role === StudyRole.Validator) ||
+            role !== StudyRole.Validator) &&
+          (!readerOnly || role === StudyRole.Reader),
+      ),
+    [readerOnly],
   )
 
   return (
@@ -109,19 +134,13 @@ const NewStudyRightForm = ({ study, user, users }: Props) => {
           name="role"
           label={t('role')}
           data-testid="study-rights-role"
+          disabled={allowedRoles.length < 2}
         >
-          {Object.keys(StudyRole)
-            .filter(
-              (role) =>
-                user.role === Role.ADMIN ||
-                (userRoleOnStudy && userRoleOnStudy.role === StudyRole.Validator) ||
-                role !== StudyRole.Validator,
-            )
-            .map((key) => (
-              <MenuItem key={key} value={key}>
-                {tRole(key)}
-              </MenuItem>
-            ))}
+          {allowedRoles.map((key) => (
+            <MenuItem key={key} value={key}>
+              {tRole(key)}
+            </MenuItem>
+          ))}
         </FormSelect>
         <Button type="submit" disabled={form.formState.isSubmitting} data-testid="study-rights-create-button">
           {t('create')}
@@ -130,6 +149,7 @@ const NewStudyRightForm = ({ study, user, users }: Props) => {
       </Form>
       <NewStudyRightDialog
         status={status}
+        rightsWarning={status == NewStudyRightStatus.OtherOrganization && form.getValues().role !== StudyRole.Reader}
         decline={() => setStatus(undefined)}
         accept={() => saveRight(form.getValues())}
       />

--- a/src/components/study/rights/SelectStudyRole.tsx
+++ b/src/components/study/rights/SelectStudyRole.tsx
@@ -3,20 +3,22 @@
 import { FullStudy } from '@/db/study'
 import { changeStudyRole } from '@/services/serverFunctions/study'
 import { MenuItem, Select, SelectChangeEvent } from '@mui/material'
-import { Role, StudyRole } from '@prisma/client'
+import { Level, Role, StudyRole } from '@prisma/client'
 import { User } from 'next-auth'
 import { useTranslations } from 'next-intl'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 interface Props {
   user: User
   userRole?: StudyRole
   rowUser: FullStudy['allowedUsers'][0]['user']
   studyId: string
+  studyLevel: Level
+  studyOrganizationId: string
   currentRole: StudyRole
 }
 
-const SelectStudyRole = ({ user, rowUser, studyId, currentRole, userRole }: Props) => {
+const SelectStudyRole = ({ user, rowUser, studyId, studyLevel, studyOrganizationId, currentRole, userRole }: Props) => {
   const t = useTranslations('study.role')
   const [role, setRole] = useState(currentRole)
   useEffect(() => {
@@ -31,25 +33,49 @@ const SelectStudyRole = ({ user, rowUser, studyId, currentRole, userRole }: Prop
     }
   }
 
+  /**
+   * Disabled if:
+   * - user is the same as the one in the row
+   * - current role is Validator and user is not Validator and (user is not admin OR user is not part of the study's organization)
+   * - user has readerOnly attribute (calculated by back-end if : user has no account or user does not match the study's level)
+   */
+  const isDisabled = useMemo(
+    () =>
+      user.email === rowUser.email ||
+      (currentRole === StudyRole.Validator &&
+        userRole !== StudyRole.Validator &&
+        (user.role !== Role.ADMIN || user.organizationId !== studyOrganizationId)) ||
+      rowUser.readerOnly,
+    [currentRole, rowUser, studyLevel, user, userRole],
+  )
+
+  /**
+   * Allowed roles:
+   * - if currentUser.role is admin or if the user is a validator or selector is disabled : all roles
+   * - otherwise : all roles except validator
+   */
+  const allowedRoles = useMemo(
+    () =>
+      Object.keys(StudyRole).filter(
+        (role) =>
+          user.role === Role.ADMIN || userRole === StudyRole.Validator || isDisabled || role !== StudyRole.Validator,
+      ),
+    [user.role, userRole, isDisabled],
+  )
+
   return (
     <Select
       className="w100"
       data-testid="select-study-role"
       value={role}
       onChange={selectNewRole}
-      disabled={
-        user.email === rowUser.email ||
-        (currentRole === StudyRole.Validator && userRole !== StudyRole.Validator && user.role !== Role.ADMIN)
-      }
+      disabled={isDisabled}
     >
-      {Object.keys(StudyRole)
-        .filter((role) => role !== StudyRole.Validator || user.role === Role.ADMIN || userRole === StudyRole.Validator)
-        .filter((role) => rowUser.organizationId || role === StudyRole.Reader)
-        .map((role) => (
-          <MenuItem key={role} value={role}>
-            {t(role)}
-          </MenuItem>
-        ))}
+      {allowedRoles.map((role) => (
+        <MenuItem key={role} value={role}>
+          {t(role)}
+        </MenuItem>
+      ))}
     </Select>
   )
 }

--- a/src/components/study/rights/StudyRightsTable.tsx
+++ b/src/components/study/rights/StudyRightsTable.tsx
@@ -39,6 +39,8 @@ const StudyRightsTable = ({ user, study, userRoleOnStudy }: Props) => {
               currentRole={role}
               rowUser={context.row.original.user}
               studyId={study.id}
+              studyLevel={study.level}
+              studyOrganizationId={study.organizationId}
             />
           )
         },

--- a/src/db/organization.ts
+++ b/src/db/organization.ts
@@ -8,7 +8,7 @@ export const getOrganizationById = (id: string | null) =>
 export const getOrganizationUsers = (id: string | null) =>
   id
     ? prismaClient.user.findMany({
-        select: { email: true, firstName: true, lastName: true },
+        select: { email: true, firstName: true, lastName: true, level: true },
         where: { organizationId: id, isActive: true },
         orderBy: { email: 'asc' },
       })

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -212,8 +212,8 @@
         },
         "dialog": {
           "title": "Are you sure you want to add this person to your study?",
-          "otherOrganization": "They are a BC+ user within another organization than yours.",
-          "nonExisting": "They are not a BC+ user, so you will only be able to give them access to the study with read or contribution rights. An email will be sent to them to give access to the study.",
+          "otherOrganization": "They are not within your organization.",
+          "rightsWarning": "If they do not match the necessary conditions for this role, you will only be able to give them access to this study only with READ or contribution rights. An email will be sent to them to give access to the study.",
           "accept": "Yes",
           "decline": "No"
         }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -209,9 +209,9 @@
           "role": "Veuillez sélectionner un droit"
         },
         "dialog": {
-          "title": "Êtes-vous sûr de vouloir ajouter cette personne à votre étude ?",
-          "otherOrganization": "Elle est utilisatrice du BC+ au sein d'une autre organisation que la votre.",
-          "nonExisting": "Elle n'est pas utilisatrice du BC+, vous ne pourrez donc lui donner un accès à l'étude qu'avec les droits de lecture ou de contribution. Un mail lui sera envoyé pour lui donner accès à l'étude.",
+          "title": "Êtes-vous sûr de vouloir ajouter cette personne à votre étude ?",
+          "otherOrganization": "Elle ne fait pas partie de votre organisation.",
+          "rightsWarning": "Si elle ne réunit pas les conditions nécessaires pour l'ajouter avec ce rôle, vous ne pourrez donc lui donner un accès qu'à cette étude et avec les droits de LECTURE ou de contribution. Un mail lui sera envoyé pour lui donner accès à l'étude.",
           "accept": "Oui",
           "decline": "Non"
         }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -194,7 +194,7 @@
     "title": "Étude",
     "rights": {
       "contributors": "Contributeurs",
-      "isPublic": "L'étude est public",
+      "isPublic": "L'étude est publique",
       "isPrivate": "L'étude est privée",
       "title": "Cadrage de l'étude : {name}",
       "newContributorLink": "Ajouter un contributeur",

--- a/src/services/permissions/emissionSource.ts
+++ b/src/services/permissions/emissionSource.ts
@@ -8,7 +8,7 @@ export const canCreateEmissionSource = async (
   emissionSource: Pick<StudyEmissionSource, 'studyId' | 'subPost' | 'siteId'> & { emissionFactorId?: string | null },
   study?: FullStudy,
 ) => {
-  const dbStudy = study || (await getStudyById(emissionSource.studyId))
+  const dbStudy = study || (await getStudyById(emissionSource.studyId, user.organizationId))
   if (!dbStudy) {
     return false
   }

--- a/src/services/serverFunctions/emissionSource.ts
+++ b/src/services/serverFunctions/emissionSource.ts
@@ -58,7 +58,7 @@ export const updateEmissionSource = async ({
   }
   const data = { ...command, emissionFactor: emissionFactorId ? { connect: { id: emissionFactorId } } : undefined }
 
-  const study = await getStudyById(emissionSource.studyId)
+  const study = await getStudyById(emissionSource.studyId, user.organizationId)
   if (!study || !(await canUpdateEmissionSource(user, emissionSource, data, study))) {
     return NOT_AUTHORIZED
   }
@@ -85,7 +85,7 @@ export const deleteEmissionSource = async (emissionSourceId: string) => {
   if (!user || !emissionSource) {
     return NOT_AUTHORIZED
   }
-  const study = await getStudyById(emissionSource.studyId)
+  const study = await getStudyById(emissionSource.studyId, user.organizationId)
 
   if (!study || !(await canDeleteEmissionSource(user, study))) {
     return NOT_AUTHORIZED

--- a/src/services/serverFunctions/study.ts
+++ b/src/services/serverFunctions/study.ts
@@ -178,14 +178,6 @@ export const changeStudyDates = async ({ studyId, ...command }: ChangeStudyDates
   await updateStudy(studyId, command)
 }
 
-export const getNewStudyRightStatus = async () => {
-  const session = await auth()
-  if (!session || !session.user) {
-    return NOT_AUTHORIZED
-  }
-  return
-}
-
 export const newStudyRight = async (right: NewStudyRightCommand) => {
   const session = await auth()
   if (!session || !session.user) {

--- a/src/services/serverFunctions/study.ts
+++ b/src/services/serverFunctions/study.ts
@@ -135,7 +135,7 @@ const getStudyRightsInformations = async (studyId: string) => {
     return null
   }
 
-  const studyWithRights = await getStudyById(studyId)
+  const studyWithRights = await getStudyById(studyId, session.user.organizationId)
 
   if (!studyWithRights) {
     return null
@@ -202,7 +202,10 @@ export const newStudyRight = async (right: NewStudyRightCommand) => {
     return NOT_AUTHORIZED
   }
 
-  const [studyWithRights, newUser] = await Promise.all([getStudyById(right.studyId), getUserByEmail(right.email)])
+  const [studyWithRights, newUser] = await Promise.all([
+    getStudyById(right.studyId, session.user.organizationId),
+    getUserByEmail(right.email),
+  ])
 
   if (!studyWithRights) {
     return NOT_AUTHORIZED
@@ -240,7 +243,10 @@ export const changeStudyRole = async (studyId: string, email: string, studyRole:
     return NOT_AUTHORIZED
   }
 
-  const [studyWithRights, user] = await Promise.all([getStudyById(studyId), getUserByEmail(email)])
+  const [studyWithRights, user] = await Promise.all([
+    getStudyById(studyId, session.user.organizationId),
+    getUserByEmail(email),
+  ])
 
   if (!studyWithRights || !user) {
     return NOT_AUTHORIZED
@@ -259,7 +265,10 @@ export const newStudyContributor = async ({ email, post, subPost, ...command }: 
     return NOT_AUTHORIZED
   }
 
-  const [studyWithRights, user] = await Promise.all([getStudyById(command.studyId), getUserByEmail(email)])
+  const [studyWithRights, user] = await Promise.all([
+    getStudyById(command.studyId, session.user.organizationId),
+    getUserByEmail(email),
+  ])
 
   if (!studyWithRights) {
     return NOT_AUTHORIZED

--- a/src/services/study.ts
+++ b/src/services/study.ts
@@ -22,11 +22,11 @@ export enum NewStudyRightStatus {
 
 export const getAllowedLevels = (level: Level | null) => {
   switch (level) {
-    case Level.Advanced:
+    case Level.Initial:
       return [Level.Initial]
     case Level.Standard:
       return [Level.Initial, Level.Standard]
-    case Level.Initial:
+    case Level.Advanced:
       return [Level.Initial, Level.Standard, Level.Advanced]
     default:
       return []

--- a/src/services/study.ts
+++ b/src/services/study.ts
@@ -14,10 +14,6 @@ const getQuality = (quality: ReturnType<typeof getQualityRating>, t: ReturnType<
   return quality === null ? t('unknown') : t(quality.toString())
 }
 
-export enum NewStudyRightStatus {
-  OtherOrganization,
-}
-
 export const getAllowedLevels = (level: Level | null) => {
   switch (level) {
     case Level.Initial:

--- a/src/services/study.ts
+++ b/src/services/study.ts
@@ -15,9 +15,7 @@ const getQuality = (quality: ReturnType<typeof getQualityRating>, t: ReturnType<
 }
 
 export enum NewStudyRightStatus {
-  SameOrganization,
   OtherOrganization,
-  NonExisting,
 }
 
 export const getAllowedLevels = (level: Level | null) => {

--- a/src/tests/end-to-end/app/study-rights.cy.ts
+++ b/src/tests/end-to-end/app/study-rights.cy.ts
@@ -6,8 +6,8 @@ describe('Create study', () => {
     cy.intercept('POST', '/etudes/*/cadrage').as('update')
   })
 
-  it('should set user as editor and manage role', () => {
-    cy.login()
+  it('should set user and manage role according to given rights', () => {
+    cy.login('bc-admin-1@yopmail.com', 'password-1')
 
     cy.getByTestId('new-study').click()
     cy.getByTestId('organization-sites-checkbox').first().click()
@@ -15,101 +15,204 @@ describe('Create study', () => {
 
     cy.getByTestId('new-study-name').should('be.visible').type('Study with rights')
     cy.getByTestId('new-validator-name').click()
-    cy.get('[data-option-index="1"]').click()
+    cy.get('[data-option-index="0"]').click()
 
     cy.getByTestId('new-study-endDate').within(() => {
       cy.get('input').type(dayjs().add(1, 'y').format('DD/MM/YYYY'))
     })
     cy.getByTestId('new-study-level').click()
-    cy.get('[data-value="Initial"]').click()
+    cy.get('[data-value="Standard"]').click()
     cy.getByTestId('new-study-create-button').click()
 
     cy.getByTestId('study-cadrage-link').click()
 
-    cy.getByTestId('study-rights-table-line').contains('bc-default-0@yopmail.comValidateur')
-    cy.getByTestId('study-rights-table-line').within(() => {
+    cy.getByTestId('study-rights-table-line').contains('bc-admin-1@yopmail.comValidateur')
+
+    // External user
+    cy.getByTestId('study-rights-change-button').click()
+
+    cy.getByTestId('study-rights-email').should('be.visible')
+    cy.getByTestId('study-rights-email').type('external@yopmail.com')
+    cy.getByTestId('study-rights-role').click()
+    cy.get('[data-value="Reader"]').click()
+
+    cy.getByTestId('study-rights-create-button').click()
+    cy.get('#new-study-right-dialog-title').should('be.visible')
+    cy.get('#new-study-right-dialog-description').should('be.visible')
+    cy.get('#new-study-right-dialog-description')
+      .invoke('text')
+      .should('include', 'Elle ne fait pas partie de votre organisation')
+    cy.get('#new-study-right-dialog-description')
+      .invoke('text')
+      .should('not.include', 'Si elle ne réunit pas les conditions nécessaires')
+    cy.getByTestId('new-study-right-dialog-decline').click()
+
+    cy.getByTestId('study-rights-role').click()
+    cy.get('[data-value="Editor"]').click()
+
+    cy.getByTestId('study-rights-create-button').click()
+    cy.get('#new-study-right-dialog-title').should('be.visible')
+    cy.get('#new-study-right-dialog-description').should('be.visible')
+    cy.get('#new-study-right-dialog-description')
+      .invoke('text')
+      .should('include', 'Elle ne fait pas partie de votre organisation')
+    cy.get('#new-study-right-dialog-description')
+      .invoke('text')
+      .should('include', 'Si elle ne réunit pas les conditions nécessaires')
+    cy.getByTestId('new-study-right-dialog-accept').click()
+    cy.wait('@create')
+
+    cy.getByTestId('study-rights-table-line').eq(1).contains('external@yopmail.comLecteur')
+
+    // Existing user outside of organization without rights
+    cy.getByTestId('study-rights-change-button').click()
+    cy.getByTestId('study-rights-email').type('bc-default-0@yopmail.com')
+    cy.getByTestId('study-rights-role').click()
+    cy.get('[data-value="Reader"]').click()
+
+    cy.getByTestId('study-rights-create-button').click()
+    cy.get('#new-study-right-dialog-description')
+      .invoke('text')
+      .should('include', 'Elle ne fait pas partie de votre organisation')
+    cy.get('#new-study-right-dialog-description')
+      .invoke('text')
+      .should('not.include', 'Si elle ne réunit pas les conditions nécessaires')
+    cy.getByTestId('new-study-right-dialog-decline').click()
+
+    cy.getByTestId('study-rights-role').click()
+    cy.get('[data-value="Editor"]').click()
+
+    cy.getByTestId('study-rights-create-button').click()
+    cy.get('#new-study-right-dialog-description')
+      .invoke('text')
+      .should('include', 'Elle ne fait pas partie de votre organisation')
+    cy.get('#new-study-right-dialog-description')
+      .invoke('text')
+      .should('include', 'Si elle ne réunit pas les conditions nécessaires')
+    cy.getByTestId('new-study-right-dialog-accept').click()
+    cy.wait('@create')
+    cy.getByTestId('study-rights-table-line').eq(1).contains('bc-default-0@yopmail.comLecteur')
+
+    // Existing user outside of organization with rights
+    cy.getByTestId('study-rights-change-button').click()
+    cy.getByTestId('study-rights-email').type('bc-default-2@yopmail.com')
+    cy.getByTestId('study-rights-role').click()
+    cy.get('[data-value="Editor"]').click()
+
+    cy.getByTestId('study-rights-create-button').click()
+    cy.getByTestId('new-study-right-dialog-accept').click()
+    cy.wait('@create')
+    cy.getByTestId('study-rights-table-line').eq(2).contains('bc-default-2@yopmail.comÉditeur')
+
+    // Organization's user without rights
+    cy.getByTestId('study-rights-change-button').click()
+    cy.getByTestId('study-rights-email').click()
+    cy.contains('[data-option-index]', 'bc-default-1@yopmail.com').click()
+    cy.getByTestId('study-rights-role').within(() => {
+      cy.get('input').should('have.value', '')
+      cy.get('input').should('not.be.disabled')
+    })
+    cy.getByTestId('study-rights-role').click()
+    cy.get('[data-value="Validator"]').click()
+    cy.getByTestId('study-rights-email').click()
+    cy.contains('[data-option-index]', 'untrained@yopmail.com').click()
+    cy.getByTestId('study-rights-role').within(() => {
+      cy.get('input').should('have.value', 'Reader')
       cy.get('input').should('be.disabled')
     })
-
-    cy.getByTestId('study-rights-change-button').click()
-
-    cy.getByTestId('study-rights-email').should('be.visible')
-    cy.getByTestId('study-rights-email').type('bc-default-1@yopmail.com')
-    cy.getByTestId('study-rights-role').click()
-    cy.get('[data-value="Reader"]').click()
-
     cy.getByTestId('study-rights-create-button').click()
-    cy.getByTestId('new-study-right-dialog-accept').click()
     cy.wait('@create')
+    cy.getByTestId('study-rights-table-line').eq(4).contains('untrained@yopmail.comLecteur')
 
-    cy.getByTestId('study-rights-table-line').eq(1).contains('bc-default-1@yopmail.comLecteur')
+    // Organization's user with rights
+    cy.getByTestId('study-rights-change-button').click()
+    cy.getByTestId('study-rights-email').click()
+    cy.contains('[data-option-index]', 'bc-default-1@yopmail.com').click()
+    cy.getByTestId('study-rights-role').click()
+    cy.get('[data-value="Validator"]').click()
+    cy.getByTestId('study-rights-create-button').click()
+    cy.wait('@create')
+    cy.getByTestId('study-rights-table-line').eq(2).contains('bc-default-1@yopmail.comValidateur')
     cy.getByTestId('study-rights-table-line')
-      .eq(1)
-      .within(() => {
-        cy.get('input').should('not.be.disabled')
-      })
+      .eq(2)
+      .within(() => cy.get('input').should('not.be.disabled'))
 
-    cy.getByTestId('study-rights-change-button').click()
-
-    cy.getByTestId('study-rights-email').should('be.visible')
-    cy.getByTestId('study-rights-email').type('bc-admin-1@yopmail.com')
-
-    cy.getByTestId('study-rights-role').click()
-    cy.get('[data-value="Reader"]').click()
-
-    cy.getByTestId('study-rights-create-button').click()
-    cy.getByTestId('new-study-right-dialog-accept').click()
-    cy.wait('@create')
-
-    cy.getByTestId('study-rights-table-line').eq(0).contains('bc-admin-1@yopmail.comLecteur')
+    // Rights management
+    // cannot edit its own rights
+    cy.getByTestId('study-rights-table-line').eq(0).contains('bc-admin-1@yopmail.comValidateur')
     cy.getByTestId('study-rights-table-line')
       .eq(0)
+      .within(() => {
+        cy.get('input').should('be.disabled')
+      })
+    // cannot edit external or untrained user's rights
+    cy.getByTestId('study-rights-table-line').eq(1).contains('bc-default-0@yopmail.comLecteur')
+    cy.getByTestId('study-rights-table-line')
+      .eq(1)
+      .within(() => cy.get('input').should('be.disabled'))
+    cy.getByTestId('study-rights-table-line').eq(4).contains('external@yopmail.comLecteur')
+    cy.getByTestId('study-rights-table-line')
+      .eq(4)
+      .within(() => cy.get('input').should('be.disabled'))
+    cy.getByTestId('study-rights-table-line').eq(5).contains('untrained@yopmail.comLecteur')
+    cy.getByTestId('study-rights-table-line')
+      .eq(5)
+      .within(() => cy.get('input').should('be.disabled'))
+    // Validators can edit other people's rights
+    cy.getByTestId('study-rights-table-line').eq(2).contains('bc-default-1@yopmail.comValidateur')
+    cy.getByTestId('study-rights-table-line')
+      .eq(2)
       .within(() => {
         cy.get('input').should('not.be.disabled')
         cy.get('.MuiSelect-select').click()
       })
     cy.get('[data-value="Editor"]').click()
     cy.wait('@update')
+    cy.getByTestId('study-rights-table-line').eq(2).contains('bc-default-1@yopmail.comÉditeur')
 
-    cy.reload()
-
-    cy.getByTestId('study-rights-table-line').eq(0).contains('bc-admin-1@yopmail.comÉditeur')
-    cy.getByTestId('study-rights-table-line')
-      .eq(0)
-      .within(() => {
-        cy.get('input').should('not.be.disabled')
-      })
-
+    // Editors cannot edit validator's rights
     cy.url().then((link) => {
       cy.logout()
       cy.login('bc-default-1@yopmail.com', 'password-1')
       cy.visit(link)
     })
+    cy.getByTestId('study-rights-change-button').should('exist')
+    cy.getByTestId('select-study-role').should('exist')
 
-    cy.getByTestId('select-study-role').should('not.exist')
-
-    cy.url().then((link) => {
-      cy.logout()
-      cy.login('bc-admin-1@yopmail.com', 'password-1')
-      cy.visit(link)
-    })
-
-    cy.getByTestId('select-study-role').should('have.length', 3)
-
-    cy.getByTestId('study-rights-table-line')
-      .eq(2)
-      .within(() => {
-        cy.get('input').should('not.be.disabled')
-      })
-    cy.getByTestId('study-rights-table-line')
-      .eq(1)
-      .within(() => {
-        cy.get('input').should('not.be.disabled')
-      })
+    cy.getByTestId('study-rights-table-line').eq(0).contains('bc-admin-1@yopmail.comValidateur')
     cy.getByTestId('study-rights-table-line')
       .eq(0)
+      .within(() => cy.get('input').should('be.disabled'))
+
+    // Editors can't select validator's rights
+    cy.getByTestId('study-rights-table-line').eq(3).contains('bc-default-2@yopmail.comÉditeur')
+    cy.getByTestId('study-rights-table-line')
+      .eq(3)
       .within(() => {
-        cy.get('input').should('be.disabled')
+        cy.get('input').should('not.be.disabled')
+        cy.get('.MuiSelect-select').click()
       })
+    cy.get('[data-value="Reader"]').should('exist')
+    cy.get('[data-value="Editor"]').should('exist')
+    cy.get('[data-value="Validator"]').should('not.exist')
+    cy.get('[data-value="Reader"]').click()
+    cy.wait('@update')
+    cy.getByTestId('study-rights-table-line').eq(3).contains('bc-default-2@yopmail.comLecteur')
+
+    cy.getByTestId('study-rights-change-button').click()
+    cy.getByTestId('study-rights-role').click()
+    cy.get('[data-value="Reader"]').should('exist')
+    cy.get('[data-value="Editor"]').should('exist')
+    cy.get('[data-value="Validator"]').should('not.exist')
+
+    // Readers can't update rights
+    cy.go('back')
+    cy.url().then((link) => {
+      cy.logout()
+      cy.login('bc-default-2@yopmail.com', 'password-2')
+      cy.visit(link)
+    })
+    cy.getByTestId('study-rights-change-button').should('not.exist')
+    cy.getByTestId('select-study-role').should('not.exist')
   })
 })


### PR DESCRIPTION
#186  Remplace https://github.com/ABC-TransitionBasCarbone/bilan-carbone/pull/204
Manque le check sur la licence (pas encore implémentée niveau organisation)

Propositions de changement des messages (mettre en évidence le changement de droit) :

---
- otherOrganization: "They are not within your organization.",
- readerOnly: "If they do not match the necessary conditions for this role, you will only be able to give them access to this study only with READ or contribution rights. An email will be sent to them to give access to the study.",
---
- otherOrganization: "Elle ne fait pas partie de votre organisation."
- readerOnly: "Si elle ne réunit pas les conditions nécessaires pour l'ajouter avec ce rôle, vous ne pourrez donc lui donner un accès qu'à cette étude et avec les droits de LECTURE ou de contribution. Un mail lui sera envoyé pour lui donner accès à l'étude."
---

Scénario réalisés :

- Ajout d'une personne hors organisation, avec les droits de lecteur -> otherOrganization
- Ajout d'une personne hors organisation, avec les droits editeur/validateur -> otherOrganization + readerOnly
- Ajout d'une personne membre de l'organisation, dont on sait qu'elle n'a pas le niveau pour l'étude -> on force le rôle à Lecteur et on désactive le selecteur de rôles
- Ajout d'une personne membre de l'organisation, dont on sait qu'elle a le niveau pour l'étude -> Selecteur libre
- Pour les membres hors orga, on fait le check à la création de l'étude (et on corrige éventuellement le rôle attribué). Ainsi, on ne fait aucune distinction entre les comptes et les externes, ce qui permet de ne plus donner d'indication