### PR TITLE
Tech/316 study creation

### DIFF
--- a/src/services/emissionSource.test.ts
+++ b/src/services/emissionSource.test.ts
@@ -17,6 +17,8 @@ const defaultEmissionSource = {
     geographicRepresentativeness: null,
     completeness: null,
   },
+  site: { id: 'siteId' },
+  emissionFactorId: 'emissionFactor',
   name: 'name',
   source: null,
   subPost: SubPost.AchatsDeServices,
@@ -29,6 +31,7 @@ const defaultEmissionSource = {
   geographicRepresentativeness: 4,
   completeness: null,
   contributor: null,
+  depreciationPeriod: null,
 } satisfies FullStudy['emissionSources'][0]
 
 describe('emissionSource Service', () => {

--- a/src/services/permissions/study.test.ts
+++ b/src/services/permissions/study.test.ts
@@ -1,49 +1,9 @@
 import * as dbUserModule from '@/db/user'
+import { getMockedDbUser, getMockedStudy, mockedOrganizationId } from '@/tests/utils/models'
 import { expect } from '@jest/globals'
-import { Level, Prisma, Role } from '@prisma/client'
-import { User } from 'next-auth'
+import { Level } from '@prisma/client'
 import * as organizationModule from './organization'
 import { canCreateStudy } from './study'
-
-const mockedUserId = 'mocked-user-id'
-const mockedOrganizationId = 'mocked-organization-id'
-
-const mockedUser = {
-  id: '6d2af85f-f6f8-42ec-9fa4-965405e52d12',
-  email: 'mocked@email.com',
-  firstName: 'Mocke',
-  lastName: 'User',
-  organizationId: mockedOrganizationId,
-  role: Role.ADMIN,
-  level: Level.Initial,
-}
-const mockedDbUser = {
-  ...mockedUser,
-  createdAt: '2025-01-01T00:00:00.000Z',
-  updatedAt: '2025-01-01T00:00:00.000Z',
-  isActive: true,
-  isValidated: true,
-}
-const mockedStudy = {
-  name: 'Mocked Study',
-  startDate: '2025-01-01T00:00:00.000Z',
-  endDate: '2025-01-01T00:00:00Z',
-  isPublic: true,
-  level: Level.Initial,
-  exports: { createMany: { data: [] } },
-  createdBy: { connect: { id: mockedUserId } },
-  organization: { connect: { id: mockedOrganizationId } },
-  version: { connect: { id: 'mocked-version-id' } },
-  allowedUsers: { createMany: { data: [{ role: 'Validator', userId: mockedUserId }] } },
-  sites: {
-    createMany: {
-      data: [{ siteId: 'mocked-site-id', etp: 64, ca: 6906733.42 }],
-    },
-  },
-}
-
-const getMockedDbUser = (props: Partial<User>): User => ({ ...mockedDbUser, ...props })
-const getMockedStudy = (props: Partial<Prisma.StudyCreateInput>) => ({ ...mockedStudy, ...props })
 
 // mocked called function
 jest.mock('@/db/user', () => ({ getUserByEmail: jest.fn() }))
@@ -57,9 +17,9 @@ jest.mock('../serverFunctions/emissionFactor', () => ({ getEmissionFactorByIds: 
 const mockGetUserByEmail = dbUserModule.getUserByEmail as jest.Mock
 const mockCheckOrganization = organizationModule.checkOrganization as jest.Mock
 
-const advancedStudy = getMockedStudy({ level: Level.Advanced }) as Prisma.StudyCreateInput
-const standardStudy = getMockedStudy({ level: Level.Standard }) as Prisma.StudyCreateInput
-const initialStudy = getMockedStudy({ level: Level.Initial }) as Prisma.StudyCreateInput
+const advancedStudy = getMockedStudy({ level: Level.Advanced })
+const standardStudy = getMockedStudy({ level: Level.Standard })
+const initialStudy = getMockedStudy({ level: Level.Initial })
 
 describe('Study permissions service', () => {
   describe('canCreateStudy', () => {
@@ -74,17 +34,17 @@ describe('Study permissions service', () => {
       })
 
       it('User should be able to create an "Advanced" study', async () => {
-        const result = await canCreateStudy(mockedUser, advancedStudy, mockedOrganizationId)
+        const result = await canCreateStudy('mocked-email', advancedStudy, mockedOrganizationId)
         expect(result).toBe(true)
       })
 
       it('User should be able to create a "Standard" study', async () => {
-        const result = await canCreateStudy(mockedUser, standardStudy, mockedOrganizationId)
+        const result = await canCreateStudy('mocked-email', standardStudy, mockedOrganizationId)
         expect(result).toBe(true)
       })
 
       it('User should be able to create an "Initial" study', async () => {
-        const result = await canCreateStudy(mockedUser, initialStudy, mockedOrganizationId)
+        const result = await canCreateStudy('mocked-email', initialStudy, mockedOrganizationId)
         expect(result).toBe(true)
       })
     })
@@ -95,17 +55,17 @@ describe('Study permissions service', () => {
       })
 
       it('User should not be able to create an "Advanced" study', async () => {
-        const result = await canCreateStudy(mockedUser, advancedStudy, mockedOrganizationId)
+        const result = await canCreateStudy('mocked-email', advancedStudy, mockedOrganizationId)
         expect(result).toBe(false)
       })
 
       it('User should be able to create a "Standard" study', async () => {
-        const result = await canCreateStudy(mockedUser, standardStudy, mockedOrganizationId)
+        const result = await canCreateStudy('mocked-email', standardStudy, mockedOrganizationId)
         expect(result).toBe(true)
       })
 
       it('User should be able to create an "Initial" study', async () => {
-        const result = await canCreateStudy(mockedUser, initialStudy, mockedOrganizationId)
+        const result = await canCreateStudy('mocked-email', initialStudy, mockedOrganizationId)
         expect(result).toBe(true)
       })
     })
@@ -116,17 +76,17 @@ describe('Study permissions service', () => {
       })
 
       it('User should not be able to create an "Advanced" study', async () => {
-        const result = await canCreateStudy(mockedUser, advancedStudy, mockedOrganizationId)
+        const result = await canCreateStudy('mocked-email', advancedStudy, mockedOrganizationId)
         expect(result).toBe(false)
       })
 
       it('User should not be able to create a "Standard" study', async () => {
-        const result = await canCreateStudy(mockedUser, standardStudy, mockedOrganizationId)
+        const result = await canCreateStudy('mocked-email', standardStudy, mockedOrganizationId)
         expect(result).toBe(false)
       })
 
       it('User should be able to create an "Initial" study', async () => {
-        const result = await canCreateStudy(mockedUser, initialStudy, mockedOrganizationId)
+        const result = await canCreateStudy('mocked-email', initialStudy, mockedOrganizationId)
         expect(result).toBe(true)
       })
     })

--- a/src/services/permissions/study.test.ts
+++ b/src/services/permissions/study.test.ts
@@ -1,0 +1,147 @@
+import * as dbUserModule from '@/db/user'
+import { expect } from '@jest/globals'
+import { Level, Prisma } from '@prisma/client'
+import { User } from 'next-auth'
+import * as organizationModule from './organization'
+import { canCreateStudy } from './study'
+
+const mockedUserId = 'mocked-user-id'
+const mockedOrganizationId = 'mocked-organization-id'
+
+const mockedUser = {
+  id: '6d2af85f-f6f8-42ec-9fa4-965405e52d12',
+  email: 'mocked@email.com',
+  firstName: 'Mocke',
+  lastName: 'User',
+  organizationId: mockedOrganizationId,
+  role: 'ADMIN',
+}
+const mockedDbUser = {
+  ...mockedUser,
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-01T00:00:00.000Z',
+  isActive: true,
+  isValidated: true,
+}
+const mockedStudy = {
+  name: 'Mocked Study',
+  startDate: '2025-01-01T00:00:00.000Z',
+  endDate: '2025-01-01T00:00:00Z',
+  isPublic: true,
+  exports: { createMany: { data: [] } },
+  createdBy: { connect: { id: mockedUserId } },
+  organization: { connect: { id: mockedOrganizationId } },
+  version: { connect: { id: 'mocked-version-id' } },
+  allowedUsers: { createMany: { data: [{ role: 'Validator', userId: mockedUserId }] } },
+  sites: {
+    createMany: {
+      data: [{ siteId: 'mocked-site-id', etp: 64, ca: 6906733.42 }],
+    },
+  },
+}
+
+const getMockedLeveledUser = (level: Level) => ({ ...mockedUser, level })
+const getMockedLeveledDbUser = (level: Level) => ({ ...mockedDbUser, level })
+const getMockedLeveledStudy = (level: Level) => ({ ...mockedStudy, level })
+
+// mocked called function
+jest.mock('@/db/user', () => ({ getUserByEmail: jest.fn() }))
+jest.mock('./organization', () => ({ checkOrganization: jest.fn() }))
+
+// mocked import problems
+jest.mock('../auth', () => ({ auth: jest.fn() }))
+jest.mock('../file', () => ({ download: jest.fn() }))
+jest.mock('../serverFunctions/emissionFactor', () => ({ getEmissionFactorByIds: jest.fn() }))
+
+const mockGetUserByEmail = dbUserModule.getUserByEmail as jest.Mock
+const mockCheckOrganization = organizationModule.checkOrganization as jest.Mock
+
+describe('Study permissions service', () => {
+  describe('canCreateStudy', () => {
+    beforeEach(() => {
+      jest.clearAllMocks()
+      mockCheckOrganization.mockResolvedValue(true)
+    })
+
+    describe('"Advanced" level user', () => {
+      beforeEach(() => {
+        mockGetUserByEmail.mockResolvedValue(getMockedLeveledDbUser(Level.Advanced))
+      })
+
+      it('User should be able to create an "Advanced" study', async () => {
+        const study = getMockedLeveledStudy(Level.Advanced) as Prisma.StudyCreateInput
+        const user = getMockedLeveledUser(Level.Advanced) as User
+        const result = await canCreateStudy(user, study, mockedOrganizationId)
+        expect(result).toBe(true)
+      })
+
+      it('User should be able to create a "Standard" study', async () => {
+        const study = getMockedLeveledStudy(Level.Standard) as Prisma.StudyCreateInput
+        const user = getMockedLeveledUser(Level.Advanced) as User
+        const result = await canCreateStudy(user, study, mockedOrganizationId)
+        expect(result).toBe(true)
+      })
+
+      it('User should be able to create an "Initial" study', async () => {
+        const study = getMockedLeveledStudy(Level.Advanced) as Prisma.StudyCreateInput
+        const user = getMockedLeveledUser(Level.Advanced) as User
+        const result = await canCreateStudy(user, study, mockedOrganizationId)
+        expect(result).toBe(true)
+      })
+    })
+
+    describe('"Standard" level user', () => {
+      beforeEach(() => {
+        mockGetUserByEmail.mockResolvedValue(getMockedLeveledDbUser(Level.Standard))
+      })
+
+      it('User should not be able to create an "Advanced" study', async () => {
+        const study = getMockedLeveledStudy(Level.Advanced) as Prisma.StudyCreateInput
+        const user = getMockedLeveledUser(Level.Standard) as User
+        const result = await canCreateStudy(user, study, mockedOrganizationId)
+        expect(result).toBe(false)
+      })
+
+      it('User should be able to create a "Standard" study', async () => {
+        const study = getMockedLeveledStudy(Level.Standard) as Prisma.StudyCreateInput
+        const user = getMockedLeveledUser(Level.Standard) as User
+        const result = await canCreateStudy(user, study, mockedOrganizationId)
+        expect(result).toBe(true)
+      })
+
+      it('User should be able to create an "Initial" study', async () => {
+        const study = getMockedLeveledStudy(Level.Initial) as Prisma.StudyCreateInput
+        const user = getMockedLeveledUser(Level.Standard) as User
+        const result = await canCreateStudy(user, study, mockedOrganizationId)
+        expect(result).toBe(true)
+      })
+    })
+
+    describe('"Initial" level user', () => {
+      beforeEach(() => {
+        mockGetUserByEmail.mockResolvedValue(getMockedLeveledDbUser(Level.Initial))
+      })
+
+      it('User should not be able to create an "Advanced" study', async () => {
+        const study = getMockedLeveledStudy(Level.Advanced) as Prisma.StudyCreateInput
+        const user = getMockedLeveledUser(Level.Initial) as User
+        const result = await canCreateStudy(user, study, mockedOrganizationId)
+        expect(result).toBe(false)
+      })
+
+      it('User should not be able to create a "Standard" study', async () => {
+        const study = getMockedLeveledStudy(Level.Standard) as Prisma.StudyCreateInput
+        const user = getMockedLeveledUser(Level.Initial) as User
+        const result = await canCreateStudy(user, study, mockedOrganizationId)
+        expect(result).toBe(false)
+      })
+
+      it('User should be able to create an "Initial" study', async () => {
+        const study = getMockedLeveledStudy(Level.Initial) as Prisma.StudyCreateInput
+        const user = getMockedLeveledUser(Level.Initial) as User
+        const result = await canCreateStudy(user, study, mockedOrganizationId)
+        expect(result).toBe(true)
+      })
+    })
+  })
+})

--- a/src/services/permissions/study.ts
+++ b/src/services/permissions/study.ts
@@ -52,8 +52,8 @@ export const filterAllowedStudies = async (user: User, studies: Study[]) => {
   return allowedStudies.filter((study) => study !== null)
 }
 
-export const canCreateStudy = async (user: User, study: Prisma.StudyCreateInput, organizationId: string) => {
-  const dbUser = await getUserByEmail(user.email)
+export const canCreateStudy = async (userEmail: string, study: Prisma.StudyCreateInput, organizationId: string) => {
+  const dbUser = await getUserByEmail(userEmail)
 
   if (!dbUser) {
     return false

--- a/src/services/serverFunctions/study.ts
+++ b/src/services/serverFunctions/study.ts
@@ -147,7 +147,7 @@ export const createStudyCommand = async ({
     },
   } satisfies Prisma.StudyCreateInput
 
-  if (!(await canCreateStudy(session.user, study, organizationId))) {
+  if (!(await canCreateStudy(session.user.email, study, organizationId))) {
     return { success: false, message: NOT_AUTHORIZED }
   }
 

--- a/src/tests/utils/models.ts
+++ b/src/tests/utils/models.ts
@@ -1,0 +1,43 @@
+import { Level, Prisma, Role } from '@prisma/client'
+import { User } from 'next-auth'
+
+export const mockedUserId = 'mocked-user-id'
+export const mockedOrganizationId = 'mocked-organization-id'
+
+const mockedUser = {
+  id: '6d2af85f-f6f8-42ec-9fa4-965405e52d12',
+  email: 'mocked@email.com',
+  firstName: 'Mocke',
+  lastName: 'User',
+  organizationId: mockedOrganizationId,
+  role: Role.ADMIN,
+  level: Level.Initial,
+}
+const mockedDbUser = {
+  ...mockedUser,
+  createdAt: '2025-01-01T00:00:00.000Z',
+  updatedAt: '2025-01-01T00:00:00.000Z',
+  isActive: true,
+  isValidated: true,
+}
+const mockedStudy = {
+  name: 'Mocked Study',
+  startDate: '2025-01-01T00:00:00.000Z',
+  endDate: '2025-01-01T00:00:00Z',
+  isPublic: true,
+  level: Level.Initial,
+  exports: { createMany: { data: [] } },
+  createdBy: { connect: { id: mockedUserId } },
+  organization: { connect: { id: mockedOrganizationId } },
+  version: { connect: { id: 'mocked-version-id' } },
+  allowedUsers: { createMany: { data: [{ role: 'Validator', userId: mockedUserId }] } },
+  sites: {
+    createMany: {
+      data: [{ siteId: 'mocked-site-id', etp: 64, ca: 6906733.42 }],
+    },
+  },
+}
+
+export const getMockedDbUser = (props: Partial<User>): User => ({ ...mockedDbUser, ...props })
+export const getMockedStudy = (props: Partial<Prisma.StudyCreateInput>) =>
+  ({ ...mockedStudy, ...props }) as Prisma.StudyCreateInput


### PR DESCRIPTION
#316 

Il y a un problème avec `import { canCreateStudy } from './study'`

Ce dernier semble faire tous les import, y compris les non-nécessaires, ce qui oblige à ajouter les lignes suivantes :
```
jest.mock('../auth', () => ({ auth: jest.fn() }))
jest.mock('../file', () => ({ download: jest.fn() }))
jest.mock('../serverFunctions/emissionFactor', () => ({ getEmissionFactorByIds: jest.fn() }))
```
Autrement, le test est en erreur :
---
auth :
![image](https://github.com/user-attachments/assets/0a2ae469-d41b-4380-a0ba-d0c778310dd1)
---
file : 
![image](https://github.com/user-attachments/assets/8a0bc690-38c5-4d67-afc2-03313db2a288)
---
getEmissionFactorByIds :
![image](https://github.com/user-attachments/assets/cc535799-d313-44eb-9fa6-6c5a3d58b2cb)
