### PR TITLE
bug/755 removing flex-end for better icon alignement with methodo button

### DIFF
--- a/src/components/organizationCard/OrganizationCard.tsx
+++ b/src/components/organizationCard/OrganizationCard.tsx
@@ -89,7 +89,7 @@ const OrganizationCard = ({ user, organizations }: Props) => {
         </div>
         <div>
           <LinkButton
-            className="align-end"
+            className="align-center"
             color="secondary"
             target="_blank"
             rel="noreferrer noopener"

--- a/src/css/globals.css
+++ b/src/css/globals.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.cdnfonts.com/css/gilroy-bold');
-
 * {
   font-family: 'gilroy-regular', sans-serif !important;
 }

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.cdnfonts.com/css/gilroy-bold');
 @import './reset.css';
 @import './variables.css';
 @import './globals.css';


### PR DESCRIPTION
https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/755

Dans la foulée J'ai aussi résolu le problème en prod avec les différences de style notamment sur les h1 ! En fait je pense que le fait de charger la font dans global faisait recharger le reset.css donc je l'ai mis avant tous les imports si ça vous va