### PR TITLE
add source

### DIFF
--- a/src/services/serverFunctions/user.ts
+++ b/src/services/serverFunctions/user.ts
@@ -126,6 +126,11 @@ export const addMember = async (member: AddMemberCommand) => {
     return NOT_AUTHORIZED
   }
 
+  const userFromDb = await getUserByEmail(session.user.email)
+  if (!userFromDb) {
+    return NOT_AUTHORIZED
+  }
+
   if (!memberExists) {
     const newMember = {
       ...member,
@@ -133,7 +138,9 @@ export const addMember = async (member: AddMemberCommand) => {
       status: UserStatus.VALIDATED,
       level: null,
       organizationId: session.user.organizationId,
+      source: userFromDb.source,
     }
+
     await addUser(newMember)
     addUserChecklistItem(UserChecklist.AddCollaborator)
   } else {


### PR DESCRIPTION
#930 
ajout de la source lors de la création d'un utilisateur. Pour l'instant on met la meme source que l'utilisateur qui créé. A vori plus tard si on veut pas mieux gérer ca. 
Je n'ai pas fait la remise à 0 de la formation car ils n'ont plus accès à la page si ils sont pas de la source CRON