### PR TITLE
fix onboarding for user not in orga

### DIFF
--- a/src/services/serverFunctions/organization.ts
+++ b/src/services/serverFunctions/organization.ts
@@ -95,7 +95,9 @@ export const onboardOrganizationCommand = async (command: OnboardingCommand) => 
     const existingUser = await getUserByEmail(collaborator.email || '')
     if (existingUser) {
       collaborators = collaborators.filter((commandCollaborator) => commandCollaborator.email !== collaborator.email)
-      existingCollaborators.push(existingUser)
+      if (existingUser.organizationId === organizationId) {
+        existingCollaborators.push(existingUser)
+      }
     }
   }
 


### PR DESCRIPTION
Si l'utilisateur n'était pas dans l'orga ca le mettait en validated alors que du coup il faut qu'il ne soit pas pris en compte. 

Bug pas hyper grave car ne l'ajoute pas à l'orga mais le met en validé donc pas fou (et cas peu probable en +)