### PR TITLE
fix typo

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -424,7 +424,7 @@
     },
     "flow": {
       "loading": "Loading document...",
-      "add": "Add a flow",
+      "add": "Add a flow mapping",
       "documentNotFound": "Document not found",
       "download": "Download flow",
       "flows": "Flows mapping",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -424,7 +424,7 @@
     },
     "flow": {
       "loading": "Chargement du document...",
-      "add": "Ajouter un flux",
+      "add": "Ajouter une cartographie des flux",
       "documentNotFound": "Document non trouvé",
       "download": "Télécharger le flux",
       "flows": "Cartographies des flux",


### PR DESCRIPTION
#566 (cf https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/566#issuecomment-2677750542)

On laisse de côté la partie placeholder sur l'ajout site (ils sont présents mais cachés par la valeur par défaut)