### PR TITLE
Fix/491 organization access

### DIFF
--- a/src/app/(dashboard)/equipe/page.tsx
+++ b/src/app/(dashboard)/equipe/page.tsx
@@ -1,10 +1,14 @@
 import withAuth, { UserProps } from '@/components/hoc/withAuth'
+import NotFound from '@/components/pages/NotFound'
 import TeamPage from '@/components/pages/Team'
 import { getUserFromUserOrganization } from '@/db/user'
 
 export const revalidate = 0
 
 const Team = async ({ user }: UserProps) => {
+  if (!user.organizationId) {
+    return <NotFound />
+  }
   const team = await getUserFromUserOrganization(user)
   return <TeamPage user={user} team={team} />
 }

--- a/src/app/(dashboard)/organisations/page.tsx
+++ b/src/app/(dashboard)/organisations/page.tsx
@@ -1,10 +1,13 @@
 import withAuth, { UserProps } from '@/components/hoc/withAuth'
+import NotFound from '@/components/pages/NotFound'
 import OrganizationPage from '@/components/pages/Organization'
 import { getUserOrganizations } from '@/db/user'
 
 const Organisation = async ({ user }: UserProps) => {
+  if (!user.organizationId) {
+    return <NotFound />
+  }
   const organizations = await getUserOrganizations(user.email)
-
   return <OrganizationPage organizations={organizations} user={user} />
 }
 

--- a/src/components/emissionFactor/EmissionFactors.tsx
+++ b/src/components/emissionFactor/EmissionFactors.tsx
@@ -2,7 +2,6 @@
 
 import { getLocale } from '@/i18n/locale'
 import { getEmissionFactors } from '@/services/emissionFactors'
