### PR TITLE
chore: protect password

### DIFF
--- a/src/app/(dashboard)/organisations/page.tsx
+++ b/src/app/(dashboard)/organisations/page.tsx
@@ -1,14 +1,11 @@
+import withAuth, { UserProps } from '@/components/hoc/withAuth'
 import OrganizationPage from '@/components/pages/Organization'
 import { getUserOrganizations } from '@/db/user'
-import { auth } from '@/services/auth'
 
-const Organisation = async () => {
-  const session = await auth()
-  if (!session || !session.user) {
-    return null
-  }
-  const organizations = await getUserOrganizations(session.user.email)
-  return <OrganizationPage organizations={organizations} user={session.user} />
+const Organisation = async ({ user }: UserProps) => {
+  const organizations = await getUserOrganizations(user.email)
+
+  return <OrganizationPage organizations={organizations} user={user} />
 }
 
-export default Organisation
+export default withAuth(Organisation)

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -5,7 +5,14 @@ const globalForPrisma = global as unknown as {
   prismaClient: PrismaClient | undefined
 }
 
-export const prismaClient = globalForPrisma.prismaClient ?? new PrismaClient()
+// https://www.prisma.io/docs/orm/prisma-client/queries/excluding-fields
+const defaultPrismaClient = new PrismaClient({
+  omit: {
+    user: { password: true, resetToken: true },
+  },
+}) as PrismaClient
+
+export const prismaClient = globalForPrisma.prismaClient ?? defaultPrismaClient
 
 if (process.env.NODE_ENV !== 'production') {
   globalForPrisma.prismaClient = prismaClient

--- a/src/db/user.ts
+++ b/src/db/user.ts
@@ -4,6 +4,23 @@ import { Prisma, Role } from '@prisma/client'
 import { User } from 'next-auth'
 import { prismaClient } from './client'
 
+export const getUserByEmailWithSensibleInformations = (email: string) =>
+  prismaClient.user.findUnique({
+    select: {
+      id: true,
+      firstName: true,
+      lastName: true,
+      role: true,
+      email: true,
+      organizationId: true,
+      level: true,
+      password: true,
+      resetToken: true,
+      isValidated: true,
+    },
+    where: { email },
+  })
+
 export const getUserByEmail = (email: string) => prismaClient.user.findUnique({ where: { email } })
 
 export const getUserByEmailWithAllowedStudies = (email: string) =>

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,4 +1,4 @@
-import { getUserByEmail } from '@/db/user'
+import { getUserByEmail, getUserByEmailWithSensibleInformations } from '@/db/user'
 import { Level, Role } from '@prisma/client'
 import bcrypt from 'bcryptjs'
 import { GetServerSidePropsContext, NextApiRequest, NextApiResponse } from 'next'
@@ -70,7 +70,7 @@ export const authOptions: NextAuthOptions = {
         if (!credentials) {
           return null
         }
-        const user = await getUserByEmail(credentials.email)
+        const user = await getUserByEmailWithSensibleInformations(credentials.email)
         if (!user || !user.password || !user.isValidated) {
           return null
         }

--- a/src/services/serverFunctions/auth.ts
+++ b/src/services/serverFunctions/auth.ts
@@ -1,5 +1,5 @@
 'use server'
-import { getUserByEmail, updateUserPasswordForEmail } from '@/db/user'
+import { getUserByEmailWithSensibleInformations, updateUserPasswordForEmail } from '@/db/user'
 import jwt from 'jsonwebtoken'
 import { computePasswordValidation } from '../utils'
 
@@ -10,7 +10,7 @@ export const checkToken = async (token: string) => {
       resetToken: string
     }
 
-    const user = await getUserByEmail(tokenValues.email)
+    const user = await getUserByEmailWithSensibleInformations(tokenValues.email)
     return !user?.resetToken
   } catch (error) {
     // Le token est expiré
@@ -29,7 +29,7 @@ export const reset = async (email: string, password: string, token: string) => {
   }
 
   if (tokenValues && tokenValues.email === email) {
-    const user = await getUserByEmail(email)
+    const user = await getUserByEmailWithSensibleInformations(email)
     if (user && user.resetToken && user.resetToken === tokenValues.resetToken) {
       const passwordValidation = computePasswordValidation(password)
       if (Object.values(passwordValidation).every((value) => value)) {


### PR DESCRIPTION
concerns #486 


J'ai pas reussi a faire un truc generalisé  a cause de ca :
"This is a type-safe object that you can mutate before the query happens. You can mutate any of the properties in args. Exception: you cannot mutate include or select because that would change the expected output type and break type safety."

du coup j'ai du multiplié les champs. Quid de ce qui se passe si tu fais un createAndReturn ? normalement c'est ok, vu que si tu crées c'est que tu as deja l'info.

On ne peut pas faire de delete non plus vu que password est fortement typé, donc si tu le demande pas tu dois le retourner quand même. D'ou le  = ''

Je trouve ce code un peu lourd, mais je ne vois pas comment faire autrement. Du coup ma reco c'est de ne pas le merger et de continuer de faire attention à ce qu'on fait, plutot qu'un code complexe (avec un any sale) ou on se dit qu'on est safe et qu'on surveille pas.