### PR TITLE
386 activation second account

### DIFF
--- a/prisma/migrations/20250221124830_add_status/migration.sql
+++ b/prisma/migrations/20250221124830_add_status/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `is_active` on the `users` table. All the data in the column will be lost.
+  - You are about to drop the column `is_validated` on the `users` table. All the data in the column will be lost.
+
+*/
+-- CreateEnum
+CREATE TYPE "UserStatus" AS ENUM ('IMPORTED', 'PENDING_REQUEST', 'VALIDATED', 'ACTIVE');
+
+-- AlterTable
+ALTER TABLE "users" DROP COLUMN "is_active",
+DROP COLUMN "is_validated",
+ADD COLUMN     "status" "UserStatus" NOT NULL DEFAULT 'ACTIVE';

--- a/prisma/schema/user.prisma
+++ b/prisma/schema/user.prisma
@@ -5,6 +5,13 @@ enum Role {
   DEFAULT
 }
 
+enum UserStatus {
+  IMPORTED
+  PENDING_REQUEST
+  VALIDATED
+  ACTIVE
+}
+
 model User {
   id               String    @id @default(uuid())
   createdAt        DateTime  @default(now()) @map("created_at")
@@ -22,8 +29,7 @@ model User {
   email                      String                   @unique
   password                   String?
   resetToken                 String?                  @map("reset_token")
-  isActive                   Boolean                  @map("is_active")
-  isValidated                Boolean                  @map("is_validated")
+  status                     UserStatus               @default(IMPORTED)
   createdStudies             Study[]
   allowedStudies             UserOnStudy[]
   contributors               Contributors[]

--- a/prisma/schema/user.prisma
+++ b/prisma/schema/user.prisma
@@ -29,7 +29,7 @@ model User {
   email                      String                   @unique
   password                   String?
   resetToken                 String?                  @map("reset_token")
-  status                     UserStatus               @default(IMPORTED)
+  status                     UserStatus
   createdStudies             Study[]
   allowedStudies             UserOnStudy[]
   contributors               Contributors[]

--- a/prisma/seed/index.ts
+++ b/prisma/seed/index.ts
@@ -137,7 +137,7 @@ const users = async () => {
       lastName: faker.person.lastName(),
       organizationId: unOnboardedOrganization.id,
       role: Role.GESTIONNAIRE,
-      status: UserStatus.IMPORTED,
+      status: UserStatus.ACTIVE,
     },
   })
 
@@ -180,7 +180,7 @@ const users = async () => {
       lastName: faker.person.lastName(),
       organizationId: organizations[0].id,
       role: Role.GESTIONNAIRE,
-      status: UserStatus.IMPORTED,
+      status: UserStatus.ACTIVE,
     },
   })
 

--- a/prisma/seed/index.ts
+++ b/prisma/seed/index.ts
@@ -137,8 +137,8 @@ const users = async () => {
       firstName: faker.person.firstName(),
       lastName: faker.person.lastName(),
       organizationId: unOnboardedOrganization.id,
-      role: Role.GESTIONNAIRE,
-      status: UserStatus.ACTIVE,
+      role: Role.DEFAULT,
+      status: UserStatus.IMPORTED,
     },
   })
 
@@ -172,18 +172,6 @@ const users = async () => {
       onboarded: true,
       activatedLicence: true,
     })),
-  })
-
-  await prisma.user.create({
-    data: {
-      email: 'onboardednotrained@yopmail.com',
-      password: onboardingPassword,
-      firstName: faker.person.firstName(),
-      lastName: faker.person.lastName(),
-      organizationId: organizations[0].id,
-      role: Role.GESTIONNAIRE,
-      status: UserStatus.ACTIVE,
-    },
   })
 
   const crOrganizations = organizations.filter((organization) => organization.isCR)
@@ -274,7 +262,6 @@ const users = async () => {
         firstName: faker.person.firstName(),
         lastName: faker.person.lastName(),
         password: await signPassword('password'),
-        level: Level.Initial,
         organizationId: regularOrganizations[1].id,
         role: Role.DEFAULT,
         status: UserStatus.ACTIVE,
@@ -287,13 +274,13 @@ const users = async () => {
 
   await prisma.user.create({
     data: {
-      email: 'to-activate@yopmail.com',
+      email: 'imported@yopmail.com',
       firstName: 'User',
-      lastName: 'ToActivate',
-      role: Role.ADMIN,
+      lastName: 'Imported',
+      role: Role.DEFAULT,
       level: Level.Initial,
       status: UserStatus.IMPORTED,
-      organizationId: organizations[0].id,
+      organizationId: regularOrganizations[0].id,
     },
   })
 

--- a/prisma/seed/index.ts
+++ b/prisma/seed/index.ts
@@ -133,6 +133,7 @@ const users = async () => {
   await prisma.user.create({
     data: {
       email: 'onboardingnottrained@yopmail.com',
+      password: onboardingPassword,
       firstName: faker.person.firstName(),
       lastName: faker.person.lastName(),
       organizationId: unOnboardedOrganization.id,
@@ -176,6 +177,7 @@ const users = async () => {
   await prisma.user.create({
     data: {
       email: 'onboardednotrained@yopmail.com',
+      password: onboardingPassword,
       firstName: faker.person.firstName(),
       lastName: faker.person.lastName(),
       organizationId: organizations[0].id,

--- a/prisma/seed/index.ts
+++ b/prisma/seed/index.ts
@@ -2,7 +2,18 @@ import { signPassword } from '@/services/auth'
 import { reCreateBegesRules } from '@/services/exportRules/beges'
 import { getEmissionFactorsFromAPI } from '@/services/importEmissionFactor/baseEmpreinte/getEmissionFactorsFromAPI'
 import { faker } from '@faker-js/faker'
-import { EmissionFactorStatus, Import, Level, PrismaClient, Role, StudyRole, SubPost, Unit, User } from '@prisma/client'
+import {
+  EmissionFactorStatus,
+  Import,
+  Level,
+  PrismaClient,
+  Role,
+  StudyRole,
+  SubPost,
+  Unit,
+  User,
+  UserStatus,
+} from '@prisma/client'
 import { Command } from 'commander'
 import { ACTUALITIES } from '../legacy_data/actualities'
 import { createRealStudy } from './study'
@@ -115,8 +126,7 @@ const users = async () => {
       password: onboardingPassword,
       level: Level.Initial,
       role: Role.DEFAULT,
-      isActive: true,
-      isValidated: true,
+      status: UserStatus.ACTIVE,
     },
   })
 
@@ -127,8 +137,7 @@ const users = async () => {
       lastName: faker.person.lastName(),
       organizationId: unOnboardedOrganization.id,
       role: Role.GESTIONNAIRE,
-      isActive: false,
-      isValidated: false,
+      status: UserStatus.IMPORTED,
     },
   })
 
@@ -150,8 +159,7 @@ const users = async () => {
       organizationId: clientLessOrganization.id,
       password: clientLessPassword,
       role: Role.DEFAULT,
-      isActive: true,
-      isValidated: true,
+      status: UserStatus.ACTIVE,
     },
   })
 
@@ -172,8 +180,7 @@ const users = async () => {
       lastName: faker.person.lastName(),
       organizationId: organizations[0].id,
       role: Role.GESTIONNAIRE,
-      isActive: false,
-      isValidated: false,
+      status: UserStatus.IMPORTED,
     },
   })
 
@@ -216,8 +223,7 @@ const users = async () => {
             password,
             level: levels[index % levels.length] as Level,
             role: role as Role,
-            isActive: true,
-            isValidated: true,
+            status: UserStatus.ACTIVE,
           }
         }),
         ...Array.from({ length: 3 }).map(async (_, index) => {
@@ -230,8 +236,7 @@ const users = async () => {
             password,
             level: levels[index % levels.length] as Level,
             role: role as Role,
-            isActive: true,
-            isValidated: true,
+            status: UserStatus.ACTIVE,
           }
         }),
       ]),
