### PR TITLE
fix getCachedDefaultEmissionFactors function for study

### DIFF
--- a/src/db/emissionFactors.ts
+++ b/src/db/emissionFactors.ts
@@ -63,7 +63,10 @@ const getDefaultEmissionFactors = (versionIds?: string[]) =>
 const filterVersionedEmissionFactor = (
   emissionFactor: AsyncReturnType<typeof getDefaultEmissionFactors>[0],
   versionIds?: string[],
-) => !versionIds || (emissionFactor.versionId && versionIds.includes(emissionFactor.versionId))
+) =>
+  !versionIds ||
+  !emissionFactor.version ||
+  (emissionFactor.version.id && versionIds.includes(emissionFactor.version.id))
 
 const getCachedDefaultEmissionFactors = async (versionIds?: string[]) => {
   if (cachedEmissionFactors.length) {


### PR DESCRIPTION
#822 

Le problème venait du fait que l'on ne récupère pas versionId des FE, et donc on ne peut pas filtrer sur versionId, mais il est possible de le faire sur version.id

Pour reproduire le bug en local, il faut simplement ne pas avoir de NO_CACHE=true dans son .env