### PR TITLE
fix onbording form when go to previous step with invalid form

### DIFF
--- a/src/components/onboarding/OnboardingModal.tsx
+++ b/src/components/onboarding/OnboardingModal.tsx
@@ -101,10 +101,16 @@ const OnboardingModal = ({ open, onClose, user, organization }: Props) => {
             <Step form={form} role={newRole} isCr={organization.isCR} />
           </DialogContent>
           <DialogActions className="noSpacing">
-            {activeStep > 0 && <Button onClick={goToPreviousStep}>{t('previous')}</Button>}
-            <LoadingButton type="submit" loading={loading}>
-              {t(buttonLabel)}
-            </LoadingButton>
+            {activeStep > 1 && <Button onClick={goToPreviousStep}>{t('previous')}</Button>}
+            {activeStep === stepCount ? (
+              <LoadingButton type="submit" loading={loading}>
+                {t(buttonLabel)}
+              </LoadingButton>
+            ) : (
+              <Button type="button" onClick={onValidate}>
+                {t(buttonLabel)}
+              </Button>
+            )}
           </DialogActions>
         </Form>
       </div>

--- a/src/components/onboarding/OnboardingModal.tsx
+++ b/src/components/onboarding/OnboardingModal.tsx
@@ -35,7 +35,6 @@ const OnboardingModal = ({ open, onClose, user, organization }: Props) => {
   const [loading, setLoading] = useState(false)
   const stepCount = 2
   const Step = activeStep === 1 ? Step1 : Step2
-  const buttonLabel = activeStep === stepCount ? 'validate' : 'next'
 
   const newRole = useMemo(() => (user.level ? Role.ADMIN : Role.GESTIONNAIRE), [user])
 
@@ -52,27 +51,24 @@ const OnboardingModal = ({ open, onClose, user, organization }: Props) => {
     },
   })
 
-  const goToPreviousStep = () => setActiveStep(activeStep > 1 ? activeStep - 1 : 0)
+  const goToPreviousStep = () => setActiveStep(activeStep > 1 ? activeStep - 1 : 1)
+  const goToNextStep = () => setActiveStep(activeStep + 1)
 
   const onValidate = async () => {
-    if (activeStep < stepCount) {
-      setActiveStep(activeStep + 1)
+    setLoading(true)
+    const values = form.getValues()
+    values.collaborators = (values.collaborators || []).filter(
+      (collaborator) => collaborator.email || collaborator.role,
+    )
+    const result = await onboardOrganizationCommand(form.getValues())
+    if (result) {
+      onClose()
     } else {
-      setLoading(true)
-      const values = form.getValues()
-      values.collaborators = (values.collaborators || []).filter(
-        (collaborator) => collaborator.email || collaborator.role,
-      )
-      const result = await onboardOrganizationCommand(form.getValues())
-      if (result) {
-        onClose()
-      } else {
-        await updateSession()
-        onClose()
-        router.refresh()
-      }
-      setLoading(false)
+      await updateSession()
+      onClose()
+      router.refresh()
     }
+    setLoading(false)
   }
 
   return (
@@ -104,11 +100,11 @@ const OnboardingModal = ({ open, onClose, user, organization }: Props) => {
             {activeStep > 1 && <Button onClick={goToPreviousStep}>{t('previous')}</Button>}
             {activeStep === stepCount ? (
               <LoadingButton type="submit" loading={loading}>
-                {t(buttonLabel)}
+                {t('validate')}
               </LoadingButton>
             ) : (
-              <Button type="button" onClick={onValidate}>
-                {t(buttonLabel)}
+              <Button type="button" onClick={goToNextStep}>
+                {t('next')}
               </Button>
             )}
           </DialogActions>


### PR DESCRIPTION
#695

Vu ensemble : on oubli le problème de validation du formulaire (cf https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/695#issuecomment-2857503080). En revanche, ça a mis en évidence 2 autres soucis :
- Le bouton "précédent" est disponible dès l'étape 1
- Si on ajoute un email invalide lors de l'étape 2 et qu'on revient à l'étape 1, on ne peut plus valider pour retourner à l'étape 2