### PR TITLE
fix: fixing bug export bcposts

### DIFF
--- a/src/components/study/results/AllResults.tsx
+++ b/src/components/study/results/AllResults.tsx
@@ -2,6 +2,7 @@
 import { EmissionFactorWithParts } from '@/db/emissionFactors'
 import { FullStudy } from '@/db/study'
 import { downloadStudyResults } from '@/services/study'
+import { useAppEnvironmentStore } from '@/store/AppEnvironment'
 import DownloadIcon from '@mui/icons-material/Download'
 import { Button, FormControl, InputLabel, MenuItem, Select } from '@mui/material'
 import { ControlMode, Export, ExportRule } from '@prisma/client'
@@ -39,6 +40,8 @@ const AllResults = ({ study, rules, emissionFactorsWithParts, validatedOnly }: P
   const { studySite, setSite } = useStudySite(study, true)
 
   const begesRules = useMemo(() => rules.filter((rule) => rule.export === Export.Beges), [rules])
+
+  const { environment } = useAppEnvironmentStore()
 
   return (
     <>
@@ -84,6 +87,7 @@ const AllResults = ({ study, rules, emissionFactorsWithParts, validatedOnly }: P
               tQuality,
               tBeges,
               tUnits,
+              environment,
             )
           }
         >

--- a/src/services/posts.ts
+++ b/src/services/posts.ts
@@ -1,3 +1,4 @@
+import { BASE, CUT } from '@/store/AppEnvironment'
 import { SubPost } from '@prisma/client'
 
 export enum BCPost {
@@ -98,4 +99,9 @@ export const subPostsByPost: Record<Post, SubPost[]> = {
     SubPost.CommunicationDigitale,
     SubPost.CaissesEtBornes,
   ],
+}
+
+export const environmentPostMapping = {
+  [BASE]: BCPost,
+  [CUT]: CutPost,
 }

--- a/src/services/results/consolidated.ts
+++ b/src/services/results/consolidated.ts
@@ -33,7 +33,7 @@ export const computeResultsByPost = (
   studySite: string,
   withDependencies: boolean,
   validatedOnly: boolean = true,
-  postValues: typeof Post | typeof CutPost | typeof BCPost = Post,
+  postValues: typeof Post | typeof CutPost | typeof BCPost = BCPost,
 ) => {
   const siteEmissionSources = getSiteEmissionSources(study.emissionSources, studySite)
 

--- a/src/services/study.ts
+++ b/src/services/study.ts
@@ -1,5 +1,6 @@
 import { EmissionFactorWithParts } from '@/db/emissionFactors'
 import { FullStudy, getStudyById } from '@/db/study'
+import { BASE, Environment } from '@/store/AppEnvironment'
 import { getEmissionFactorValue } from '@/utils/emissionFactors'
 import { STUDY_UNIT_VALUES } from '@/utils/study'
 import { Export, ExportRule, Level, StudyResultUnit, SubPost } from '@prisma/client'
@@ -8,7 +9,7 @@ import { useTranslations } from 'next-intl'
 import { canBeValidated, getEmissionSourcesTotalCo2, getStandardDeviation } from './emissionSource'
 import { download } from './file'
 import { StudyWithoutDetail } from './permissions/study'
-import { Post, subPostsByPost } from './posts'
+import { environmentPostMapping, Post, subPostsByPost } from './posts'
 import { computeBegesResult } from './results/beges'
 import { computeResultsByPost } from './results/consolidated'
 import { EmissionFactorWithMetaData, getEmissionFactorsByIds } from './serverFunctions/emissionFactor'
@@ -302,11 +303,19 @@ export const formatConsolidatedStudyResultsForExport = (
   tQuality: ReturnType<typeof useTranslations>,
   tUnits: ReturnType<typeof useTranslations>,
   validatedEmissionSourcesOnly?: boolean,
+  environment: Environment = BASE,
 ) => {
   const dataForExport = []
 
   for (const site of siteList) {
-    const resultList = computeResultsByPost(study, tPost, site.id, true, validatedEmissionSourcesOnly)
+    const resultList = computeResultsByPost(
+      study,
+      tPost,
+      site.id,
+      true,
+      validatedEmissionSourcesOnly,
+      environmentPostMapping[environment],
+    )
 
     dataForExport.push([site.name])
     dataForExport.push([tStudy('post'), tStudy('uncertainty'), tStudy('value', { unit: tUnits(study.resultsUnit) })])
@@ -435,6 +444,7 @@ export const downloadStudyResults = async (
   tQuality: ReturnType<typeof useTranslations>,
   tBeges: ReturnType<typeof useTranslations>,
   tUnits: ReturnType<typeof useTranslations>,
+  environment: Environment = BASE,
 ) => {
   const data = []
 
@@ -455,6 +465,7 @@ export const downloadStudyResults = async (
       tQuality,
       tUnits,
       validatedEmissionSourcesOnly,
+      environment,
     ),
   )
 


### PR DESCRIPTION
Fix d'un bug suite à la PR https://github.com/ABC-TransitionBasCarbone/bilan-carbone/pull/870

Par défaut on utilise toujours que les postes BC et on verra côté cut etc... ce qu'on veut utiliser

@cmolle je te laisse check :) 