-import NotFound from '../pages/NotFound'
 import EmissionFactorsTable from './Table'
 
 interface Props {
@@ -12,10 +11,6 @@ interface Props {
 const EmissionFactors = async ({ userOrganizationId }: Props) => {
   const locale = await getLocale()
   const emissionFactors = await getEmissionFactors(locale)
-
-  if (!userOrganizationId) {
-    return <NotFound />
-  }
 
   return <EmissionFactorsTable emissionFactors={emissionFactors} userOrganizationId={userOrganizationId} />
 }

--- a/src/components/emissionFactor/Table.tsx
+++ b/src/components/emissionFactor/Table.tsx
@@ -89,7 +89,7 @@ const sources = Object.values(Import).map((source) => source)
 interface Props {
   emissionFactors: EmissionFactorWithMetaData[]
   selectEmissionFactor?: (emissionFactor: EmissionFactorWithMetaData) => void
-  userOrganizationId?: string
+  userOrganizationId?: string | null
 }
 
 const EmissionFactorsTable = ({ emissionFactors, selectEmissionFactor, userOrganizationId }: Props) => {

--- a/src/components/home/UserView.tsx
+++ b/src/components/home/UserView.tsx
@@ -6,7 +6,6 @@ import Actualities from '../actuality/Actualities'
 import Block from '../base/Block'
 import Onboarding from '../onboarding/Onboarding'
 import Organizations from '../organization/OrganizationsContainer'
-import NotFound from '../pages/NotFound'
 import ResultsContainerForUser from '../study/results/ResultsContainerForUser'
 import Studies from '../study/StudiesContainer'
 import UserToValidate from './UserToValidate'
@@ -23,11 +22,7 @@ const UserView = async ({ user }: Props) => {
   ])
 
   const userOrganization = organizations.find((organization) => organization.id === user.organizationId)
-  if (!userOrganization) {
-    return <NotFound />
-  }
-
-  const isCR = userOrganization.isCR
+  const isCR = userOrganization?.isCR
 
   return (
     <>
@@ -47,7 +42,7 @@ const UserView = async ({ user }: Props) => {
           {isCR ? <Organizations organizations={organizations} /> : <Studies user={user} />}
         </div>
       </Block>
-      {!userOrganization.onboarded && <Onboarding organization={userOrganization} />}
+      {userOrganization && !userOrganization.onboarded && <Onboarding organization={userOrganization} />}
     </>
   )
 }

--- a/src/components/navbar/Navbar.module.css
+++ b/src/components/navbar/Navbar.module.css
@@ -51,4 +51,6 @@
   background-color: var(--primary-80);
   flex-direction: column;
   padding: 1rem;
+  position: absolute;
+  top: 100%;
 }

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -36,14 +36,19 @@ const Navbar = ({ user }: Props) => {
             <span className={styles.big}>{t('factors')}</span>
             <span className={styles.small}>{t('fe')}</span>
           </Link>
-          <div
-            className={styles.link}
-            onMouseEnter={handleMouseEnter}
-            onMouseLeave={handleMouseLeave}
-            onClick={() => setShowSubMenu(!showSubMenu)}
-          >
-            {t('organization')}
-          </div>
+          {user.organizationId && (
+            <div
+              className={styles.link}
+              onMouseEnter={handleMouseEnter}
+              onMouseLeave={handleMouseLeave}
+              onClick={() => setShowSubMenu(!showSubMenu)}
+            >
+              {t('organization')}
+            </div>
+          )}
+          <Link className={styles.link} href="/transition">
+            {t('transition')}
+          </Link>
         </div>
         <div className={classNames(styles.navbarContainer, 'flex-cc')}>
           {user.role === Role.SUPER_ADMIN && (

--- a/src/components/navbar/Navbar.tsx
+++ b/src/components/navbar/Navbar.tsx
@@ -37,18 +37,36 @@ const Navbar = ({ user }: Props) => {
             <span className={styles.small}>{t('fe')}</span>
           </Link>
           {user.organizationId && (
-            <div
-              className={styles.link}
-              onMouseEnter={handleMouseEnter}
-              onMouseLeave={handleMouseLeave}
-              onClick={() => setShowSubMenu(!showSubMenu)}
-            >
-              {t('organization')}
+            <div className="flex-col">
+              <div
+                className={styles.link}
+                onMouseEnter={handleMouseEnter}
+                onMouseLeave={handleMouseLeave}
+                onClick={() => setShowSubMenu(!showSubMenu)}
+              >
+                {t('organization')}
+              </div>
+              {showSubMenu && (
+                <div
+                  className={classNames(styles.subMenu, 'flex-cc')}
+                  onMouseEnter={handleMouseEnter}
+                  onMouseLeave={handleMouseLeave}
+                >
+                  {user.role === Role.ADMIN && (
+                    <Link href={`/organisations/${user.organizationId}/modifier`} className={styles.link}>
+                      {t('information')}
+                    </Link>
+                  )}
+                  <Link href="/equipe" className={styles.link}>
+                    {t('team')}
+                  </Link>
+                  <Link href="/organisations" className={styles.link}>
+                    {t('organizations')}
+                  </Link>
+                </div>
+              )}
             </div>
           )}
-          <Link className={styles.link} href="/transition">
-            {t('transition')}
-          </Link>
         </div>
         <div className={classNames(styles.navbarContainer, 'flex-cc')}>
           {user.role === Role.SUPER_ADMIN && (
@@ -81,25 +99,6 @@ const Navbar = ({ user }: Props) => {
           </button>
         </div>
       </div>
-      {showSubMenu && (
-        <div
-          className={classNames(styles.subMenu, 'flex-cc')}
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
-        >
-          {user.role === Role.ADMIN && (
-            <Link href={`/organisations/${user.organizationId}/modifier`} className={styles.link}>
-              {t('information')}
-            </Link>
-          )}
-          <Link href="/equipe" className={styles.link}>
-            {t('team')}
-          </Link>
-          <Link href="/organisations" className={styles.link}>
-            {t('organizations')}
-          </Link>
-        </div>
-      )}
     </nav>
   )
 }

--- a/src/components/study/StudiesContainer.tsx
+++ b/src/components/study/StudiesContainer.tsx
@@ -19,15 +19,17 @@ const StudiesContainer = ({ user, organizationId }: Props) => {
       <div data-testid="studies-title" className={classNames(styles.title, 'flex-cc pb1')}>
         <NewspaperIcon /> <h2>{t('myStudies')}</h2>
       </div>
-      <div className={classNames(styles.button, 'w100 flex')}>
-        <LinkButton
-          data-testid="new-study"
-          className="mb1"
-          href={`${organizationId ? `/organisations/${organizationId}` : ''}/etudes/creer`}
-        >
-          {t('create')}
-        </LinkButton>
-      </div>
+      {(user.organizationId || organizationId) && (
+        <div className={classNames(styles.button, 'w100 flex')}>
+          <LinkButton
+            data-testid="new-study"
+            className="mb1"
+            href={`${organizationId ? `/organisations/${organizationId}` : ''}/etudes/creer`}
+          >
+            {t('create')}
+          </LinkButton>
+        </div>
+      )}
       <Studies user={user} organizationId={organizationId} />
     </Box>
   )

--- a/src/db/emissionFactors.ts
+++ b/src/db/emissionFactors.ts
@@ -56,12 +56,14 @@ const getCachedDefaultEmissionFactors = unstable_cache(() => {
   return getDefaultEmissionFactors()
 })
 
-export const getAllEmissionFactors = async (organizationId: string) => {
-  const organizationEmissionFactor = await prismaClient.emissionFactor.findMany({
-    where: { organizationId },
-    select: selectEmissionFactor,
-    orderBy: { createdAt: 'desc' },
-  })
+export const getAllEmissionFactors = async (organizationId: string | null) => {
+  const organizationEmissionFactor = organizationId
+    ? await prismaClient.emissionFactor.findMany({
+        where: { organizationId },
+        select: selectEmissionFactor,
+        orderBy: { createdAt: 'desc' },
+      })
+    : []
   const defaultEmissionFactors = await (process.env.NO_CACHE === 'true'
     ? getDefaultEmissionFactors()
     : getCachedDefaultEmissionFactors())

--- a/src/services/emissionFactors.ts
+++ b/src/services/emissionFactors.ts
@@ -4,7 +4,7 @@ import { sortAlphabetically } from './utils'
 
 export const getEmissionFactors = async (locale: string) => {
   const session = await auth()
-  if (!session || !session.user.organizationId) {
+  if (!session || !session.user) {
     return []
   }
 


### PR DESCRIPTION
#491 
- Aucun reset de mdp quand pas de compte associé -> déjà en place
- Suppression de l'élément de la NavBar concernant l'organisation quand l'utilisateur ne fait pas partie d'une orga (exemple : un utilisateur invité pour être un collaborateur sur une étude)

Le cas d'afficher une autre personne qui a priori n'a pas d'organisation non plus vient du fait qu'aucun check n'est fait sur la page "Équipe" et donc que l'utilisateur récupère tous les utilisateurs tous les utilisateurs qui ont le même organizationId (null dans notre cas). J'ai supprimé l'accès à cette page qui n'avait pas lieu d'être

Testé avec `to-activate@yopmail.com` compte créé uniquement pour tester la connexion, donc rattaché à aucune organisation