### PR TITLE
fix client card background color

### DIFF
--- a/src/components/organization/Organization.module.css
+++ b/src/components/organization/Organization.module.css
@@ -1,5 +1,5 @@
 .card {
-  background-color: var(--organization-card-bg);
+  background-color: var(--neutral-00);
 }
 
 .link {


### PR DESCRIPTION
#494 (cf comment https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/494#issuecomment-2670812831)

Corrige uniquement la couleur de fond des cartes des clients d'un utilisateur CR. Les autres points seront corrigés à l'avenir s'il le faut