### PR TITLE
Fix/496 study results

### DIFF
--- a/src/components/study/EmissionSourceForm.tsx
+++ b/src/components/study/EmissionSourceForm.tsx
@@ -122,7 +122,7 @@ const EmissionSourceForm = ({
               disabled={!canEdit}
               type="number"
               data-testid="emission-source-value-da"
-              value={emissionSource.value}
+              defaultValue={emissionSource.value}
               onBlur={(event) => handleUpdate(event)}
               label={`${t('form.value')} *`}
               helperText={error}

--- a/src/components/study/results/AllResults.tsx
+++ b/src/components/study/results/AllResults.tsx
@@ -84,7 +84,9 @@ const AllResults = ({ study, rules, emissionFactorsWithParts }: Props) => {
         >
           <DownloadIcon />
         </Button>
-        <DependenciesSwitch withDependencies={withDependencies} setWithDependencies={setWithDependencies} />
+        {type !== 'consolidated' && (
+          <DependenciesSwitch withDependencies={withDependencies} setWithDependencies={setWithDependencies} />
+        )}
       </div>
       <div className="mt1">
         {type === 'consolidated' && (

--- a/src/services/permissions/emissionSource.ts
+++ b/src/services/permissions/emissionSource.ts
@@ -1,5 +1,6 @@
 import { getEmissionFactorById } from '@/db/emissionFactors'
 import { FullStudy, getStudyById } from '@/db/study'
+import { getUserRoleOnStudy } from '@/utils/study'
 import { StudyEmissionSource, StudyRole, User } from '@prisma/client'
 import { canBeValidated } from '../emissionSource'
 import { Post, subPostsByPost } from '../posts'
@@ -97,8 +98,8 @@ export const canUpdateEmissionSource = async (
 }
 
 export const canDeleteEmissionSource = async (user: User, study: FullStudy) => {
-  const rights = study.allowedUsers.find((right) => right.user.email === user.email)
-  if (rights && rights.role !== StudyRole.Reader) {
+  const userRoleOnStudy = getUserRoleOnStudy(user, study)
+  if (userRoleOnStudy && userRoleOnStudy !== StudyRole.Reader) {
     return true
   }
 


### PR DESCRIPTION
#496 : Les valeurs affichée sur la Box de résultats dans les cases "Avec dépendances" et "Sans dépendances" semblent être doublées (plus un facteur x1000 avec une confusion kg/t)

Hors scope : 
- Permettre la mise à jour des valeurs des sources d'emissions
- Corriger le droit de suppression d'émission pour les études publiques