### PR TITLE
increase boldness

### DIFF
--- a/src/css/globals.css
+++ b/src/css/globals.css
@@ -133,5 +133,5 @@ table {
 }
 
 .bold {
-  font-weight: 400;
+  font-weight: bold;
 }


### PR DESCRIPTION
Je sais pas trop pourquoi sur figma c'est amrqué qu'on est seulement à 400 de font weight alors que clairement on est à plus. je me demande si c'est pas parce que c'est 400 par rapport à Gilroy semi bold ? 
Dans tous les cas c'est plus proche de la maquette ainsi. 