### PR TITLE
Fix/658 admin roles on study

### DIFF
--- a/src/components/pages/NewStudyRight.tsx
+++ b/src/components/pages/NewStudyRight.tsx
@@ -1,5 +1,6 @@
 import { getOrganizationUsers } from '@/db/organization'
 import { FullStudy } from '@/db/study'
+import { isAdmin } from '@/services/permissions/user'
 import { getUserRoleOnStudy } from '@/utils/study'
 import { User } from 'next-auth'
 import { getTranslations } from 'next-intl/server'
@@ -24,7 +25,10 @@ const NewStudyRightPage = async ({ study, user }: Props) => {
   }
 
   const existingUsers = study.allowedUsers.map((allowedUser) => allowedUser.user.email)
-  const filteredUsers = users.filter((user) => !existingUsers.includes(user.email))
+  const filteredUsers = users
+    .filter((user) => !existingUsers.includes(user.email))
+    .filter((user) => !isAdmin(user.role))
+
   return (
     <>
       <Breadcrumbs

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -315,7 +315,9 @@
       "Validator_description": "Has full rights over the study and can validate the emission sources entered by validators, editors and contributors.",
       "Editor_description": "Has all rights to the study except for validation of emission sources.",
       "Reader_description": "Can only read the study and export its information.",
-      "close": "Close"
+      "close": "Close",
+      "Not authorized": "You are not allowed to do this action",
+      "saved": "New role saved"
     },
     "title": "Study",
     "rights": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -315,7 +315,9 @@
       "Validator_description": "A tous les droits sur l'étude et peut valider les sources d'émission qui ont été renseignées par les validateurs, éditeurs et contributeurs.",
       "Editor_description": "A tous les droits sur l'étude à l'exception de la validation des sources d'émission.",
       "Reader_description": "Peut uniquement accéder en lecture à l'étude et exporter les informations de celle-ci.",
-      "close": "Fermer"
+      "close": "Fermer",
+      "Not authorized": "Vous n'avez pas les droits pour effectuer cette action",
+      "saved": "Nouveau rôle sauvegardé"
     },
     "title": "Étude",
     "rights": {

--- a/src/services/permissions/study.ts
+++ b/src/services/permissions/study.ts
@@ -1,17 +1,16 @@
 import { getDocumentById } from '@/db/document'
 import { FullStudy, getStudyById } from '@/db/study'
 import { getUserByEmail, getUserByEmailWithAllowedStudies, UserWithAllowedStudies } from '@/db/user'
+import { isAdminOnOrga } from '@/utils/onganization'
 import { getUserRoleOnStudy } from '@/utils/study'
 import { User as DbUser, Level, Prisma, Study, StudyRole } from '@prisma/client'
 import { User } from 'next-auth'
 import { auth } from '../auth'
 import { checkLevel } from '../study'
 import { checkOrganization } from './organization'
-import { isAdmin } from './user'
 
 export const isAdminOnStudyOrga = (user: User, study: Pick<FullStudy, 'organizationId' | 'organization'>) =>
-  (user.organizationId === study.organizationId || user.organizationId === study.organization.parentId) &&
-  isAdmin(user.role)
+  isAdminOnOrga(user, study.organization)
 
 export const canReadStudy = async (user: User | UserWithAllowedStudies, studyId: string) => {
   if (!user) {

--- a/src/services/serverFunctions/study.ts
+++ b/src/services/serverFunctions/study.ts
@@ -37,7 +37,6 @@ import { getTranslations } from 'next-intl/server'
 import { auth } from '../auth'
 import { allowedFlowFileTypes, isAllowedFileType } from '../file'
 import { ALREADY_IN_STUDY, NOT_AUTHORIZED } from '../permissions/check'
-import { checkOrganization } from '../permissions/organization'
 import {
   canAccessFlowFromStudy,
   canAddContributorOnStudy,
@@ -49,6 +48,7 @@ import {
   canChangeSites,
   canCreateStudy,
   canDeleteStudy,
+  isAdminOnStudyOrga,
 } from '../permissions/study'
 import { isAdmin } from '../permissions/user'
 import { subPostsByPost } from '../posts'
@@ -359,11 +359,7 @@ export const newStudyRight = async (right: NewStudyRightCommand) => {
     return NOT_AUTHORIZED
   }
 
-  if (
-    existingUser &&
-    isAdmin(existingUser.role) &&
-    (await checkOrganization(existingUser.organizationId, studyWithRights.organizationId))
-  ) {
+  if (existingUser && isAdminOnStudyOrga(existingUser, studyWithRights)) {
     right.role = StudyRole.Validator
   }
 
@@ -409,12 +405,7 @@ export const changeStudyRole = async (studyId: string, email: string, studyRole:
     return NOT_AUTHORIZED
   }
 
-  if (
-    existingUser &&
-    isAdmin(existingUser.role) &&
-    (await checkOrganization(existingUser.organizationId, studyWithRights.organizationId)) &&
-    studyRole !== StudyRole.Validator
-  ) {
+  if (existingUser && isAdminOnStudyOrga(existingUser, studyWithRights) && studyRole !== StudyRole.Validator) {
     return NOT_AUTHORIZED
   }
 

--- a/src/utils/study.ts
+++ b/src/utils/study.ts
@@ -9,11 +9,16 @@ export const getUserRoleOnStudy = async (user: User, study: FullStudy) => {
   if (isAdminOnStudyOrga(user, study)) {
     return StudyRole.Validator
   }
+
+  const right = study.allowedUsers.find((right) => right.user.email === user.email)
+  if (right) {
+    return right.role
+  }
+
   if (study.isPublic && (await checkOrganization(user.organizationId, study.organizationId))) {
     return user.role === Role.DEFAULT ? StudyRole.Editor : StudyRole.Reader
   }
-  const right = study.allowedUsers.find((right) => right.user.email === user.email)
-  return right ? right.role : null
+  return null
 }
 
 export const colors: Record<string, { dark: string; light: string }> = {


### PR DESCRIPTION
#658 

- Les admins de l'entreprise ne peuvent pas être ajoutées dans la vue cadrage/ajouter d'une étude (ne concerne pas la création)
- Si un admin est ajouté manuellement, alors un check est réalisé pour forcer le rôle à Validateur
- On ne peut changer le rôle d'un admin pour autre chose que Validateur
- Ajout d'un toaster, comme pour le rôle dans l'organisation
- Fix de la récupération du rôle : On check d'abord si l'utilisateur à un rôle enregistré dans l'étude. Autrement, les collaborateurs et gestionnaires ont le rôle par défaut sur les études (editeur et lecteur) plutot que le rôle qui leur a été attribué manuellement