### PR TITLE
only get emission factor with subpost

### DIFF
--- a/src/db/emissionFactors.ts
+++ b/src/db/emissionFactors.ts
@@ -47,7 +47,7 @@ const selectEmissionFactor = {
 
 const getDefaultEmissionFactors = () =>
   prismaClient.emissionFactor.findMany({
-    where: { organizationId: null },
+    where: { organizationId: null, subPosts: { isEmpty: false } },
     select: selectEmissionFactor,
     orderBy: { createdAt: 'desc' },
   })


### PR DESCRIPTION
related to #536 

On ne veut pas récupérer les FEs qui ne sont pas attribués à un sous poste. J'ai laissé la possibilité si la personne le récupère directement via l'id, je me suis dit que si il avait l'id c'est qu'il y avait probablement une raison (FE qui était utilisé avant dans une étude car il fut attribué par exemple mais ne l'est plus) 