### PR TITLE
Create default site for user organization

### DIFF
--- a/src/scripts/oldBC/transition/oldBC.ts
+++ b/src/scripts/oldBC/transition/oldBC.ts
@@ -63,6 +63,10 @@ export const uploadOldBCInformations = async (file: string, email: string, organ
     console.log("L'utilisateur n'existe pas ou n'appartient pas à l'organisation spécifiée")
     return
   }
+  const userOrganization = await prismaClient.organization.findUnique({ where: { id: user.organizationId } })
+  if (!userOrganization) {
+    throw new Error(`L'organisation de l'utilisateur n'existe pas.`)
+  }
 
   const workSheetsFromFile = xlsx.parse(file)
 
@@ -93,7 +97,7 @@ export const uploadOldBCInformations = async (file: string, email: string, organ
       transaction,
       organizationsSheet.data,
       organizationsIndexes,
-      organizationId,
+      userOrganization,
     )
     hasEmissionFactorsWarning = await uploadEmissionFactors(
       transaction,


### PR DESCRIPTION
Avant, on ne créait pas ce site par défaut, et donc il y avait des cas où on ne pouvait rajouter ni les études, ni les sites des études, ni les données sources qui y étaient fonctionnellement rattachées.