### PR TITLE
fix: quick fix ui icon edit study name + new props block for addition…

### DIFF
--- a/src/components/base/Block.tsx
+++ b/src/components/base/Block.tsx
@@ -25,6 +25,7 @@ export interface Props {
   ['data-testid']?: string
   description?: ReactNode
   actions?: Action[]
+  className?: string
 }
 
 const Block = ({
@@ -38,6 +39,7 @@ const Block = ({
   description,
   actions,
   expIcon,
+  className,
   ...rest
 }: Props) => {
   const Title = as === 'h1' ? 'h1' : 'h2'
@@ -54,7 +56,7 @@ const Block = ({
 
   return (
     <div className={classNames('main-container', styles.block)} {...rest}>
-      <div className={styles.content}>
+      <div className={classNames(styles.content, className)}>
         {actions ? (
           <div className={classNames(styles.header, 'align-center justify-between')}>
             {titleDiv}

--- a/src/components/study/rights/StudyParams.module.css
+++ b/src/components/study/rights/StudyParams.module.css
@@ -1,3 +1,7 @@
 .iconButton {
-  background-color: white !important;
+  background-color: var(--primary-40) !important;
+}
+
+.blockStudyParams {
+  width: fit-content;
 }

--- a/src/components/study/rights/StudyParams.tsx
+++ b/src/components/study/rights/StudyParams.tsx
@@ -40,7 +40,7 @@ const StudyParams = ({ user, study, disabled }: Props) => {
               className: styles.iconButton,
               'aria-label': t('edit'),
               title: t('edit'),
-              children: <EditIcon color="info" />,
+              children: <EditIcon />,
               onClick: () => setEditTitle(true),
             },
           ],
@@ -84,7 +84,7 @@ const StudyParams = ({ user, study, disabled }: Props) => {
 
   return (
     <>
-      <Block title={t('title', { name: study.name })} as="h1" actions={actions}>
+      <Block title={t('title', { name: study.name })} as="h1" actions={actions} className={styles.blockStudyParams}>
         <StudyLevel study={study} user={user} disabled={disabled} />
         <StudyPublicStatus study={study} user={user} disabled={disabled} />
       </Block>


### PR DESCRIPTION
https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/651

quick fix ui icon edit study name + new props block for additionnal props

![image](https://github.com/user-attachments/assets/6a8fe45c-c257-459f-87e9-23737e7b9b6b)