@@ -245,8 +250,7 @@ const users = async () => {
           password,
           level: levels[index % levels.length] as Level,
           role: Role.DEFAULT,
-          isActive: false,
-          isValidated: false,
+          status: UserStatus.IMPORTED,
         }
       }),
     ]),
@@ -261,8 +265,7 @@ const users = async () => {
         level: Level.Initial,
         organizationId: organizations[0].id,
         role: Role.DEFAULT,
-        isActive: true,
-        isValidated: true,
+        status: UserStatus.ACTIVE,
       },
       {
         email: 'untrained@yopmail.com',
@@ -272,8 +275,7 @@ const users = async () => {
         level: Level.Initial,
         organizationId: regularOrganizations[1].id,
         role: Role.DEFAULT,
-        isActive: true,
-        isValidated: true,
+        status: UserStatus.ACTIVE,
       },
     ],
   })
@@ -288,8 +290,7 @@ const users = async () => {
       lastName: 'ToActivate',
       role: Role.ADMIN,
       level: Level.Initial,
-      isActive: false,
-      isValidated: false,
+      status: UserStatus.IMPORTED,
       organizationId: organizations[0].id,
     },
   })
@@ -297,7 +298,7 @@ const users = async () => {
   const subPosts = Object.keys(SubPost)
   const studies = await Promise.all(
     Array.from({ length: 20 }).map(() => {
-      const creator = faker.helpers.arrayElement(users.filter((user) => user.isValidated))
+      const creator = faker.helpers.arrayElement(users.filter((user) => user.status === UserStatus.ACTIVE))
       const organizationSites = sites.filter((site) => site.organizationId === creator.organizationId)
       return prisma.study.create({
         include: { sites: true },

--- a/prisma/seed/index.ts
+++ b/prisma/seed/index.ts
@@ -113,7 +113,7 @@ const users = async () => {
       siret: faker.finance.accountNumber(14),
       isCR: false,
       onboarded: false,
-      activatedLicence: false,
+      activatedLicence: true,
     },
   })
   const onboardingPassword = await signPassword('onboarding1234')
@@ -126,7 +126,7 @@ const users = async () => {
       password: onboardingPassword,
       level: Level.Initial,
       role: Role.DEFAULT,
-      status: UserStatus.ACTIVE,
+      status: UserStatus.IMPORTED,
     },
   })
 

--- a/prisma/seed/index.ts
+++ b/prisma/seed/index.ts
@@ -290,6 +290,7 @@ const users = async () => {
       level: Level.Initial,
       isActive: false,
       isValidated: false,
+      organizationId: organizations[0].id,
     },
   })
 

--- a/src/app/(dashboard)/equipe/page.tsx
+++ b/src/app/(dashboard)/equipe/page.tsx
@@ -14,6 +14,7 @@ const Team = async ({ user }: UserProps) => {
     getUserFromUserOrganization(user),
     getOrganizationById(user.organizationId),
   ])
+
   return <TeamPage user={user} team={team} crOrga={organization?.isCR} />
 }
 

--- a/src/components/auth/ActivationForm.tsx
+++ b/src/components/auth/ActivationForm.tsx
@@ -72,9 +72,6 @@ const ActivationForm = () => {
     }
   }
 
