### PR TITLE
add fake emission source import to fix migration

### DIFF
--- a/prisma/seed/study.ts
+++ b/prisma/seed/study.ts
@@ -24,6 +24,20 @@ export const createRealStudy = async (prisma: PrismaClient, creator: User) => {
   }
 
   await getEmissionFactorsFromCSV('test', './prisma/seed/Base_Carbone_Test.csv')
+  await prisma.emissionFactorImportVersion.createMany({
+    data: [
+      {
+        internId: 'Legifrance_Test.csv',
+        name: 'test',
+        source: Import.Legifrance,
+      },
+      {
+        internId: 'Negaoctet_Test.csv',
+        name: 'test',
+        source: Import.NegaOctet,
+      },
+    ],
+  })
 
   await prisma.site.create({
     data: {


### PR DESCRIPTION
Le déploiement de la migration `20250306130357_add_studies_emission_factor_versions_to_studies` pose problème sur la seed car il n'existe pas d'import pour les sources NegaOctet et Legifrance. Ce fix règle le problème sur la seed.

Reproduction : 
- checkout  sur la branche old_master
- prisma migrate reset
- checkout develop
- migrate deploy -> error

Correction : 
- checkout  sur la branche old_master
- prisma migrate reset
- checkout branche
- db seed

Le problème est censé être corrigé car il y aura toujours une version pour les 2 imports, qu'importe le nombre de seed que l'on fait