### PR TITLE
Feat/374 app settings

### DIFF
--- a/prisma/migrations/20250130150807_add_application_settings/migration.sql
+++ b/prisma/migrations/20250130150807_add_application_settings/migration.sql
@@ -1,0 +1,14 @@
+-- CreateTable
+CREATE TABLE "user_application_settings" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "validated_emission_sources_only" BOOLEAN NOT NULL DEFAULT true,
+
+    CONSTRAINT "user_application_settings_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "user_application_settings_user_id_key" ON "user_application_settings"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "user_application_settings" ADD CONSTRAINT "user_application_settings_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema/user.prisma
+++ b/prisma/schema/user.prisma
@@ -16,18 +16,28 @@ model User {
 
   role                       Role
   level                      Level?
-  firstName                  String                @map("first_name")
-  lastName                   String                @map("last_name")
-  email                      String                @unique
+  firstName                  String                   @map("first_name")
+  lastName                   String                   @map("last_name")
+  email                      String                   @unique
   password                   String?
-  resetToken                 String?               @map("reset_token")
-  isActive                   Boolean               @map("is_active")
-  isValidated                Boolean               @map("is_validated")
+  resetToken                 String?                  @map("reset_token")
+  isActive                   Boolean                  @map("is_active")
+  isValidated                Boolean                  @map("is_validated")
   createdStudies             Study[]
   allowedStudies             UserOnStudy[]
   contributors               Contributors[]
   contributedEmissionSources StudyEmissionSource[]
   flows                      Document[]
+  userApplicationSettings    UserApplicationSettings?
 
   @@map("users")
+}
+
+model UserApplicationSettings {
+  id                           String  @id @default(uuid())
+  userId                       String  @unique @map("user_id")
+  user                         User?   @relation(fields: [userId], references: [id])
+  validatedEmissionSourcesOnly Boolean @default(true) @map("validated_emission_sources_only")
+
+	@@map("user_application_settings")
 }

