### PR TITLE
fix dompurify import usage

### DIFF
--- a/prisma/legacy_data/actualities.ts
+++ b/prisma/legacy_data/actualities.ts
@@ -60,7 +60,7 @@ export const ACTUALITIES = [
     updatedAt: new Date('2023-08-31 12:00:00.000'),
   },
   {
-    title: 'BC+ Version <b>Windows</b> en cours de ravallement',
+    title: 'BC+ Version Windows en cours de ravallement',
     text: "La version <b>Windows</b> du BC+ est en cours de 'ravallement' pour avoir un aspect similaire à la version Web. Pendant les travaux l'application continue de fonctionner, mais certaines fenêtres pourront avoir un aspect modifié.",
     createdAt: new Date('2023-10-28 12:00:00.000'),
     updatedAt: new Date('2023-10-28 12:00:00.000'),

--- a/src/components/actuality/Actuality.tsx
+++ b/src/components/actuality/Actuality.tsx
@@ -4,7 +4,7 @@ import { Actuality } from '@prisma/client'
 import classNames from 'classnames'
 import DOMPurify from 'dompurify'
 import { useFormatter, useTranslations } from 'next-intl'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import Box from '../base/Box'
 import Button from '../base/Button'
 import styles from './styles.module.css'
@@ -17,11 +17,16 @@ const ActualityRow = ({ actuality }: Props) => {
   const format = useFormatter()
   const t = useTranslations('actuality')
   const [expanded, setExpanded] = useState(false)
+  const [cleanText, setCleanText] = useState('')
   const maxLength = 200
 
   const displayText = expanded
     ? actuality.text
     : `${actuality.text.slice(0, maxLength)}${actuality.text.length > maxLength ? '...' : ''}`
+
+  useEffect(() => {
+    setCleanText(DOMPurify.sanitize(displayText))
+  }, [displayText])
 
   return (
     <li data-testid="actuality" className="flex-col">
@@ -34,7 +39,7 @@ const ActualityRow = ({ actuality }: Props) => {
             day: 'numeric',
           })}
         </p>
-        <p className={styles.text} dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(displayText) }} />
+        <p className={styles.text} dangerouslySetInnerHTML={{ __html: cleanText }} />
 
         {actuality.text.length > maxLength && (
           <div className="mt1">


### PR DESCRIPTION
Fix suite à une erreur détectée avec l'utilisation de DOMPurify : 
![image](https://github.com/user-attachments/assets/6432198a-3ce9-4415-81ef-8219cf2921bf)

Solution trouvée ici (je n'ai pas réussi à sécuriser les données à l'enregistrement. Dans tous les cas, je pense que c'est une bonne chose de faire un nettoyage côté front) : https://www.reddit.com/r/nextjs/comments/kty9vi/comment/giptplq/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button