### PR TITLE
fix add contributor check when user has a default role

### DIFF
--- a/src/services/serverFunctions/study.ts
+++ b/src/services/serverFunctions/study.ts
@@ -598,7 +598,7 @@ export const newStudyContributor = async ({ email, subPosts, ...command }: NewSt
     return NOT_AUTHORIZED
   }
 
-  if (studyWithRights.allowedUsers.some((allowedUser) => allowedUser.user.id === existingUser?.id)) {
+  if (existingUser && getUserRoleOnStudy(existingUser, studyWithRights)) {
     return ALREADY_IN_STUDY
   }
 


### PR DESCRIPTION
#666 (cf https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/666#issuecomment-2827973987)

Question : On n'ajoute pas le contributeur si la personne a déjà accès à l'étude : On vérifie son rôle via la fonction `getUserRoleOnStudy` mais qu'en est-il si la personne a le rôle `Reader` ? En soit, un contributeur a plus de droits d'édition qu'un lecteur