### PR TITLE
Fix/861 demo

### DIFF
--- a/src/components/study/EmissionSource.module.css
+++ b/src/components/study/EmissionSource.module.css
@@ -102,7 +102,7 @@
   gap: 1rem;
 }
 
-.caracterisationSource {
+.optionnalFields {
   flex: 2 !important;
 }
 

--- a/src/components/study/EmissionSourceForm.tsx
+++ b/src/components/study/EmissionSourceForm.tsx
@@ -246,6 +246,25 @@ const EmissionSourceForm = ({
             <HelpIcon className="ml1" onClick={() => setGlossary('type')} label={tGlossary('title')} />
           </div>
         </FormControl>
+        {caracterisations.length > 0 && mandatoryCaracterisation && (
+          <FormControl className="grow">
+            <InputLabel id="emission-source-caracterisation-label">{`${t('form.caracterisation')} *`}</InputLabel>
+            <Select
+              disabled={!canEdit || caracterisations.length === 1}
+              value={emissionSource.caracterisation || ''}
+              data-testid="emission-source-caracterisation"
+              onChange={(event) => update('caracterisation', event.target.value)}
+              labelId="emission-source-caracterisation-label"
+              label={`${t('form.caracterisation')} *`}
+            >
+              {caracterisations.map((categorisation) => (
+                <MenuItem key={categorisation} value={categorisation}>
+                  {tCategorisations(categorisation)}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        )}
       </div>
       {selectedFactor ? (
         <div className={styles.row} data-testid="emission-source-factor">
@@ -270,26 +289,7 @@ const EmissionSourceForm = ({
 
       <p className={classNames(styles.subTitle, 'mt1 mb-2')}>{t('optionalFields')}</p>
       <div className={classNames(styles.row, 'flex', expandedQuality || !canShrink ? 'flex-col' : '')}>
-        <div className={classNames(styles.gapped, styles.caracterisationSource, 'flex')}>
-          {caracterisations.length > 0 && (
-            <FormControl className="grow">
-              <InputLabel id="emission-source-caracterisation-label">{`${t('form.caracterisation')}${mandatoryCaracterisation ? ' *' : ''}`}</InputLabel>
-              <Select
-                disabled={!canEdit || caracterisations.length === 1}
-                value={emissionSource.caracterisation || ''}
-                data-testid="emission-source-caracterisation"
-                onChange={(event) => update('caracterisation', event.target.value)}
-                labelId="emission-source-caracterisation-label"
-                label={`${t('form.caracterisation')}${mandatoryCaracterisation ? ' *' : ''}`}
-              >
-                {caracterisations.map((categorisation) => (
-                  <MenuItem key={categorisation} value={categorisation}>
-                    {tCategorisations(categorisation)}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          )}
+        <div className={classNames(styles.gapped, styles.optionnalFields, 'flex')}>
           <TextField
             className="grow"
             disabled={!canEdit}
@@ -297,6 +297,14 @@ const EmissionSourceForm = ({
             defaultValue={emissionSource.source}
             onBlur={(event) => update('source', event.target.value)}
             label={t('form.source')}
+          />
+          <TextField
+            className="grow"
+            disabled={!canEdit}
+            data-testid="emission-source-comment"
+            defaultValue={emissionSource.comment}
+            onBlur={(event) => update('comment', event.target.value)}
+            label={t('form.comment')}
           />
         </div>
         <QualitySelectGroup
@@ -309,16 +317,6 @@ const EmissionSourceForm = ({
           setExpanded={setExpandedQuality}
           canShrink={canShrink}
           defaultQuality={defaultQuality}
-        />
-      </div>
-      <div className={classNames(styles.row, 'flex')}>
-        <TextField
-          style={{ flex: 2 }}
-          disabled={!canEdit}
-          data-testid="emission-source-comment"
-          defaultValue={emissionSource.comment}
-          onBlur={(event) => update('comment', event.target.value)}
-          label={t('form.comment')}
         />
       </div>
       <div className={classNames(styles.gapped, 'justify-end mt1 w100')}>

--- a/src/components/study/rights/StudyVersions.module.css
+++ b/src/components/study/rights/StudyVersions.module.css
@@ -1,8 +1,7 @@
 .upgradeButton {
   margin: 0 !important;
-  padding: 0 !important;
+  padding: 0 0.5rem !important;
   min-width: 0 !important;
-  border-radius: 50% !important;
 }
 
 .updatedValue {

--- a/src/components/study/rights/StudyVersions.tsx
+++ b/src/components/study/rights/StudyVersions.tsx
@@ -6,7 +6,6 @@ import {
   simulateStudyEmissionFactorSourceUpgrade,
   upgradeStudyEmissionFactorSource,
 } from '@/services/serverFunctions/study'
-import UpgradeIcon from '@mui/icons-material/Upgrade'
 import { EmissionFactorImportVersion, Import, StudyResultUnit } from '@prisma/client'
 import classNames from 'classnames'
 import { useTranslations } from 'next-intl'
@@ -94,10 +93,9 @@ const StudyVersions = ({ study, emissionFactorSources, canUpdate }: Props) => {
                 <Button
                   className={styles.upgradeButton}
                   onClick={() => simulateSourceUpgrade(source.source)}
-                  aria-label={t('upgradeSource')}
-                  title={t('upgradeSource')}
+                  color="secondary"
                 >
-                  <UpgradeIcon />
+                  {t('upgradeSource')}
                 </Button>
               </div>
             )}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -415,7 +415,7 @@
       },
       "versions": {
         "list": "Study's emission factors versions",
-        "upgradeSource": "Updating emissions factors",
+        "upgradeSource": "Update",
         "Not authorized": "You are not allowed to do this action",
         "latest": "You are already using the latest version of {name}.",
         "title": "Are you sure you want to update the {name} source?",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -415,7 +415,7 @@
       },
       "versions": {
         "list": "Versions des facteurs d'emissions de l'étude",
-        "upgradeSource": "Mettre à jour les facteurs d'émissions",
+        "upgradeSource": "Mettre à jour",
         "Not authorized": "Vous n'avez pas les droits pour effectuer cette action",
         "latest": "Vous utilisez déjà la dernière version de {name}",
         "title": "Êtes vous sûr de vouloir mettre à jour la source {name} ?",


### PR DESCRIPTION
#861 

À bien tester pour le champs caractérisation
- Le champs caractérisation est uniquement affiché dans les champs obligatoire, quand ce dernier est obligatoire (il y a 1 export ou plus, uniquement BEGES aujourd'hui). Il reste désactivé quand il n'y a qu'un seule option (Poste déchet par exemple)
- Les FE sans unités sont traités dans un autre ticket