### PR TITLE
Fix/695 onboarding

### DIFF
--- a/src/components/onboarding/OnboardingModal.tsx
+++ b/src/components/onboarding/OnboardingModal.tsx
@@ -71,7 +71,7 @@ const OnboardingModal = ({ open, onClose, user, organization }: Props) => {
     values.collaborators = (values.collaborators || []).filter(
       (collaborator) => collaborator.email || collaborator.role,
     )
-    await onboardOrganizationCommand(form.getValues())
+    await onboardOrganizationCommand(values)
     setLoading(false)
     onCloseModal()
   }

--- a/src/components/onboarding/OnboardingModal.tsx
+++ b/src/components/onboarding/OnboardingModal.tsx
@@ -1,4 +1,5 @@
 import { onboardOrganizationCommand } from '@/services/serverFunctions/organization'
+import { fixUserRoleOnOnboarding } from '@/services/serverFunctions/user'
 import { OnboardingCommand, OnboardingCommandValidation } from '@/services/serverFunctions/user.command'
 import { zodResolver } from '@hookform/resolvers/zod'
 import CloseIcon from '@mui/icons-material/Close'
@@ -9,7 +10,7 @@ import { User } from 'next-auth'
 import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/navigation'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import Button from '../base/Button'
 import Form from '../base/Form'
@@ -38,6 +39,10 @@ const OnboardingModal = ({ open, onClose, user, organization }: Props) => {
 
   const newRole = useMemo(() => (user.level ? Role.ADMIN : Role.GESTIONNAIRE), [user])
 
+  useEffect(() => {
+    fixUserRoleOnOnboarding()
+  }, [])
+
   const form = useForm<OnboardingCommand>({
     resolver: zodResolver(OnboardingCommandValidation),
     mode: 'onSubmit',
@@ -54,21 +59,21 @@ const OnboardingModal = ({ open, onClose, user, organization }: Props) => {
   const goToPreviousStep = () => setActiveStep(activeStep > 1 ? activeStep - 1 : 1)
   const goToNextStep = () => setActiveStep(activeStep + 1)
 
+  const onCloseModal = async () => {
+    await updateSession()
+    onClose()
+    router.refresh()
+  }
+
   const onValidate = async () => {
     setLoading(true)
     const values = form.getValues()
     values.collaborators = (values.collaborators || []).filter(
       (collaborator) => collaborator.email || collaborator.role,
     )
-    const result = await onboardOrganizationCommand(form.getValues())
-    if (result) {
-      onClose()
-    } else {
-      await updateSession()
-      onClose()
-      router.refresh()
-    }
+    await onboardOrganizationCommand(form.getValues())
     setLoading(false)
+    onCloseModal()
   }
 
   return (
@@ -82,7 +87,7 @@ const OnboardingModal = ({ open, onClose, user, organization }: Props) => {
       <div className={styles.container}>
         <Form onSubmit={form.handleSubmit(onValidate)}>
           <div className="justify-end">
-            <MUIButton className={styles.closeIcon} onClick={onClose}>
+            <MUIButton className={styles.closeIcon} onClick={onCloseModal}>
               <CloseIcon />
             </MUIButton>
           </div>

--- a/src/components/onboarding/OnboardingModal.tsx
+++ b/src/components/onboarding/OnboardingModal.tsx
@@ -1,5 +1,5 @@
 import { onboardOrganizationCommand } from '@/services/serverFunctions/organization'
-import { fixUserRoleOnOnboarding } from '@/services/serverFunctions/user'
+import { changeUserRoleOnOnboarding } from '@/services/serverFunctions/user'
 import { OnboardingCommand, OnboardingCommandValidation } from '@/services/serverFunctions/user.command'
 import { zodResolver } from '@hookform/resolvers/zod'
 import CloseIcon from '@mui/icons-material/Close'
@@ -40,7 +40,7 @@ const OnboardingModal = ({ open, onClose, user, organization }: Props) => {
   const newRole = useMemo(() => (user.level ? Role.ADMIN : Role.GESTIONNAIRE), [user])
 
   useEffect(() => {
-    fixUserRoleOnOnboarding()
+    changeUserRoleOnOnboarding()
   }, [])
 
   const form = useForm<OnboardingCommand>({

--- a/src/db/organization.ts
+++ b/src/db/organization.ts
@@ -78,7 +78,6 @@ export const onboardOrganization = async (
   if (!dbUser) {
     return
   }
-  const role = dbUser.level ? Role.ADMIN : Role.GESTIONNAIRE
   const newCollaborators: Pick<User, 'firstName' | 'lastName' | 'email' | 'role' | 'status' | 'organizationId'>[] = []
   for (const collaborator of collaborators) {
     newCollaborators.push({
@@ -99,7 +98,7 @@ export const onboardOrganization = async (
       }),
       transaction.user.update({
         where: { id: userId },
-        data: { firstName, lastName, role },
+        data: { firstName, lastName },
       }),
       transaction.user.createMany({ data: newCollaborators }),
       ...existingCollaborators.map((collaborator) =>

--- a/src/services/serverFunctions/user.ts
+++ b/src/services/serverFunctions/user.ts
@@ -361,3 +361,13 @@ export const verifyPasswordAndProcessUsers = async (uuid: string) => uuid !== pr
 export const getFormationFormStart = async (userId: string) => getUserFormationFormStart(userId)
 
 export const startFormationForm = async (userId: string, date: Date) => startUserFormationForm(userId, date)
+
+export const fixUserRoleOnOnboarding = async () => {
+  const session = await auth()
+  if (!session || !session.user) {
+    return
+  }
+
+  const newRole = session.user.level ? Role.ADMIN : Role.GESTIONNAIRE
+  await changeUserRole(session.user.email, newRole)
+}

--- a/src/services/serverFunctions/user.ts
+++ b/src/services/serverFunctions/user.ts
@@ -362,7 +362,7 @@ export const getFormationFormStart = async (userId: string) => getUserFormationF
 
 export const startFormationForm = async (userId: string, date: Date) => startUserFormationForm(userId, date)
 
-export const fixUserRoleOnOnboarding = async () => {
+export const changeUserRoleOnOnboarding = async () => {
   const session = await auth()
   if (!session || !session.user) {
     return


### PR DESCRIPTION
#695 (cf https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/695#issuecomment-2875270407)

Ajout d'un correctif pour changer le rôle de l'utilisateur dès l'ouverture de la modale d'onboarding pour couvrir le cas où l'utilisateur ferme avant de terminer l'onboarding