--- a/prisma/seed/index.ts
+++ b/prisma/seed/index.ts
@@ -32,6 +32,7 @@ const users = async () => {
   await prisma.emissionFactorImportVersion.deleteMany()
 
   await prisma.site.deleteMany()
+  await prisma.userApplicationSettings.deleteMany()
   await prisma.user.deleteMany()
 
   await prisma.organization.deleteMany()

--- a/src/app/(dashboard)/parametres/page.tsx
+++ b/src/app/(dashboard)/parametres/page.tsx
@@ -1,0 +1,17 @@
+'use server'
+
+import Block from '@/components/base/Block'
+import withAuth from '@/components/hoc/withAuth'
+import SettingsPage from '@/components/pages/Settings'
+import { useTranslations } from 'next-intl'
+
+const Settings = () => {
+  const t = useTranslations('settings')
+  return (
+    <Block title={t('title')} as="h1">
+      <SettingsPage />
+    </Block>
+  )
+}
+
+export default withAuth(Settings)

--- a/src/components/auth/ActivationForm.module.css
+++ b/src/components/auth/ActivationForm.module.css
@@ -1,3 +1,0 @@
-.error {
-  color: var(--error);
-}

--- a/src/components/auth/ActivationForm.tsx
+++ b/src/components/auth/ActivationForm.tsx
@@ -6,7 +6,6 @@ import { useTranslations } from 'next-intl'
 import Link from 'next/link'
 import { FormEvent, useState } from 'react'
 import LoadingButton from '../base/LoadingButton'
-import styles from './ActivationForm.module.css'
 import authStyles from './Auth.module.css'
 
 const contactMail = process.env.NEXT_PUBLIC_ABC_SUPPORT_MAIL
@@ -52,7 +51,7 @@ const ActivationForm = () => {
         {t('validate')}
       </LoadingButton>
       {error && (
-        <p className={styles.error} data-testid="activation-form-error">
+        <p className="error" data-testid="activation-form-error">
           {t.rich(error, {
             link: (children) => <Link href={`mailto:${contactMail}`}>{children}</Link>,
           })}

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -4,6 +4,7 @@ import AccountCircleIcon from '@mui/icons-material/AccountCircle'
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
 import MenuBookIcon from '@mui/icons-material/MenuBook'
 import PowerSettingsNewIcon from '@mui/icons-material/PowerSettingsNew'
+import SettingsIcon from '@mui/icons-material/Settings'
 import { Role } from '@prisma/client'
 import classNames from 'classnames'
 import { User } from 'next-auth'
@@ -62,6 +63,9 @@ const Navbar = ({ user }: Props) => {
             aria-label={t('help')}
           >
             <HelpOutlineIcon />
+          </Link>
+          <Link className={classNames(styles.link, 'align-center')} aria-label={t('settings')} href="/parametres">
+            <SettingsIcon />
           </Link>
           <Link className={classNames(styles.link, 'align-center')} aria-label={t('profile')} href="/profil">
             <AccountCircleIcon />

--- a/src/components/pages/Settings.tsx
+++ b/src/components/pages/Settings.tsx
@@ -1,0 +1,16 @@
+'use server'
+
+import { NOT_AUTHORIZED } from '@/services/permissions/check'
+import { getUserSettings } from '@/services/serverFunctions/user'
+import Settings from '../settings/Settings'
+import NotFound from './NotFound'
+
+const SettingsPage = async () => {
+  const userSettings = await getUserSettings()
+  if (!userSettings || userSettings === NOT_AUTHORIZED) {
+    return <NotFound />
+  }
+  return <Settings userSettings={userSettings} />
+}
+
+export default SettingsPage

--- a/src/components/pages/Settings.tsx
+++ b/src/components/pages/Settings.tsx
@@ -1,13 +1,12 @@
 'use server'
 
-import { NOT_AUTHORIZED } from '@/services/permissions/check'
 import { getUserSettings } from '@/services/serverFunctions/user'
 import Settings from '../settings/Settings'
 import NotFound from './NotFound'
 
 const SettingsPage = async () => {
   const userSettings = await getUserSettings()
-  if (!userSettings || userSettings === NOT_AUTHORIZED) {
+  if (!userSettings) {
     return <NotFound />
   }
   return <Settings userSettings={userSettings} />

--- a/src/components/settings/Settings.tsx
+++ b/src/components/settings/Settings.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { updateUserSettings } from '@/services/serverFunctions/user'
+import { EditSettingsCommand, EditSettingsCommandValidation } from '@/services/serverFunctions/user.command'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { FormControl, FormControlLabel, FormLabel, Switch } from '@mui/material'
+import { UserApplicationSettings } from '@prisma/client'
+import { useTranslations } from 'next-intl'
+import { useState } from 'react'
+import { Controller, useForm } from 'react-hook-form'
+import Form from '../base/Form'
+import LoadingButton from '../base/LoadingButton'
+
+interface Props {
+  userSettings: UserApplicationSettings
+}
+
+const Settings = ({ userSettings }: Props) => {
+  const t = useTranslations('settings')
+  const [error, setError] = useState('')
+
+  const form = useForm<EditSettingsCommand>({
+    resolver: zodResolver(EditSettingsCommandValidation),
+    mode: 'onBlur',
+    reValidateMode: 'onChange',
+    defaultValues: {
+      validatedEmissionSourcesOnly: userSettings.validatedEmissionSourcesOnly,
+    },
+  })
+
+  const onSubmit = async () => {
+    form.clearErrors()
+    const result = await updateUserSettings(form.getValues())
+    if (result) {
+      setError(result)
+    }
+    form.reset(form.getValues())
+  }
+
+  return (
+    <>
+      <div className="mb1">
+        <Form onSubmit={form.handleSubmit(onSubmit)}>
+          <FormControl>
+            <FormLabel>{t('validatedEmissionSourcesOnly')}</FormLabel>
+            <Controller
+              name="validatedEmissionSourcesOnly"
+              control={form.control}
+              render={({ field }) => (
+                <FormControlLabel
+                  control={
+                    <Switch
+                      {...field}
+                      checked={field.value}
+                      onChange={(event) => field.onChange(event.target.checked)}
+                    />
+                  }
+                  label={t(field.value ? 'yes' : 'no')}
+                />
+              )}
+            />
+          </FormControl>
+          <LoadingButton
+            type="submit"
+            disabled={!form.formState.isDirty}
+            loading={form.formState.isSubmitting}
+            data-testid="update-settings"
+          >
+            {t('validate')}
+          </LoadingButton>
+        </Form>
+      </div>
+      {error && <p className="error">{t(error)}</p>}
+    </>
+  )
+}
+
+export default Settings

--- a/src/components/study/infography/AllPostsInfography.tsx
+++ b/src/components/study/infography/AllPostsInfography.tsx
@@ -1,10 +1,11 @@
 import { FullStudy } from '@/db/study'
 import { Post } from '@/services/posts'
 import { computeResultsByPost } from '@/services/results/consolidated'
+import { getUserSettings } from '@/services/serverFunctions/user'
 import { SubPost } from '@prisma/client'
 import classNames from 'classnames'
 import { useTranslations } from 'next-intl'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import styles from './AllPostsInfography.module.css'
 import PostInfography from './PostInfography'
 
@@ -15,8 +16,23 @@ interface Props {
 
 const AllPostsInfography = ({ study, studySite }: Props) => {
   const tPost = useTranslations('emissionFactors.post')
+  const [validatedOnly, setValidatedOnly] = useState(true)
 
-  const data = useMemo(() => computeResultsByPost(study, tPost, studySite, true), [study, tPost, studySite])
+  useEffect(() => {
+    applyUserSettings()
+  }, [])
+
+  const applyUserSettings = async () => {
+    const validatedOnlySetting = (await getUserSettings())?.validatedEmissionSourcesOnly
+    if (validatedOnlySetting !== undefined) {
+      setValidatedOnly(validatedOnlySetting)
+    }
+  }
+
+  const data = useMemo(
+    () => computeResultsByPost(study, tPost, studySite, true, validatedOnly),
+    [study, tPost, studySite, validatedOnly],
+  )
   const findSubPost = (subPost: SubPost) => {
     const post = data.find((post) => post.subPosts.find((sb) => sb.post === subPost))
     const foundSubPost = post?.subPosts.find((sb) => sb.post === subPost)

--- a/src/components/study/perimeter/flow/StudyFlow.module.css
+++ b/src/components/study/perimeter/flow/StudyFlow.module.css
@@ -20,7 +20,3 @@
   max-height: 30rem;
   object-fit: contain;
 }
-
-.error {
-  color: var(--error);
-}

--- a/src/components/study/perimeter/flow/StudyFlow.tsx
+++ b/src/components/study/perimeter/flow/StudyFlow.tsx
@@ -119,7 +119,7 @@ const StudyFlow = ({ canAddFlow, documents, initialDocument, study }: Props) => 
           : undefined
       }
     >
-      {error && <div className={classNames(styles.error, 'mb1')}>{error}</div>}
+      {error && <div className="error mb1">{error}</div>}
       {selectedFlow ? (
         <div className="flex-col">
           <div className="flex-col mb1">

--- a/src/components/study/results/Result.tsx
+++ b/src/components/study/results/Result.tsx
@@ -4,6 +4,7 @@ import LoadingButton from '@/components/base/LoadingButton'
 import { FullStudy } from '@/db/study'
 import { Post, subPostsByPost } from '@/services/posts'
 import { computeResultsByPost, ResultsByPost } from '@/services/results/consolidated'
+import { getUserSettings } from '@/services/serverFunctions/user'
 import { downloadStudyEmissionSources, downloadStudyPost } from '@/services/study'
 import { formatNumber } from '@/utils/number'
 import DownloadIcon from '@mui/icons-material/Download'
@@ -52,6 +53,18 @@ const Result = ({ study, by, studySite, withDependenciesGlobal }: Props) => {
   const [withDependencies, setWithDependencies] = useState(
     withDependenciesGlobal === undefined ? true : withDependenciesGlobal,
   )
+  const [validatedOnly, setValidatedOnly] = useState(true)
+
+  useEffect(() => {
+    applyUserSettings()
+  }, [])
+
+  const applyUserSettings = async () => {
+    const validatedOnlySetting = (await getUserSettings())?.validatedEmissionSourcesOnly
+    if (validatedOnlySetting !== undefined) {
+      setValidatedOnly(validatedOnlySetting)
+    }
+  }
 
   useEffect(() => {
     if (withDependenciesGlobal !== undefined) {
@@ -70,7 +83,7 @@ const Result = ({ study, by, studySite, withDependenciesGlobal }: Props) => {
   )
 
   const yData = useMemo(() => {
-    const computedResults = computeResultsByPost(study, tPost, studySite, withDependencies)
+    const computedResults = computeResultsByPost(study, tPost, studySite, withDependencies, validatedOnly)
     if (by === 'Post') {
       if (computedResults.every((post) => post.value === 0)) {
         return []
@@ -87,7 +100,7 @@ const Result = ({ study, by, studySite, withDependenciesGlobal }: Props) => {
         .filter((subPost) => withDependencies || subPost !== SubPost.UtilisationEnDependance)
         .map((subPost) => subPosts.find((subPostResult) => subPostResult.post === subPost)?.value || 0)
     }
-  }, [post, by, studySite, withDependencies])
+  }, [post, by, studySite, withDependencies, validatedOnly])
 
   useEffect(() => {
     if (canvasRef.current) {

--- a/src/components/study/results/beges/BegesResultsTable.tsx
+++ b/src/components/study/results/beges/BegesResultsTable.tsx
@@ -3,12 +3,13 @@
 import { EmissionFactorWithParts } from '@/db/emissionFactors'
 import { FullStudy } from '@/db/study'
 import { BegesLine, computeBegesResult, rulesSpans } from '@/services/results/beges'
+import { getUserSettings } from '@/services/serverFunctions/user'
 import { getStandardDeviationRating } from '@/services/uncertainty'
 import { formatNumber } from '@/utils/number'
 import { ExportRule } from '@prisma/client'
 import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import { useTranslations } from 'next-intl'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 interface Props {
   study: FullStudy
@@ -21,6 +22,18 @@ interface Props {
 const BegesResultsTable = ({ study, rules, emissionFactorsWithParts, studySite, withDependencies }: Props) => {
   const t = useTranslations('beges')
   const tQuality = useTranslations('quality')
+  const [validatedOnly, setValidatedOnly] = useState(true)
+
+  useEffect(() => {
+    applyUserSettings()
+  }, [])
+
+  const applyUserSettings = async () => {
+    const validatedOnlySetting = (await getUserSettings())?.validatedEmissionSourcesOnly
+    if (validatedOnlySetting !== undefined) {
+      setValidatedOnly(validatedOnlySetting)
+    }
+  }
 
   const columns = useMemo(
     () =>
@@ -76,8 +89,8 @@ const BegesResultsTable = ({ study, rules, emissionFactorsWithParts, studySite, 
   )
 
   const data = useMemo(
-    () => computeBegesResult(study, rules, emissionFactorsWithParts, studySite, withDependencies),
-    [study, rules, emissionFactorsWithParts, studySite, withDependencies],
+    () => computeBegesResult(study, rules, emissionFactorsWithParts, studySite, withDependencies, validatedOnly),
+    [study, rules, emissionFactorsWithParts, studySite, withDependencies, validatedOnly],
   )
 
   const table = useReactTable({

--- a/src/components/study/results/consolidated/ConsolidatedResultsTable.tsx
+++ b/src/components/study/results/consolidated/ConsolidatedResultsTable.tsx
@@ -2,6 +2,7 @@
 
 import { FullStudy } from '@/db/study'
 import { computeResultsByPost, ResultsByPost } from '@/services/results/consolidated'
+import { getUserSettings } from '@/services/serverFunctions/user'
 import { getStandardDeviationRating } from '@/services/uncertainty'
 import { formatNumber } from '@/utils/number'
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
@@ -9,7 +10,7 @@ import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight'
 import { ColumnDef, flexRender, getCoreRowModel, getExpandedRowModel, useReactTable } from '@tanstack/react-table'
 import classNames from 'classnames'
 import { useTranslations } from 'next-intl'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import styles from './ConsolidatedResultsTable.module.css'
 
 interface Props {
@@ -22,6 +23,18 @@ const ConsolidatedResultsTable = ({ study, studySite, withDependencies }: Props)
   const t = useTranslations('study.results')
   const tQuality = useTranslations('quality')
   const tPost = useTranslations('emissionFactors.post')
+  const [validatedOnly, setValidatedOnly] = useState(true)
+
+  useEffect(() => {
+    applyUserSettings()
+  }, [])
+
+  const applyUserSettings = async () => {
+    const validatedOnlySetting = (await getUserSettings())?.validatedEmissionSourcesOnly
+    if (validatedOnlySetting !== undefined) {
+      setValidatedOnly(validatedOnlySetting)
+    }
+  }
 
   const columns = useMemo(
     () =>
@@ -64,8 +77,8 @@ const ConsolidatedResultsTable = ({ study, studySite, withDependencies }: Props)
   )
 
   const data = useMemo(
-    () => computeResultsByPost(study, tPost, studySite, withDependencies),
-    [study, tPost, studySite, withDependencies],
+    () => computeResultsByPost(study, tPost, studySite, withDependencies, validatedOnly),
+    [study, tPost, studySite, withDependencies, validatedOnly],
   )
 
   const table = useReactTable({

--- a/src/components/transition/Organizations.module.css
+++ b/src/components/transition/Organizations.module.css
@@ -3,7 +3,3 @@
   top: 0;
   left: -999999px;
 }
-
-.error {
-  color: var(--error);
-}

--- a/src/components/transition/Organizations.tsx
+++ b/src/components/transition/Organizations.tsx
@@ -2,7 +2,6 @@
 
 import { maxAllowedFileSize, MB } from '@/services/file'
 import { downloadOrganizations } from '@/services/serverFunctions/transitions'
-import classNames from 'classnames'
 import { useTranslations } from 'next-intl'
 import { useState } from 'react'
 import LoadingButton from '../base/LoadingButton'
@@ -58,7 +57,7 @@ const OrganizationsTransition = () => {
         <input type="file" className={styles.input} onChange={download} value="" accept=".xlsx" />
       </LoadingButton>
       {success && <p className="mt1">{t('success')}</p>}
-      {error && <p className={classNames(styles.error, 'mt1')}>{error}</p>}
+      {error && <p className="error mt1">{error}</p>}
     </>
   )
 }

--- a/src/css/globals.css
+++ b/src/css/globals.css
@@ -117,3 +117,7 @@ table {
   margin: 0 !important;
   padding: 0 !important;
 }
+
+.error {
+  color: var(--error);
+}

--- a/src/db/user.ts
+++ b/src/db/user.ts
@@ -103,3 +103,12 @@ export const updateProfile = (userId: string, data: Prisma.UserUpdateInput) =>
     where: { id: userId },
     data,
   })
+
+export const getUserApplicationSettings = (userId: string) =>
+  prismaClient.userApplicationSettings.upsert({ where: { userId }, update: {}, create: { userId } })
+
+export const updateUserApplicationSettings = (userId: string, data: Prisma.UserApplicationSettingsUpdateInput) =>
+  prismaClient.userApplicationSettings.update({
+    where: { userId },
+    data,
+  })

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -156,6 +156,7 @@
     "logout": "Log out",
     "methodology": "Methodology",
     "organizations": "My carbon assessments",
+    "settings": "Settings",
     "team": "My team",
     "information": "Global informations"
   },
@@ -175,6 +176,13 @@
       "firstName": "1 character minimum",
       "lastName": "1 character minimum"
     }
+  },
+  "settings": {
+    "title": "My application settings",
+    "validate": "Save",
+    "validatedEmissionSourcesOnly": "Only display the validated emission sources",
+    "yes": "Yes",
+    "no": "No"
   },
   "admin": {
     "title": "Administration",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -156,6 +156,7 @@
     "logout": "Se déconnecter",
     "methodology": "Méthodologie",
     "organizations": "Mes bilans carbone",
+    "settings": "Paramètres",
     "team": "Mon équipe",
     "information": "Informations générales"
   },
@@ -175,6 +176,13 @@
       "firstName": "1 caractère minimum",
       "lastName": "1 caractère minimum"
     }
+  },
+  "settings": {
+    "title": "Mes paramètres d'application",
+    "validate": "Sauvegarder",
+    "validatedEmissionSourcesOnly": "Afficher uniquement les sources d'emissions validées",
+    "yes": "Oui",
+    "no": "Non"
   },
   "admin": {
     "title": "Administration du BC+",

--- a/src/services/results/beges.ts
+++ b/src/services/results/beges.ts
@@ -156,6 +156,7 @@ export const computeBegesResult = (
   emissionFactorsWithParts: EmissionFactorWithParts[],
   studySite: string,
   withDependencies: boolean,
+  validatedOnly: boolean = true,
 ) => {
   const results: Record<string, Omit<BegesLine, 'rule'>[]> = allRules.reduce(
     (acc, rule) => ({ ...acc, [rule]: [] }),
@@ -166,7 +167,11 @@ export const computeBegesResult = (
   siteEmissionSources
     .filter((emissionSource) => filterWithDependencies(emissionSource.subPost, withDependencies))
     .forEach((emissionSource) => {
-      if (emissionSource.emissionFactor === null || !emissionSource.value || !emissionSource.validated) {
+      if (
+        emissionSource.emissionFactor === null ||
+        !emissionSource.value ||
+        (validatedOnly && !emissionSource.validated)
+      ) {
         return
       }
 

--- a/src/services/results/consolidated.ts
+++ b/src/services/results/consolidated.ts
@@ -32,6 +32,7 @@ export const computeResultsByPost = (
   tPost: (key: string) => string,
   studySite: string,
   withDependencies: boolean,
+  validatedOnly: boolean = true,
 ) => {
   const siteEmissionSources = getSiteEmissionSources(study.emissionSources, studySite)
 
@@ -42,7 +43,9 @@ export const computeResultsByPost = (
         .filter((subPost) => filterWithDependencies(subPost, withDependencies))
         .map((subPost) => {
           const emissionSources = siteEmissionSources.filter((emissionSource) => emissionSource.subPost === subPost)
-          const validatedEmissionSources = emissionSources.filter((emissionSource) => emissionSource.validated)
+          const validatedEmissionSources = emissionSources.filter(
+            (emissionSource) => !validatedOnly || emissionSource.validated,
+          )
 
           return {
             post: subPost,

--- a/src/services/serverFunctions/user.command.ts
+++ b/src/services/serverFunctions/user.command.ts
@@ -72,3 +72,9 @@ export const OnboardingCommandValidation = z.object({
     .optional(),
 })
 export type OnboardingCommand = z.infer<typeof OnboardingCommandValidation>
+
+export const EditSettingsCommandValidation = z.object({
+  validatedEmissionSourcesOnly: z.boolean(),
+})
+
+export type EditSettingsCommand = z.infer<typeof EditSettingsCommandValidation>

--- a/src/services/serverFunctions/user.ts
+++ b/src/services/serverFunctions/user.ts
@@ -5,8 +5,10 @@ import {
   addUser,
   changeUserRole,
   deleteUser,
+  getUserApplicationSettings,
   getUserByEmail,
   updateProfile,
+  updateUserApplicationSettings,
   updateUserResetTokenForEmail,
   validateUser,
 } from '@/db/user'
@@ -25,7 +27,7 @@ import {
 } from '../email/email'
 import { NOT_AUTHORIZED } from '../permissions/check'
 import { canAddMember, canChangeRole, canDeleteMember } from '../permissions/user'
-import { AddMemberCommand, EditProfileCommand } from './user.command'
+import { AddMemberCommand, EditProfileCommand, EditSettingsCommand } from './user.command'
 
 const updateUserResetToken = async (email: string, duration: number) => {
   const resetToken = Math.random().toString(36)
@@ -191,4 +193,20 @@ export const activateEmail = async (email: string) => {
   }
   await validateUser(email)
   await sendActivation(email)
+}
+
+export const getUserSettings = async () => {
+  const session = await auth()
+  if (!session || !session.user) {
+    return NOT_AUTHORIZED
+  }
+  return getUserApplicationSettings(session.user.id)
+}
+
+export const updateUserSettings = async (command: EditSettingsCommand) => {
+  const session = await auth()
+  if (!session || !session.user) {
+    return NOT_AUTHORIZED
+  }
+  await updateUserApplicationSettings(session.user.id, command)
 }

--- a/src/services/serverFunctions/user.ts
+++ b/src/services/serverFunctions/user.ts
@@ -198,7 +198,7 @@ export const activateEmail = async (email: string) => {
 export const getUserSettings = async () => {
   const session = await auth()
   if (!session || !session.user) {
-    return NOT_AUTHORIZED
+    return null
   }
   return getUserApplicationSettings(session.user.id)
 }


### PR DESCRIPTION
#374 

J'ai fais le choix de mettre des valeurs par défaut à tous les settings (même s'il n'y en a qu'un pour le moment) : cela permet de se poser moins de questions au moment de la création des comptes, on n'a pas à se poser de question quand on ajoutera des paramètres, etc. Ainsi :
- Le getUserSettings est un return upsert(where: {userId}, udate: {}, create: {userId}) : On récupère la donnée non mise à jour ou celle qui vient d'être créée, avec toutes les valeurs par défaut
- Toutes les fonctions qui utilisent un paramètre utilisateur doivent lui donner une valeur par défaut
- Pour ce premier paramètre (utilisation des sources d'émissions validées uniquement), la valeur par défaut est `true`