### PR TITLE
fix organizationLess contributors access

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -37,12 +37,14 @@ const NavLayout = async ({ children, user: account }: Props & UserSessionProps) 
       <main className={classNames(styles.content, { [styles.withOrganizationCard]: account.organizationVersionId })}>
         {children}
       </main>
-      <ChecklistButton
-        accountOrganizationVersion={accountOrganizationVersion}
-        clientId={clientId}
-        studyId={studyId}
-        userRole={account.role}
-      />
+      {accountOrganizationVersion && (
+        <ChecklistButton
+          accountOrganizationVersion={accountOrganizationVersion}
+          clientId={clientId}
+          studyId={studyId}
+          userRole={account.role}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/study/perimeter/StudyPerimeter.tsx
+++ b/src/components/study/perimeter/StudyPerimeter.tsx
@@ -308,7 +308,7 @@ const StudyPerimeter = ({ study, organizationVersion, userRoleOnStudy, caUnit }:
         showControl={showControl}
         setGlossary={setGlossary}
         t={t}
-        disabled={!hasEditionRights}
+        disabled={!hasEditionRole}
       />
       <DeleteStudySiteModal
         open={open}

--- a/src/utils/organization.ts
+++ b/src/utils/organization.ts
@@ -9,7 +9,9 @@ export const isAdminOnOrga = (account: UserSession, organizationVersion: Organiz
 export const isInOrgaOrParent = (
   userOrganizationVersionId: string | null,
   organizationVersion: OrganizationVersionWithOrganization,
-) => userOrganizationVersionId === organizationVersion.id || userOrganizationVersionId === organizationVersion.parentId
+) =>
+  userOrganizationVersionId &&
+  (userOrganizationVersionId === organizationVersion.id || userOrganizationVersionId === organizationVersion.parentId)
 
 export const hasEditionRole = (isCR: boolean, userRole: Role) =>
   isCR ? userRole !== Role.DEFAULT : isAdmin(userRole) || userRole === Role.GESTIONNAIRE


### PR DESCRIPTION
3 bugs détectés sur master. Un hotfix est en cours de déploiement, mais je répercute les changements sur develop : 
- Un contributeur invité, normalement sans organisation a sa page d'accueil en erreur car le bouton de checklist a besoin de organisationId
- Ce même contributeur a accès aux études avec les droits lecteur car le test canReadStudyDetail n'est pas parfait :
  - Le test `(study.isPublic &&
      isInOrgaOrParent(user.organizationVersionId, study.organizationVersion as OrganizationVersionWithOrganization))` peut passer car user.organizationVersionId est null et dans certains cas, organizationVersion.parentId est null également
- Un utilisateur avec le rôle lecteur a accès aux champs export en édition