### PR TITLE
fix: 754 BCPost instead of Post for special cases in BC

### DIFF
--- a/src/components/emissionFactor/Form/MultiplePosts.tsx
+++ b/src/components/emissionFactor/Form/MultiplePosts.tsx
@@ -1,7 +1,7 @@
 import HelpIcon from '@/components/base/HelpIcon'
 import { Select } from '@/components/base/Select'
 import GlossaryModal from '@/components/modals/GlossaryModal'
-import { Post } from '@/services/posts'
+import { BCPost, Post } from '@/services/posts'
 import { EmissionFactorCommand } from '@/services/serverFunctions/emissionFactor.command'
 import { Box, FormControl, FormHelperText, MenuItem, SelectChangeEvent } from '@mui/material'
 import { SubPost } from '@prisma/client'
@@ -33,11 +33,11 @@ const MultiplePosts = <T extends EmissionFactorCommand>({ form }: Props<T>) => {
     form.trigger('subPosts' as FieldPath<T>)
   }, [posts])
 
-  const postSelection: Post[] = useMemo(
+  const postSelection: BCPost[] = useMemo(
     () =>
-      Object.keys(Post)
+      Object.keys(BCPost)
         .sort((a, b) => tPost(a).localeCompare(tPost(b)))
-        .filter((p) => !Object.keys(posts).includes(p)) as Post[],
+        .filter((p) => !Object.keys(posts).includes(p)) as BCPost[],
     [posts],
   )
 

--- a/src/components/emissionFactor/Form/Posts.tsx
+++ b/src/components/emissionFactor/Form/Posts.tsx
@@ -3,7 +3,7 @@
 import Button from '@/components/base/Button'
 import { MultiSelect } from '@/components/base/MultiSelect'
 import { Select } from '@/components/base/Select'
-import { Post, subPostsByPost } from '@/services/posts'
+import { BCPost, Post, subPostsByPost } from '@/services/posts'
 import { EmissionFactorCommand } from '@/services/serverFunctions/emissionFactor.command'
 import { getPost } from '@/utils/post'
 import DeleteIcon from '@mui/icons-material/Delete'
@@ -36,7 +36,7 @@ const Posts = <T extends EmissionFactorCommand>({
 
   const setValue = form.setValue as UseFormSetValue<EmissionFactorCommand>
 
-  const posts = useMemo(() => Object.keys(Post).sort((a, b) => tPost(a).localeCompare(tPost(b))), [tPost])
+  const posts = useMemo(() => Object.keys(BCPost).sort((a, b) => tPost(a).localeCompare(tPost(b))), [tPost])
   const subPosts = useMemo<SubPost[]>(
     () => (post ? subPostsByPost[post].sort((a, b) => tPost(a).localeCompare(tPost(b))) : []),
     [post, tPost],

--- a/src/components/emissionFactor/Table.tsx
+++ b/src/components/emissionFactor/Table.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Post, subPostsByPost } from '@/services/posts'
+import { BCPost, subPostsByPost } from '@/services/posts'
 import { canEditEmissionFactor, EmissionFactorWithMetaData } from '@/services/serverFunctions/emissionFactor'
 import { getEmissionFactorValue } from '@/utils/emissionFactors'
 import { formatNumber } from '@/utils/number'
@@ -420,11 +420,11 @@ const EmissionFactorsTable = ({
         ? tPosts('none')
         : filteredSubPosts.map((subPosts) => tPosts(subPosts)).join(', ')
 
-  const areAllSelected = (post: Post) => !subPostsByPost[post].some((subPost) => !filteredSubPosts.includes(subPost))
+  const areAllSelected = (post: BCPost) => !subPostsByPost[post].some((subPost) => !filteredSubPosts.includes(subPost))
 
   const selectAllSubPosts = () => setFilteredSubPosts(allSelectedSubPosts ? [] : initialSelectedSubPosts)
 
-  const selectPost = (post: Post) => {
+  const selectPost = (post: BCPost) => {
     const newValue = areAllSelected(post)
       ? filteredSubPosts.filter((filteredSubPost) => !subPostsByPost[post].includes(filteredSubPost))
       : filteredSubPosts.concat(subPostsByPost[post].filter((a) => !filteredSubPosts.includes(a)))
@@ -541,7 +541,7 @@ const EmissionFactorsTable = ({
                   <Checkbox checked={allSelectedSubPosts} />
                   <ListItemText primary={tPosts(allSelectedSubPosts ? 'unselectAll' : 'selectAll')} />
                 </MenuItem>
-                {Object.values(Post).map((post) => (
+                {Object.values(BCPost).map((post) => (
                   <div key={`subpostGroup-${post}`}>
                     <MenuItem key={`subpost-${post}`} selected={areAllSelected(post)} onClick={() => selectPost(post)}>
                       <Checkbox checked={areAllSelected(post)} />

--- a/src/components/study/rights/NewStudyContributorForm.tsx
+++ b/src/components/study/rights/NewStudyContributorForm.tsx
@@ -5,7 +5,7 @@ import LoadingButton from '@/components/base/LoadingButton'
 import { FormSelect } from '@/components/form/Select'
 import { FormTextField } from '@/components/form/TextField'
 import { FullStudy } from '@/db/study'
-import { Post, subPostsByPost } from '@/services/posts'
+import { BCPost, subPostsByPost } from '@/services/posts'
 import { newStudyContributor } from '@/services/serverFunctions/study'
 import {
   NewStudyContributorCommand,
@@ -78,7 +78,7 @@ const NewStudyContributorForm = ({ study }: Props) => {
         data-testid="study-contributor-post"
       >
         <MenuItem value="all">{tPost('allPost')}</MenuItem>
-        {Object.keys(Post).map((key) => (
+        {Object.keys(BCPost).map((key) => (
           <MenuItem key={key} value={key}>
             {tPost(key)}
           </MenuItem>


### PR DESCRIPTION
https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/754

Corrections suite à https://github.com/ABC-TransitionBasCarbone/bilan-carbone/pull/870

J'ai laissé au maximum Post pour tout l'aspect logique mais j'ai utilisé BCPost qui contient seulement les posts du BC pour les endroits ou ils étaient affiché (normalement ce sont des endroits exclusif BC pour l'instant à voir si il faut complexifier par la suite)