-  if (success) {
-    return <p data-testid="activation-success">{t('success')}</p>
-  }
   return (
     <Form onSubmit={onSubmit} className="grow justify-center">
       <FormControl className={authStyles.form}>

--- a/src/components/auth/ActivationForm.tsx
+++ b/src/components/auth/ActivationForm.tsx
@@ -4,6 +4,7 @@ import { activateEmail } from '@/services/serverFunctions/user'
 import { EmailCommand, EmailCommandValidation } from '@/services/serverFunctions/user.command'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { FormControl } from '@mui/material'
+import classNames from 'classnames'
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
@@ -19,7 +20,7 @@ const contactMail = process.env.NEXT_PUBLIC_ABC_SUPPORT_MAIL
 const ActivationForm = () => {
   const t = useTranslations('activation')
   const [submitting, setSubmitting] = useState(false)
-  const [errorMessage, setErrorMessage] = useState('')
+  const [message, setMessage] = useState('')
   const [success, setSuccess] = useState(false)
 
   const searchParams = useSearchParams()
@@ -51,20 +52,23 @@ const ActivationForm = () => {
   }
 
   const activate = async () => {
-    setErrorMessage('')
+    setMessage('')
     setSubmitting(true)
 
     if (isValid) {
-      const result = await activateEmail(getValues().email)
+      const { error, message } = await activateEmail(getValues().email)
       setSubmitting(false)
-      if (result) {
-        setErrorMessage(result)
+
+      if (error) {
+        setSuccess(false)
+        setMessage(message)
       } else {
         setSuccess(true)
+        setMessage(message)
       }
     } else {
       setSubmitting(false)
-      setErrorMessage('emailRequired')
+      setMessage('emailRequired')
     }
   }
 
@@ -87,9 +91,9 @@ const ActivationForm = () => {
         <LoadingButton data-testid="activation-button" type="submit" loading={submitting} fullWidth>
           {t('validate')}
         </LoadingButton>
-        {errorMessage && (
-          <p className="error" data-testid="activation-form-error">
-            {t.rich(errorMessage, {
+        {message && (
+          <p className={classNames(!success ? 'error' : '')} data-testid="activation-form-error">
+            {t.rich(message, {
               link: (children) => <Link href={`mailto:${contactMail}`}>{children}</Link>,
             })}
           </p>

--- a/src/components/auth/ActivationForm.tsx
+++ b/src/components/auth/ActivationForm.tsx
@@ -89,7 +89,7 @@ const ActivationForm = () => {
           {t('validate')}
         </LoadingButton>
         {message && (
-          <p className={classNames(!success ? 'error' : '')} data-testid="activation-form-error">
+          <p className={classNames(!success ? 'error' : '')} data-testid="activation-form-message">
             {t.rich(message, {
               link: (children) => <Link href={`mailto:${contactMail}`}>{children}</Link>,
             })}

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -122,7 +122,7 @@ const LoginForm = () => {
           </LoadingButton>
         </div>
         {errorMessage && (
-          <p className="error" data-testid="activation-form-error">
+          <p className="error">
             {t.rich(errorMessage, {
               link: (children) => <Link href={`mailto:${contactMail}`}>{children}</Link>,
             })}

--- a/src/components/auth/NewPasswordForm.tsx
+++ b/src/components/auth/NewPasswordForm.tsx
@@ -76,7 +76,7 @@ const NewPasswordForm = () => {
           {t('reset')}
         </LoadingButton>
         {errorMessage && (
-          <p className="error" data-testid="activation-form-error">
+          <p className="error">
             {t.rich(errorMessage, {
               link: (children) => <Link href={`mailto:${contactMail}`}>{children}</Link>,
             })}

--- a/src/components/auth/ResetForm.tsx
+++ b/src/components/auth/ResetForm.tsx
@@ -187,7 +187,7 @@ const ResetForm = ({ user, token }: Props) => {
           {t('reset')}
         </LoadingButton>
         {errorMessage && (
-          <p className="error" data-testid="activation-form-error">
+          <p className="error">
             {t.rich(errorMessage, {
               link: (children) => <Link href={`mailto:${contactMail}`}>{children}</Link>,
             })}

--- a/src/components/onboarding/OnboardingModal.tsx
+++ b/src/components/onboarding/OnboardingModal.tsx
@@ -95,6 +95,7 @@ const OnboardingModal = ({ open, onClose, user, organization }: Props) => {
   return (
     <Dialog
       open={open}
+      data-testid="onboarding-modal"
       aria-labelledby="onboarding-modale-title"
       aria-describedby="onboarding-modale-description"
       classes={{ paper: styles.dialog }}

--- a/src/components/onboarding/OnboardingStep1.tsx
+++ b/src/components/onboarding/OnboardingStep1.tsx
@@ -44,7 +44,9 @@ const OnboardingStep = ({ form, role }: Props) => {
         <div className="mb-2 bold">
           <span>{t('role')}</span>
         </div>
-        <div className={styles.roleLabel}>{tRole(role)}</div>
+        <div data-testid="user-role" className={styles.roleLabel}>
+          {tRole(role)}
+        </div>
         {role === Role.ADMIN ? (
           <p className="mt1">{t('adminDescription')}</p>
         ) : (

--- a/src/components/pages/Team.tsx
+++ b/src/components/pages/Team.tsx
@@ -1,4 +1,5 @@
 import { TeamMember } from '@/db/user'
+import { UserStatus } from '@prisma/client'
 import { User } from 'next-auth'
 import { useTranslations } from 'next-intl'
 import Block from '../base/Block'
@@ -21,9 +22,9 @@ const TeamPage = ({ user, team, crOrga = false }: Props) => {
     <>
       <Breadcrumbs current={tNav('team')} links={[{ label: tNav('home'), link: '/' }]} />
       <Block title={t('title')} as="h1" />
-      <InvitationsToValidate team={team.filter((member) => !member.isValidated)} user={user} />
-      <PendingInvitations team={team.filter((member) => !member.isActive && member.isValidated)} user={user} />
-      <Team team={team.filter((member) => member.isActive)} user={user} crOrga={crOrga} />
+      <InvitationsToValidate team={team.filter((member) => member.status === UserStatus.PENDING_REQUEST)} user={user} />
+      <PendingInvitations team={team.filter((member) => member.status === UserStatus.VALIDATED)} user={user} />
+      <Team team={team.filter((member) => member.status === UserStatus.ACTIVE)} user={user} crOrga={crOrga} />
     </>
   )
 }

--- a/src/components/team/InvitationsToValidate.tsx
+++ b/src/components/team/InvitationsToValidate.tsx
@@ -18,9 +18,9 @@ const InvitationsToValidate = ({ user, team }: Props) => {
 
   return user.role === Role.DEFAULT || team.length === 0 ? null : (
     <Block title={t('toValidate')}>
-      <ul className={classNames(styles.members, 'flex-col')}>
+      <ul data-testid="invitations-to-validate" className={classNames(styles.members, 'flex-col')}>
         {team.map((member) => (
-          <li key={member.email} className={classNames(styles.line, 'align-center')}>
+          <li data-testid="invitation" key={member.email} className={classNames(styles.line, 'align-center')}>
             <p>
               <span className={styles.email}>{member.email}</span>
               <br />

--- a/src/components/team/InvitationsToValidateActions.tsx
+++ b/src/components/team/InvitationsToValidateActions.tsx
@@ -29,6 +29,7 @@ const InvitationsToValidateActions = ({ user, member }: Props) => {
     <div className={classNames(styles.buttons, 'flex')}>
       <SelectRole currentUserEmail={user.email} email={member.email} currentRole={role} level={member.level} />
       <LoadingButton
+        data-testid="validate-invitation"
         aria-label={t('resend')}
         title={t('resend')}
         loading={validating}
@@ -45,6 +46,7 @@ const InvitationsToValidateActions = ({ user, member }: Props) => {
         <CheckIcon />
       </LoadingButton>
       <LoadingButton
+        data-testid="delete-invitation"
         aria-label={t('delete')}
         title={t('delete')}
         loading={deleting}

--- a/src/components/team/NewMemberForm.tsx
+++ b/src/components/team/NewMemberForm.tsx
@@ -6,8 +6,9 @@ import { addMember } from '@/services/serverFunctions/user'
 import { AddMemberCommand, AddMemberCommandValidation } from '@/services/serverFunctions/user.command'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { MenuItem } from '@mui/material'
-import { Level, Role } from '@prisma/client'
+import { Role } from '@prisma/client'
 import { useTranslations } from 'next-intl'
+import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -17,7 +18,6 @@ import { FormSelect } from '../form/Select'
 const NewMemberForm = () => {
   const router = useRouter()
   const t = useTranslations('newMember')
-  const tLevel = useTranslations('level')
   const tRole = useTranslations('role')
 
   const [error, setError] = useState('')
@@ -69,13 +69,6 @@ const NewMemberForm = () => {
         name="email"
         label={t('email')}
       />
-      <FormSelect control={form.control} translation={t} name="level" label={t('level')} data-testid="new-member-level">
-        {Object.keys(Level).map((key) => (
-          <MenuItem key={key} value={key}>
-            {tLevel(key)}
-          </MenuItem>
-        ))}
-      </FormSelect>
       <FormSelect control={form.control} translation={t} name="role" label={t('role')} data-testid="new-member-role">
         {Object.keys(Role)
           .filter((role) => role !== Role.SUPER_ADMIN)
@@ -88,7 +81,13 @@ const NewMemberForm = () => {
       <LoadingButton type="submit" loading={form.formState.isSubmitting} data-testid="new-member-create-button">
         {t('create')}
       </LoadingButton>
-      {error && <p>{error}</p>}
+      {error && (
+        <p className="error">
+          {t.rich(error, {
+            link: (children) => <Link href={`mailto:${process.env.NEXT_PUBLIC_ABC_SUPPORT_MAIL}`}>{children}</Link>,
+          })}
+        </p>
+      )}
     </Form>
   )
 }

--- a/src/db/organization.ts
+++ b/src/db/organization.ts
@@ -1,6 +1,6 @@
 import { UpdateOrganizationCommand } from '@/services/serverFunctions/organization.command'
 import { OnboardingCommand } from '@/services/serverFunctions/user.command'
-import { Prisma, Role } from '@prisma/client'
+import { Prisma, Role, UserStatus } from '@prisma/client'
 import { prismaClient } from './client'
 
 export const getRawOrganizationById = (id: string | null) =>
@@ -13,7 +13,7 @@ export const getOrganizationUsers = (id: string | null) =>
   id
     ? prismaClient.user.findMany({
         select: { email: true, firstName: true, lastName: true, level: true, role: true },
-        where: { organizationId: id, isActive: true },
+        where: { organizationId: id, status: UserStatus.ACTIVE },
         orderBy: { email: 'asc' },
       })
     : []
@@ -68,8 +68,7 @@ export const onboardOrganization = async (
         lastName: '',
         email: collaborator.email || '',
         role: collaborator.role || Role.DEFAULT,
-        isActive: false,
-        isValidated: true,
+        status: UserStatus.VALIDATED,
         organizationId,
       })
     }

--- a/src/db/user.ts
+++ b/src/db/user.ts
@@ -89,12 +89,12 @@ export const getUserFromUserOrganization = (user: User) =>
   prismaClient.user.findMany({ ...findUserInfo(user), orderBy: { email: 'asc' } })
 export type TeamMember = AsyncReturnType<typeof getUserFromUserOrganization>[0]
 
-export const addUser = async (user: Prisma.UserCreateInput & { role?: Exclude<Role, 'SUPER_ADMIN'> }) =>
+export const addUser = (user: Prisma.UserCreateInput & { role?: Exclude<Role, 'SUPER_ADMIN'> }) =>
   prismaClient.user.create({
     data: user,
   })
 
-export const deleteUser = (email: string) =>
+export const deleteUserFromOrga = (email: string) =>
   prismaClient.user.update({
     where: { email },
     data: { status: UserStatus.IMPORTED, organizationId: null },
@@ -124,15 +124,14 @@ export const organizationActiveUsersCount = async (organizationId: string) =>
     where: { organizationId, status: UserStatus.ACTIVE },
   })
 
-export const updateUser = async (
+export const updateUser = (
   userId: string,
-  data: Prisma.UserCreateInput & { role?: Exclude<Role, 'SUPER_ADMIN'> },
-) => {
-  await prismaClient.user.update({
+  data: Partial<Prisma.UserCreateInput & { role: Exclude<Role, 'SUPER_ADMIN'> | undefined }>,
+) =>
+  prismaClient.user.update({
     where: { id: userId },
     data,
   })
-}
 
 export const changeStatus = (userId: string, newStatus: UserStatus) =>
   prismaClient.user.update({ where: { id: userId }, data: { status: newStatus } })

--- a/src/db/user.ts
+++ b/src/db/user.ts
@@ -85,9 +85,13 @@ export const getUserOrganizations = async (email: string) => {
 
 export type OrganizationWithSites = AsyncReturnType<typeof getUserOrganizations>[0]
 
-export const getUserFromUserOrganization = (user: User) =>
-  prismaClient.user.findMany({ ...findUserInfo(user), orderBy: { email: 'asc' } })
+export const getUserFromUserOrganization = (user: User) => {
+  return prismaClient.user.findMany({ ...findUserInfo(user), orderBy: { email: 'asc' } })
+}
 export type TeamMember = AsyncReturnType<typeof getUserFromUserOrganization>[0]
+
+export const getOnlyActiveUsersForOrganization = (organizationId: string) =>
+  prismaClient.user.findMany({ where: { organizationId, isActive: true, isValidated: true } })
 
 export const addUser = (user: Prisma.UserCreateInput) =>
   prismaClient.user.create({
@@ -117,6 +121,11 @@ export const hasUserToValidateInOrganization = async (organizationId: string | n
         where: { organizationId, isValidated: false },
       })
     : 0
+
+export const hasActiveUserInOrganization = async (organizationId: string) =>
+  prismaClient.user.count({
+    where: { organizationId, isValidated: true },
+  })
 
 export const updateProfile = (userId: string, data: Prisma.UserUpdateInput) =>
   prismaClient.user.update({

--- a/src/db/user.ts
+++ b/src/db/user.ts
@@ -85,11 +85,8 @@ export const getUserOrganizations = async (email: string) => {
 
 export type OrganizationWithSites = AsyncReturnType<typeof getUserOrganizations>[0]
 
-export const getUserFromUserOrganization = async (user: User) => {
-  const test = await prismaClient.user.findMany({ ...findUserInfo(user), orderBy: { email: 'asc' } })
-  console.log(test)
-  return test
-}
+export const getUserFromUserOrganization = async (user: User) =>
+  prismaClient.user.findMany({ ...findUserInfo(user), orderBy: { email: 'asc' } })
 export type TeamMember = AsyncReturnType<typeof getUserFromUserOrganization>[0]
 
 export const getOnlyActiveUsersForOrganization = (organizationId: string) =>
@@ -153,12 +150,11 @@ export const updateUserApplicationSettings = (userId: string, data: Prisma.UserA
     data,
   })
 
-export const linkUserToOrganization = (user: Prisma.UserCreateInput) => {
+export const linkUserToOrganization = async (user: Prisma.UserCreateInput) => {
   if (user.role === Role.SUPER_ADMIN) {
     throw Error('Cannot create a super admin')
   }
-
-  prismaClient.user.update({
+  await prismaClient.user.update({
     where: { email: user.email },
     data: user,
   })

--- a/src/db/user.ts
+++ b/src/db/user.ts
@@ -89,15 +89,10 @@ export const getUserFromUserOrganization = (user: User) =>
   prismaClient.user.findMany({ ...findUserInfo(user), orderBy: { email: 'asc' } })
 export type TeamMember = AsyncReturnType<typeof getUserFromUserOrganization>[0]
 
-export const addUser = async (user: Prisma.UserCreateInput) => {
-  if (user.role === Role.SUPER_ADMIN) {
-    throw Error('Cannot create a super admin')
-  }
-
-  return prismaClient.user.create({
+export const addUser = async (user: Prisma.UserCreateInput & { role?: Exclude<Role, 'SUPER_ADMIN'> }) =>
+  prismaClient.user.create({
     data: user,
   })
-}
 
 export const deleteUser = (email: string) =>
   prismaClient.user.update({
@@ -129,11 +124,10 @@ export const organizationActiveUsersCount = async (organizationId: string) =>
     where: { organizationId, status: UserStatus.ACTIVE },
   })
 
-export const updateUserFromId = async (userId: string, data: Prisma.UserUpdateInput) => {
-  if (data.role && data.role === Role.SUPER_ADMIN) {
-    throw Error('Cannot create a super admin')
-  }
-
+export const updateUser = async (
+  userId: string,
+  data: Prisma.UserCreateInput & { role?: Exclude<Role, 'SUPER_ADMIN'> },
+) => {
   await prismaClient.user.update({
     where: { id: userId },
     data,

--- a/src/db/user.ts
+++ b/src/db/user.ts
@@ -92,12 +92,12 @@ export type TeamMember = AsyncReturnType<typeof getUserFromUserOrganization>[0]
 export const getOnlyActiveUsersForOrganization = (organizationId: string) =>
   prismaClient.user.findMany({ where: { organizationId, status: UserStatus.ACTIVE } })
 
-export const addUser = (user: Prisma.UserCreateInput) => {
+export const addUser = async (user: Prisma.UserCreateInput) => {
   if (user.role === Role.SUPER_ADMIN) {
     throw Error('Cannot create a super admin')
   }
 
-  prismaClient.user.create({
+  return prismaClient.user.create({
     data: user,
   })
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -151,8 +151,8 @@
     "emailRequired": "Please enter an email",
     "validate": "Validate",
     "Not authorized": "You are not a member or have not completed the training. If you believe this is an error, please contact <link>support</link>.",
-    "success": "You will receive an email to finish your account validation.",
-    "Request sent": "A request has been sent to your colleagues"
+    "Request sent": "A request has been sent to your colleagues",
+    "Email sent": "You will receive an email to finish your account validation."
   },
   "navigation": {
     "factors": "Emission factors",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -151,7 +151,8 @@
     "emailRequired": "Please enter an email",
     "validate": "Validate",
     "Not authorized": "You are not a member or have not completed the training. If you believe this is an error, please contact <link>support</link>.",
-    "success": "You will receive an email to finish your account validation."
+    "success": "You will receive an email to finish your account validation.",
+    "request sent": "A request has been sent to your colleagues"
   },
   "navigation": {
     "factors": "Emission factors",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -152,7 +152,7 @@
     "validate": "Validate",
     "Not authorized": "You are not a member or have not completed the training. If you believe this is an error, please contact <link>support</link>.",
     "success": "You will receive an email to finish your account validation.",
-    "request sent": "A request has been sent to your colleagues"
+    "Request sent": "A request has been sent to your colleagues"
   },
   "navigation": {
     "factors": "Emission factors",
@@ -698,6 +698,7 @@
     "role": "Rights",
     "level": "Training",
     "create": "Invite User",
+    "Not authorized": "User invitation not authorized. Please contact <link>the support</link> for more information.",
     "validation": {
       "email": "Please enter a valid email",
       "firstName": "Please enter a first name",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -166,7 +166,7 @@
     "transition": "Transition BC+",
     "logout": "Se déconnecter",
     "methodology": "Méthodologie",
-    "organizations": "Mes bilans carbone",
+    "organizations": "Mes Bilans Carbone®",
     "settings": "Paramètres",
     "team": "Mon équipe",
     "information": "Informations générales"

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -151,7 +151,7 @@
     "emailRequired": "Veuillez entrer un email",
     "validate": "Valider",
     "Not authorized": "Vous n'êtes pas adhérent ou pas formé. Si vous pensez qu'il s'agit d'une erreur, merci de contacter le <link>support</link>.",
-    "request sent": "Une demande d'activation de votre compte a été envoyé à vos collègues",
+    "Request sent": "Une demande d'activation de votre compte a été envoyé à vos collègues",
     "success": "Vous allez recevoir un mail pour finaliser l'activation de votre compte."
   },
   "navigation": {
@@ -698,6 +698,7 @@
     "role": "Droits",
     "level": "Formation",
     "create": "Inviter l'utilisateur",
+    "Not authorized": "Impossible d'inviter cette utilisateur. Veuillez contacter le <link>support</link> pour plus d'informations.",
     "validation": {
       "email": "Veuillez renseigner un email valide",
       "firstName": "Veuillez renseigner un prénom",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -152,7 +152,7 @@
     "validate": "Valider",
     "Not authorized": "Vous n'êtes pas adhérent ou pas formé. Si vous pensez qu'il s'agit d'une erreur, merci de contacter le <link>support</link>.",
     "Request sent": "Une demande d'activation de votre compte a été envoyé à vos collègues",
-    "success": "Vous allez recevoir un mail pour finaliser l'activation de votre compte."
+    "Email sent": "Vous allez recevoir un mail pour finaliser l'activation de votre compte."
   },
   "navigation": {
     "factors": "Facteurs d'émission",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -151,6 +151,7 @@
     "emailRequired": "Veuillez entrer un email",
     "validate": "Valider",
     "Not authorized": "Vous n'êtes pas adhérent ou pas formé. Si vous pensez qu'il s'agit d'une erreur, merci de contacter le <link>support</link>.",
+    "request sent": "Une demande d'activation de votre compte a été envoyé à vos collègues",
     "success": "Vous allez recevoir un mail pour finaliser l'activation de votre compte."
   },
   "navigation": {

--- a/src/scripts/ftp/importUsers.ts
+++ b/src/scripts/ftp/importUsers.ts
@@ -1,4 +1,4 @@
-import { Level, Prisma, Role } from '@prisma/client'
+import { Level, Prisma, Role, UserStatus } from '@prisma/client'
 import { AccessOptions, Client } from 'basic-ftp'
 import dotenv from 'dotenv'
 import fs from 'fs'
@@ -52,8 +52,7 @@ const processUser = async (value: Record<string, string>, importedFileDate: Date
     firstName,
     lastName,
     role: Role.DEFAULT,
-    isActive: false,
-    isValidated: false,
+    status: UserStatus.IMPORTED,
     importedFileDate,
   }
 

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,5 +1,5 @@
 import { getUserByEmail, getUserByEmailWithSensibleInformations } from '@/db/user'
-import { Level, Role } from '@prisma/client'
+import { Level, Role, UserStatus } from '@prisma/client'
 import bcrypt from 'bcryptjs'
 import { GetServerSidePropsContext, NextApiRequest, NextApiResponse } from 'next'
 import { getServerSession, NextAuthOptions } from 'next-auth'
@@ -79,7 +79,7 @@ export const authOptions: NextAuthOptions = {
           return null
         }
         const user = await getUserByEmailWithSensibleInformations(credentials.email)
-        if (!user || !user.password || !user.isValidated) {
+        if (!user || !user.password || user.status !== UserStatus.ACTIVE) {
           return null
         }
 

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -78,6 +78,7 @@ export const authOptions: NextAuthOptions = {
         if (!credentials) {
           return null
         }
+
         const user = await getUserByEmailWithSensibleInformations(credentials.email)
         if (!user || !user.password || user.status !== UserStatus.ACTIVE) {
           return null

--- a/src/services/email/email.ts
+++ b/src/services/email/email.ts
@@ -57,6 +57,15 @@ export const sendActivationEmail = async (toEmail: string, token: string, fromRe
   return send([toEmail], 'Vous avez activé votre compte sur le BC+', html)
 }
 
+export const sendActivationRequest = async (toEmailList: string[], emailToActivate: string, userToActivate: string) => {
+  const html = await getHtml('activation-request', {
+    support: process.env.NEXT_PUBLIC_ABC_SUPPORT_MAIL,
+    emailToActivate,
+    userToActivate,
+  })
+  return send(toEmailList, "Demande d'accès à votre organisation BC+", html)
+}
+
 export const sendUserOnStudyInvitationEmail = async (
   toEmail: string,
   studyName: string,

--- a/src/services/email/views/activation-request.ejs
+++ b/src/services/email/views/activation-request.ejs
@@ -1,0 +1,25 @@
+<html>
+  <%- include('./partials/style'); %>
+  <body>
+    <div>
+      <p>Bonjour,</p>
+      <br />
+      <p>
+        Vous avez une demande d'accès au compte BC+ de votre organisation de la part de <span><%= userToActivate %></span> (mail: <span><%= emailToActivate %></span>). 
+        Vous pouvez retrouver les demandes d'accès dans votre compte dans la page "Mon organisation > Mon équipe".
+        En acceptant sa demande d'accès, vous lui définirez un rôle sur votre organisation.
+        Il aura alors accès suivant son rôle aux informations et actions correspondantes de votre compte. 
+        Si vous refusez, il n'aura pas accès au compte de votre organisation.
+      </p>
+      <p>
+        En cas de question vous pouvez consulter
+        <a href="https://association-pour-la-transition-1.gitbook.io/bc+">notre FAQ</a> ou nous envoyer un email à
+        <a href="mailto:<%= support %>"><%= support %></a>.
+      </p>
+      <br />
+      <p>Bonne journée,</p>
+      <p>Cordialement,</p>
+      <p>L'équipe BC+</p>
+    </div>
+  </body>
+</html>

--- a/src/services/permissions/check.ts
+++ b/src/services/permissions/check.ts
@@ -1,2 +1,2 @@
 export const NOT_AUTHORIZED = 'Not authorized'
-export const REQUEST_SENT = 'request sent'
+export const REQUEST_SENT = 'Request sent'

--- a/src/services/permissions/check.ts
+++ b/src/services/permissions/check.ts
@@ -1,1 +1,2 @@
 export const NOT_AUTHORIZED = 'Not authorized'
+export const REQUEST_SENT = 'request sent'

--- a/src/services/permissions/check.ts
+++ b/src/services/permissions/check.ts
@@ -1,2 +1,3 @@
 export const NOT_AUTHORIZED = 'Not authorized'
 export const REQUEST_SENT = 'Request sent'
+export const EMAIL_SENT = 'Email sent'

--- a/src/services/permissions/user.ts
+++ b/src/services/permissions/user.ts
@@ -1,4 +1,4 @@
-import { User as DbUser, Prisma, Role } from '@prisma/client'
+import { User as DbUser, Prisma, Role, UserStatus } from '@prisma/client'
 import { User } from 'next-auth'
 
 export const isAdmin = (userRole: Role) => userRole === Role.ADMIN || userRole === Role.SUPER_ADMIN
@@ -11,13 +11,12 @@ export const findUserInfo = (user: User) =>
       lastName: true,
       role: user.role !== Role.DEFAULT,
       level: true,
-      isActive: true,
-      isValidated: true,
+      status: true,
       updatedAt: true,
     },
     where:
       user.role === Role.DEFAULT
-        ? { isActive: true, isValidated: true, organizationId: user.organizationId }
+        ? { status: UserStatus.ACTIVE, organizationId: user.organizationId }
         : { organizationId: user.organizationId },
   }) satisfies Prisma.UserFindManyArgs
 
@@ -53,7 +52,7 @@ export const canDeleteMember = (user: User, member: DbUser | null) => {
     return false
   }
 
-  if (member.isValidated && (member.isActive || member.password)) {
+  if (member.status === UserStatus.ACTIVE) {
     return false
   }
 

--- a/src/services/permissions/user.ts
+++ b/src/services/permissions/user.ts
@@ -9,7 +9,7 @@ export const findUserInfo = (user: User) =>
       email: true,
       firstName: true,
       lastName: true,
-      role: user.role !== Role.DEFAULT,
+      role: true,
       level: true,
       status: true,
       updatedAt: true,

--- a/src/services/serverFunctions/study.ts
+++ b/src/services/serverFunctions/study.ts
@@ -30,6 +30,7 @@ import {
   Role,
   StudyRole,
   SubPost,
+  UserStatus,
 } from '@prisma/client'
 import { User } from 'next-auth'
 import { getTranslations } from 'next-intl/server'
@@ -310,13 +311,14 @@ const getOrCreateUserAndSendStudyInvite = async (
   if (!existingUser) {
     const newUser = await addUser({
       email: email,
-      isActive: true,
-      isValidated: true,
+      status: UserStatus.VALIDATED,
       role: Role.DEFAULT,
       firstName: '',
       lastName: '',
     })
+
     await sendInvitation(email, study, organization, creator, role ? t(role).toLowerCase() : '')
+
     userId = newUser.id
   } else {
     if (existingUser.organizationId !== organization.id) {

--- a/src/services/serverFunctions/user.command.ts
+++ b/src/services/serverFunctions/user.command.ts
@@ -1,4 +1,4 @@
-import { Level, Role, SiteCAUnit } from '@prisma/client'
+import { Role, SiteCAUnit } from '@prisma/client'
 import z from 'zod'
 
 export const AddMemberCommandValidation = z.object({
@@ -20,7 +20,6 @@ export const AddMemberCommandValidation = z.object({
     })
     .trim()
     .min(1, 'lastName'),
-  level: z.nativeEnum(Level, { required_error: 'level' }),
   role: z.nativeEnum(Role, { required_error: 'role' }),
 })
 

--- a/src/services/serverFunctions/user.ts
+++ b/src/services/serverFunctions/user.ts
@@ -256,7 +256,7 @@ export const activateEmail = async (email: string, fromReset: boolean = false) =
     await validateUser(email)
     await sendActivation(email, fromReset)
 
-    return { error: true, message: EMAIL_SENT }
+    return { error: false, message: EMAIL_SENT }
   }
 }
 

--- a/src/services/serverFunctions/user.ts
+++ b/src/services/serverFunctions/user.ts
@@ -12,7 +12,7 @@ import {
   getUserFromUserOrganization,
   organizationActiveUsersCount,
   updateUserApplicationSettings,
-  updateUserFromId,
+  updateUser,
   updateUserResetTokenForEmail,
   validateUser,
 } from '@/db/user'
@@ -140,7 +140,7 @@ export const addMember = async (member: AddMemberCommand) => {
       role: memberExists.level ? memberExists.role : Role.DEFAULT,
       organizationId: session.user.organizationId,
     }
-    await updateUserFromId(memberExists.id, updateMember)
+    await updateUser(memberExists.id, updateMember)
   }
 
   await sendNewUser(member.email, session.user, member.firstName)
@@ -206,7 +206,8 @@ export const updateUserProfile = async (command: EditProfileCommand) => {
   if (!session || !session.user) {
     return NOT_AUTHORIZED
   }
-  await updateUserFromId(session.user.id, command)
+
+  await updateUser(session.user.id, command)
 }
 
 export const resetPassword = async (email: string) => {

--- a/src/services/serverFunctions/user.ts
+++ b/src/services/serverFunctions/user.ts
@@ -138,6 +138,7 @@ export const addMember = async (member: AddMemberCommand) => {
       ...member,
       status: UserStatus.VALIDATED,
       level: memberExists.level ? memberExists.level : null,
+      role: memberExists.level ? memberExists.role : Role.DEFAULT,
       organizationId: session.user.organizationId,
     }
     await linkUserToOrganization(updateMember)

--- a/src/services/serverFunctions/user.ts
+++ b/src/services/serverFunctions/user.ts
@@ -129,7 +129,10 @@ export const addMember = async (member: AddMemberCommand) => {
     }
     await addUser(newMember)
   } else {
-    if (memberExists.status === UserStatus.ACTIVE || memberExists.organizationId !== session.user.organizationId) {
+    if (
+      memberExists.status === UserStatus.ACTIVE ||
+      (memberExists.organizationId && memberExists.organizationId !== session.user.organizationId)
+    ) {
       return NOT_AUTHORIZED
     }
 

--- a/src/services/serverFunctions/user.ts
+++ b/src/services/serverFunctions/user.ts
@@ -130,10 +130,7 @@ export const addMember = async (member: AddMemberCommand) => {
     }
     await addUser(newMember)
   } else {
-    if (
-      memberExists.status === UserStatus.ACTIVE ||
-      (memberExists.organizationId && memberExists.organizationId !== session.user.organizationId)
-    ) {
+    if (memberExists.status === UserStatus.ACTIVE && memberExists.organizationId) {
       return NOT_AUTHORIZED
     }
 

--- a/src/services/serverFunctions/user.ts
+++ b/src/services/serverFunctions/user.ts
@@ -6,7 +6,7 @@ import {
   addUser,
   changeStatus,
   changeUserRole,
-  deleteUser,
+  deleteUserFromOrga,
   getUserApplicationSettings,
   getUserByEmail,
   getUserFromUserOrganization,
@@ -109,7 +109,7 @@ export const sendActivation = async (email: string, fromReset: boolean) => {
 
 export const addMember = async (member: AddMemberCommand) => {
   const session = await auth()
-  if (!session || !session.user || !session.user.organizationId) {
+  if (!session || !session.user || !session.user.organizationId || member.role === Role.SUPER_ADMIN) {
     return NOT_AUTHORIZED
   }
 
@@ -118,6 +118,10 @@ export const addMember = async (member: AddMemberCommand) => {
   }
 
   const memberExists = await getUserByEmail(member.email)
+
+  if (memberExists?.role === Role.SUPER_ADMIN) {
+    return NOT_AUTHORIZED
+  }
 
   if (!memberExists) {
     const newMember = {
@@ -185,7 +189,7 @@ export const deleteMember = async (email: string) => {
   if (!canDeleteMember(session.user, userToRemove)) {
     return NOT_AUTHORIZED
   }
-  await deleteUser(email)
+  await deleteUserFromOrga(email)
 }
 
 export const changeRole = async (email: string, role: Role) => {

--- a/src/services/serverFunctions/user.ts
+++ b/src/services/serverFunctions/user.ts
@@ -11,8 +11,8 @@ import {
   getUserByEmail,
   getUserFromUserOrganization,
   organizationActiveUsersCount,
-  updateUserApplicationSettings,
   updateUser,
+  updateUserApplicationSettings,
   updateUserResetTokenForEmail,
   validateUser,
 } from '@/db/user'

--- a/src/tests/end-to-end/app/auth.cy.ts
+++ b/src/tests/end-to-end/app/auth.cy.ts
@@ -112,7 +112,7 @@ describe('Authentication', () => {
     cy.url().should('not.include', '/login')
   })
 
-  it('does not authorize unactive user', () => {
+  it('does not authorize inactive user', () => {
     cy.visit('/')
     cy.url().should('include', '/login')
 
@@ -132,8 +132,8 @@ describe('Authentication', () => {
     cy.visit('/')
     cy.url().should('include', '/login')
 
-    cy.get('[data-testid="input-email"] > .MuiInputBase-root > .MuiInputBase-input').type('onboarding@yopmail.com')
-    cy.get('[data-testid="input-password"] > .MuiInputBase-root > .MuiInputBase-input').type('onboarding1234')
+    cy.get('[data-testid="input-email"] > .MuiInputBase-root > .MuiInputBase-input').type('imported@yopmail.com')
+    cy.get('[data-testid="input-password"] > .MuiInputBase-root > .MuiInputBase-input').type('Password-0')
     cy.getByTestId('login-button').click()
 
     cy.wait('@login')
@@ -148,7 +148,7 @@ describe('Authentication', () => {
     cy.getByTestId('activation-email').should('be.visible')
     cy.getByTestId('activation-button').should('be.visible')
 
-    cy.getByTestId('activation-email').type('onboarding@yopmail.co')
+    cy.getByTestId('activation-email').type('imported@yopmail.co')
     cy.getByTestId('activation-form-message').should('not.exist')
     cy.getByTestId('activation-button').click()
 
@@ -163,6 +163,36 @@ describe('Authentication', () => {
     cy.wait('@activate')
 
     cy.getByTestId('activation-form-message').should('exist')
+    cy.getByTestId('activation-form-message')
+      .invoke('text')
+      .should('include', "Une demande d'activation de votre compte a été envoyé à vos collègues")
+
+    cy.visit('http://localhost:1080')
+    cy.origin('http://localhost:1080', () => {
+      cy.get('.email-item-link')
+        .first()
+        .within(() => {
+          cy.get('.title')
+            .invoke('text')
+            .should('match', /Demande d'accès à votre organisation BC+/)
+        })
+    })
+
+    cy.visit('/')
+    cy.login('bc-admin-0@yopmail.com', 'password-0')
+    cy.wait('@login')
+    cy.visit('/equipe')
+    cy.getByTestId('invitations-to-validate').should('be.visible')
+    cy.getByTestId('invitations-to-validate').within(() => {
+      cy.getByTestId('invitation')
+        .filter((_index, el) => Cypress.$(el).text().includes('imported@yopmail.com'))
+        .getByTestId('validate-invitation')
+        .click()
+    })
+
+    cy.getByTestId('pending-invitation').contains('imported@yopmail.com').should('be.visible')
+
+    cy.logout()
 
     cy.visit('http://localhost:1080')
     cy.origin('http://localhost:1080', () => {
@@ -180,16 +210,17 @@ describe('Authentication', () => {
         })
     })
 
-    cy.get('[data-testid="input-email"] > .MuiInputBase-root > .MuiInputBase-input').type('onboarding@yopmail.com')
-    cy.get('[data-testid="input-password"] > .MuiInputBase-root > .MuiInputBase-input').type('Password-1')
-    cy.get('[data-testid="input-confirm-password"] > .MuiInputBase-root > .MuiInputBase-input').type('Password-1')
+    cy.get('[data-testid="input-email"] > .MuiInputBase-root > .MuiInputBase-input').type('imported@yopmail.com')
+    cy.get('[data-testid="input-password"] > .MuiInputBase-root > .MuiInputBase-input').type('Password-0')
+    cy.get('[data-testid="input-confirm-password"] > .MuiInputBase-root > .MuiInputBase-input').type('Password-0')
 
     cy.getByTestId('reset-button').click()
+
     cy.wait('@reset-password')
     cy.url().should('include', '/login')
 
-    cy.get('[data-testid="input-email"] > .MuiInputBase-root > .MuiInputBase-input').type('onboarding@yopmail.com')
-    cy.get('[data-testid="input-password"] > .MuiInputBase-root > .MuiInputBase-input').type('Password-1')
+    cy.get('[data-testid="input-email"] > .MuiInputBase-root > .MuiInputBase-input').type('imported@yopmail.com')
+    cy.get('[data-testid="input-password"] > .MuiInputBase-root > .MuiInputBase-input').type('Password-0')
     cy.getByTestId('login-button').click()
 
     cy.wait('@login')

--- a/src/tests/end-to-end/app/auth.cy.ts
+++ b/src/tests/end-to-end/app/auth.cy.ts
@@ -132,8 +132,8 @@ describe('Authentication', () => {
     cy.visit('/')
     cy.url().should('include', '/login')
 
-    cy.get('[data-testid="input-email"] > .MuiInputBase-root > .MuiInputBase-input').type('to-activate@yopmail.com')
-    cy.get('[data-testid="input-password"] > .MuiInputBase-root > .MuiInputBase-input').type('password-1')
+    cy.get('[data-testid="input-email"] > .MuiInputBase-root > .MuiInputBase-input').type('onboarding@yopmail.com')
+    cy.get('[data-testid="input-password"] > .MuiInputBase-root > .MuiInputBase-input').type('onboarding1234')
     cy.getByTestId('login-button').click()
 
     cy.wait('@login')
@@ -148,18 +148,21 @@ describe('Authentication', () => {
     cy.getByTestId('activation-email').should('be.visible')
     cy.getByTestId('activation-button').should('be.visible')
 
-    cy.getByTestId('activation-email').type('to-activate@yopmail.co')
-    cy.getByTestId('activation-form-error').should('not.exist')
-    cy.getByTestId('activation-button').click()
-    cy.getByTestId('activation-form-error').should('be.visible')
-
-    cy.getByTestId('activation-email').type('m')
+    cy.getByTestId('activation-email').type('onboarding@yopmail.co')
     cy.getByTestId('activation-form-message').should('not.exist')
     cy.getByTestId('activation-button').click()
 
     cy.wait('@activate')
 
+    cy.getByTestId('activation-form-message').should('be.visible')
+
+    cy.getByTestId('activation-email').type('m')
+    cy.getByTestId('activation-button').click()
     cy.getByTestId('activation-form-message').should('not.exist')
+
+    cy.wait('@activate')
+
+    cy.getByTestId('activation-form-message').should('exist')
 
     cy.visit('http://localhost:1080')
     cy.origin('http://localhost:1080', () => {
@@ -177,7 +180,7 @@ describe('Authentication', () => {
         })
     })
 
-    cy.get('[data-testid="input-email"] > .MuiInputBase-root > .MuiInputBase-input').type('to-activate@yopmail.com')
+    cy.get('[data-testid="input-email"] > .MuiInputBase-root > .MuiInputBase-input').type('onboarding@yopmail.com')
     cy.get('[data-testid="input-password"] > .MuiInputBase-root > .MuiInputBase-input').type('Password-1')
     cy.get('[data-testid="input-confirm-password"] > .MuiInputBase-root > .MuiInputBase-input').type('Password-1')
 
@@ -185,7 +188,7 @@ describe('Authentication', () => {
     cy.wait('@reset-password')
     cy.url().should('include', '/login')
 
-    cy.get('[data-testid="input-email"] > .MuiInputBase-root > .MuiInputBase-input').type('to-activate@yopmail.com')
+    cy.get('[data-testid="input-email"] > .MuiInputBase-root > .MuiInputBase-input').type('onboarding@yopmail.com')
     cy.get('[data-testid="input-password"] > .MuiInputBase-root > .MuiInputBase-input').type('Password-1')
     cy.getByTestId('login-button').click()
 

--- a/src/tests/end-to-end/app/auth.cy.ts
+++ b/src/tests/end-to-end/app/auth.cy.ts
@@ -154,15 +154,12 @@ describe('Authentication', () => {
     cy.getByTestId('activation-form-error').should('be.visible')
 
     cy.getByTestId('activation-email').type('m')
-    cy.getByTestId('activation-success').should('not.exist')
+    cy.getByTestId('activation-form-message').should('not.exist')
     cy.getByTestId('activation-button').click()
 
     cy.wait('@activate')
 
-    cy.getByTestId('activation-success').should('be.visible')
-    cy.getByTestId('activation-email').should('not.exist')
-    cy.getByTestId('activation-button').should('not.exist')
-    cy.getByTestId('activation-form-error').should('not.exist')
+    cy.getByTestId('activation-form-message').should('not.exist')
 
     cy.visit('http://localhost:1080')
     cy.origin('http://localhost:1080', () => {

--- a/src/tests/end-to-end/app/onboarding.cy.ts
+++ b/src/tests/end-to-end/app/onboarding.cy.ts
@@ -1,0 +1,120 @@
+describe('Authentication', () => {
+  beforeEach(() => {
+    cy.exec('npx prisma db seed')
+    cy.intercept('POST', '/api/auth/callback/credentials').as('login')
+  })
+
+  it('trained user has ADMIN role after onboarding', () => {
+    cy.visit('/')
+
+    cy.get('[data-testid="input-email"] > .MuiInputBase-root > .MuiInputBase-input').type('onboarding@yopmail.com')
+    cy.get('[data-testid="input-password"] > .MuiInputBase-root > .MuiInputBase-input').type('onboarding1234')
+    cy.getByTestId('login-button').click()
+
+    cy.wait('@login')
+
+    cy.visit('/activation')
+
+    cy.getByTestId('activation-email').type('onboarding@yopmail.com')
+    cy.getByTestId('activation-button').click()
+
+    cy.getByTestId('activation-form-message').should('exist')
+    cy.getByTestId('activation-form-message')
+      .invoke('text')
+      .should('include', "Vous allez recevoir un mail pour finaliser l'activation de votre compte.")
+
+    cy.visit('http://localhost:1080')
+    cy.origin('http://localhost:1080', () => {
+      cy.get('.email-item-link')
+        .first()
+        .invoke('attr', 'href')
+        .then((link) => {
+          const hmtlUrl = `http://localhost:1080${(link as string).replace('#/', '/')}/html`
+          cy.visit(hmtlUrl)
+          cy.url().should('include', hmtlUrl)
+
+          cy.get('a')
+            .invoke('attr', 'href')
+            .then((link) => cy.visit(link as string))
+        })
+    })
+
+    cy.get('[data-testid="input-email"] > .MuiInputBase-root > .MuiInputBase-input').type('onboarding@yopmail.com')
+    cy.get('[data-testid="input-password"] > .MuiInputBase-root > .MuiInputBase-input').type('Password-0')
+    cy.get('[data-testid="input-confirm-password"] > .MuiInputBase-root > .MuiInputBase-input').type('Password-0')
+    cy.getByTestId('reset-button').click()
+
+    cy.url().should('include', '/login')
+
+    cy.get('[data-testid="input-email"] > .MuiInputBase-root > .MuiInputBase-input').type('onboarding@yopmail.com')
+    cy.get('[data-testid="input-password"] > .MuiInputBase-root > .MuiInputBase-input').type('Password-0')
+    cy.getByTestId('login-button').click()
+
+    cy.wait('@login')
+
+    cy.getByTestId('onboarding-modal').should('be.visible')
+    cy.getByTestId('user-role').scrollIntoView()
+    cy.getByTestId('user-role').should('be.visible')
+    cy.getByTestId('user-role').should('have.text', 'Administrateur')
+  })
+
+  it('untraiend user has GESTIONNAIRE role after onboarding', () => {
+    cy.visit('/')
+
+    cy.get('[data-testid="input-email"] > .MuiInputBase-root > .MuiInputBase-input').type(
+      'onboardingnottrained@yopmail.com',
+    )
+    cy.get('[data-testid="input-password"] > .MuiInputBase-root > .MuiInputBase-input').type('onboarding1234')
+    cy.getByTestId('login-button').click()
+
+    cy.wait('@login')
+
+    cy.visit('/activation')
+
+    cy.getByTestId('activation-email').type('onboardingnottrained@yopmail.com')
+    cy.getByTestId('activation-button').click()
+
+    cy.getByTestId('activation-form-message').should('exist')
+    cy.getByTestId('activation-form-message')
+      .invoke('text')
+      .should('include', "Vous allez recevoir un mail pour finaliser l'activation de votre compte.")
+
+    cy.visit('http://localhost:1080')
+    cy.origin('http://localhost:1080', () => {
+      cy.get('.email-item-link')
+        .first()
+        .invoke('attr', 'href')
+        .then((link) => {
+          const hmtlUrl = `http://localhost:1080${(link as string).replace('#/', '/')}/html`
+          cy.visit(hmtlUrl)
+          cy.url().should('include', hmtlUrl)
+
+          cy.get('a')
+            .invoke('attr', 'href')
+            .then((link) => cy.visit(link as string))
+        })
+    })
+
+    cy.get('[data-testid="input-email"] > .MuiInputBase-root > .MuiInputBase-input').type(
+      'onboardingnottrained@yopmail.com',
+    )
+    cy.get('[data-testid="input-password"] > .MuiInputBase-root > .MuiInputBase-input').type('Password-0')
+    cy.get('[data-testid="input-confirm-password"] > .MuiInputBase-root > .MuiInputBase-input').type('Password-0')
+    cy.getByTestId('reset-button').click()
+
+    cy.url().should('include', '/login')
+
+    cy.get('[data-testid="input-email"] > .MuiInputBase-root > .MuiInputBase-input').type(
+      'onboardingnottrained@yopmail.com',
+    )
+    cy.get('[data-testid="input-password"] > .MuiInputBase-root > .MuiInputBase-input').type('Password-0')
+    cy.getByTestId('login-button').click()
+
+    cy.wait('@login')
+
+    cy.getByTestId('onboarding-modal').should('be.visible')
+    cy.getByTestId('user-role').scrollIntoView()
+    cy.getByTestId('user-role').should('be.visible')
+    cy.getByTestId('user-role').should('have.text', 'Gestionnaire')
+  })
+})

--- a/src/tests/end-to-end/app/team.cy.ts
+++ b/src/tests/end-to-end/app/team.cy.ts
@@ -58,8 +58,6 @@ describe('Team', () => {
     cy.getByTestId('new-member-firstName').type('User')
     cy.getByTestId('new-member-lastName').type('Test')
     cy.getByTestId('new-member-email').type('user-test-1@test.fr')
-    cy.getByTestId('new-member-level').click()
-    cy.get('[data-value="Initial"]').click()
     cy.getByTestId('new-member-role').click()
     cy.get('[data-value="GESTIONNAIRE"]').click()
 

--- a/src/tests/utils/models.ts
+++ b/src/tests/utils/models.ts
@@ -1,4 +1,4 @@
-import { Level, Prisma, Role } from '@prisma/client'
+import { Level, Prisma, Role, UserStatus } from '@prisma/client'
 import { User } from 'next-auth'
 
 export const mockedUserId = 'mocked-user-id'
@@ -17,8 +17,7 @@ const mockedDbUser = {
   ...mockedUser,
   createdAt: '2025-01-01T00:00:00.000Z',
   updatedAt: '2025-01-01T00:00:00.000Z',
-  isActive: true,
-  isValidated: true,
+  status: UserStatus.ACTIVE,
 }
 const mockedStudy = {
   name: 'Mocked Study',


### PR DESCRIPTION
#386 
J'ai essayé de faire au mieux au niveau du fonctionnement mais je pense qu'il y a encore quelques choses étranges. Je veux bien que cette PR soit testée et pas uniquement relu au vue de sa criticité. 


Fait dans ce ticket : 
- Ne pas activer directement le compte de quelqu'un si l'organisation a déjà un utilisateur actif
- Ajout du status dans l'utilisateur 
- Suppression du champs niveau de formation dans le formulaire d'ajout d'utilisateur
- Autres gestions d'activation/ajout d'utilisateur