### PR TITLE
Cut/feat/761 specific translation

### DIFF
--- a/src/i18n/fr-cut.json
+++ b/src/i18n/fr-cut.json
@@ -1,0 +1,17 @@
+{
+  "organization": {
+    "sites": {
+      "title": "Les cinemas de l'organisation concernés par l'étude",
+      "noSites": "Il n'y a pas de cinemas configurés sur l'organisation",
+      "name": "Nom",
+      "namePlaceholder": "Nom du cinema",
+      "etp": "Nombre d'Équivalents Temps Plein",
+      "etpPlaceholder": "Entrez votre nombre d'ETP pour ce cinema ici",
+      "ca": "Chiffre d'affaire ({unit})",
+      "caPlaceholder": "Entrez votre CA pour ce cinema en {unit} ici",
+      "actions": "Actions",
+      "delete": "Supprimer",
+      "add": "Ajouter un cinema"
+    }
+  }
+}

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,13 +1,33 @@
+import { mergeObjects } from '@/utils/object'
+import fs from 'fs'
 import { getRequestConfig } from 'next-intl/server'
+import path from 'path'
 import { getLocale } from './locale'
 
 export default getRequestConfig(async () => {
   // Provide a static locale, fetch a user setting,
   // read from `cookies()`, `headers()`, etc.
   const locale = await getLocale()
+  const baseMessages = (await import(`./${locale}.json`)).default
+
+  const tag = '' // ex tag='cut' TODO CUT: get tag dynamically
+  if (!tag) {
+    return {
+      locale,
+      messages: baseMessages,
+    }
+  }
+
+  const overrideFilePath = path.join(process.cwd(), 'src/i18n', `${locale}-${tag}.json`)
+  let overrideMessages = {}
+  if (fs.existsSync(overrideFilePath)) {
+    overrideMessages = JSON.parse(fs.readFileSync(overrideFilePath, 'utf-8'))
+  } else {
+    console.log(`No translation files at: ${overrideFilePath}`)
+  }
 
   return {
     locale,
-    messages: (await import(`./${locale}.json`)).default,
+    messages: mergeObjects({}, baseMessages, overrideMessages),
   }
 })

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -1,0 +1,32 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isObject(item: any): boolean {
+  return item && typeof item === 'object' && !Array.isArray(item)
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function mergeObjects<T extends Record<string, any>>(target: T, ...sources: Partial<T>[]): T {
+  if (!sources.length) {
+    return target
+  }
+
+  for (const source of sources) {
+    if (!isObject(source)) {
+      continue
+    }
+
+    for (const key in source) {
+      if (isObject(source[key])) {
+        if (!target[key] || !isObject(target[key])) {
+          target[key] = {} as T[Extract<keyof T, string>]
+        }
+        mergeObjects(target[key] as T[Extract<keyof T, string>], source[key] as Partial<T[Extract<keyof T, string>]>)
+      } else {
+        if (source[key] !== undefined) {
+          target[key] = source[key]
+        }
+      }
+    }
+  }
+
+  return target
+}


### PR DESCRIPTION
https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/761

- adding lodash + lodash types
- overriding translation for specific tags + example cut file

j'ai été obligé d'importer le fichier avec fs.readFileSync car sinon il y a une erreur à la compilation lorsqu'il n'existe pas et je pense que c'est mieux de traiter les cas ou ils n'existent pas (par ex en-cut) et les ignorer plutot que de forcer à créer des fichiers mais dites moi ce que vous en pensez ou si vous avez d'autres suggestions !

Je pense qu'on remplira le fichier fr-cut au fil des avancées si ça vous semble bien et j'ai laissé la façon de récupérer le tag en TODO car actuellement on ne l'a pas encore