### PR TITLE
Investigate flaky test

### DIFF
--- a/src/app/(dashboard)/etudes/[id]/(organization)/cadrage/page.tsx
+++ b/src/app/(dashboard)/etudes/[id]/(organization)/cadrage/page.tsx
@@ -32,6 +32,7 @@ const StudyRights = async (props: Props) => {
     return <NotFound />
   }
 
+  console.log('render StudyRights')
   return <StudyRightsPage study={study} user={session.user} />
 }
 

--- a/src/components/pages/StudyRights.tsx
+++ b/src/components/pages/StudyRights.tsx
@@ -20,6 +20,7 @@ const StudyRightsPage = async ({ study, user }: Props) => {
 
   const userRoleOnStudy = study.allowedUsers.find((right) => right.user.email === user.email)
 
+  console.log('render StudyRightsPage')
   return (
     <>
       <Breadcrumbs

--- a/src/components/study/rights/StudyRightsTable.tsx
+++ b/src/components/study/rights/StudyRightsTable.tsx
@@ -60,6 +60,7 @@ const StudyRightsTable = ({ user, study, userRoleOnStudy }: Props) => {
     getCoreRowModel: getCoreRowModel(),
   })
 
+  console.log('render StudyContributorsTable')
   return (
     <Block
       title={t('title')}

--- a/src/tests/end-to-end/app/study-rights.cy.ts
+++ b/src/tests/end-to-end/app/study-rights.cy.ts
@@ -1,3 +1,4 @@
+/* eslint-disable cypress/unsafe-to-chain-command */
 import dayjs from 'dayjs'
 
 describe('Create study', () => {
@@ -164,9 +165,14 @@ describe('Create study', () => {
       .eq(2)
       .within(() => {
         cy.get('input').should('not.be.disabled')
-        cy.get('.MuiSelect-select').click()
+        cy.get('.MuiSelect-select').as('BCDefault1RoleSelector')
       })
-    cy.get('[data-value="Editor"]').click()
+    cy.get('@BCDefault1RoleSelector')
+      .click()
+      .then(() => console.log('Sélecteur cliqué'))
+    cy.get('[data-value="Editor"]')
+      .click()
+      .then(() => console.log('Sélecteur changé'))
     cy.wait('@update')
     cy.getByTestId('study-rights-table-line').eq(2).contains('bc-default-1@yopmail.comÉditeur')
 
@@ -190,8 +196,9 @@ describe('Create study', () => {
       .eq(3)
       .within(() => {
         cy.get('input').should('not.be.disabled')
-        cy.get('.MuiSelect-select').click()
+        cy.get('.MuiSelect-select').as('BCDefault2RoleSelector')
       })
+    cy.get('@BCDefault2RoleSelector').click()
     cy.get('[data-value="Reader"]').should('exist')
     cy.get('[data-value="Editor"]').should('exist')
     cy.get('[data-value="Validator"]').should('not.exist')


### PR DESCRIPTION
Le problème récurrent était au niveau des tests study-rights, ligne 169 : Sélection du nouveau rôle.

```
Create study
       should set user and manage role according to given rights:
     CypressError: Timed out retrying after 4050ms: `cy.click()` failed because the page updated while this command was executing. Cypress tried to locate elements based on this query:

> cy.get([data-value="Editor"])
```

Le test en question : 
```cy.getByTestId('study-rights-table-line').eq(2).contains('bc-default-1@yopmail.comValidateur')
    cy.getByTestId('study-rights-table-line')
      .eq(2)
      .within(() => {
        cy.get('input').should('not.be.disabled')
        cy.get('.MuiSelect-select').click()
      })
    cy.get('[data-value="Editor"]').click()
    cy.wait('@update')
```

Il semblerait que la dropdown soit, dans certains cas refermée suite à un re-render du composant.

Pistes de résolution : 
- Utiliser la suggestion de cypress et mettre un alias sur la dropdown pour enchainer ouverture et sélection. Après une 20aine de tests, cela semble fonctionner, mais il faudrait idéalement supprimer le re-rendu superflu

Ce re-rendu me semble inévitable car il est la conséquence d'un double rendu depuis le composant page.tsx 
![image](https://github.com/user-attachments/assets/ef3956b6-8eb1-420d-9d45-686f700d303e)

Si quelqu'un a une idée, je suis preneur

--- 

Autre test : 
edit-organization.cy.ts : Create organization (nom à changer également)
    1) should edit an organization

  0 passing (14s)
  1 failing

  1) Create organization
       should edit an organization:

      Timed out retrying after 4000ms
      + expected - actual

      -'My new site 0'
      +'My new site 1'
      
      at Context.eval (webpack://bilan-carbone/./src/tests/end-to-end/app/edit-organization.cy.ts:30:0)

Également une erreur récurrente 

--- 

Nouvelle erreur : En local uniquement, oké dans la CI :

study-rights.cy.ts :

1) should set user and manage role according to given rights


  0 passing (19s)
  1 failing

  1) Create study
       should set user and manage role according to given rights:
     CypressError: `cy.visit()` failed trying to load:

http://localhost:3000/etudes/d67322b9-bb96-430d-a60e-c67a9303deb3/cadrage

The response we received from your web server was:

  > 500: Internal Server Error

This was considered a failure because the status code was not `2xx`.

L'erreur se situe ligne 186, lors de la déconnexion/reconnexion, le login ne semble pas attendu. Cette erreur est déjà apparue il y a quelques semaines, elle est censée être corrigée depuis le commit https://github.com/ABC-TransitionBasCarbone/bilan-carbone/commit/e55c01c93b010a7044afda3ef0cf1127d9bf6eda. Je pense que le @login n'est pas correctement reçu, et cypress cherche à faire une redirection avant que l'application ne soit chargée