### PR TITLE
fix: fixing bad migrations for account/user deployment

### DIFF
--- a/prisma/schema/migrations/20250519130837_create_account_and_organization_version_tables/migration.sql
+++ b/prisma/schema/migrations/20250519130837_create_account_and_organization_version_tables/migration.sql
@@ -2,7 +2,6 @@
   Warnings:
 
   - A unique constraint covering the columns `[account_id]` on the table `user_application_settings` will be added. If there are existing duplicate values, this will fail.
-  - Added the required column `uploader_account_id` to the `documents` table without a default value. This is not possible if the table is not empty.
 
 */
 -- CreateEnum
@@ -27,7 +26,7 @@ ALTER TABLE "contributors" ADD COLUMN     "account_id" TEXT;
 ALTER TABLE "deactivable_features_statuses" ADD COLUMN     "updated_by_account" TEXT;
 
 -- AlterTable
-ALTER TABLE "documents" ADD COLUMN     "uploader_account_id" TEXT NOT NULL,
+ALTER TABLE "documents" ADD COLUMN     "uploader_account_id" TEXT,
 ALTER COLUMN "uploader_id" DROP NOT NULL;
 
 -- AlterTable
@@ -100,7 +99,7 @@ CREATE UNIQUE INDEX "accounts_user_id_organizationVersion_id_key" ON "accounts"(
 CREATE UNIQUE INDEX "user_application_settings_account_id_key" ON "user_application_settings"("account_id");
 
 -- AddForeignKey
-ALTER TABLE "documents" ADD CONSTRAINT "documents_uploader_account_id_fkey" FOREIGN KEY ("uploader_account_id") REFERENCES "accounts"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "documents" ADD CONSTRAINT "documents_uploader_account_id_fkey" FOREIGN KEY ("uploader_account_id") REFERENCES "accounts"("id") ON DELETE SET NULL ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "documents" ADD CONSTRAINT "documents_uploader_id_fkey" FOREIGN KEY ("uploader_id") REFERENCES "users"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema/migrations/20250519134457_remove_old_user_and_organization_field_for_account_and_organization_version_refactor/migration.sql
+++ b/prisma/schema/migrations/20250519134457_remove_old_user_and_organization_field_for_account_and_organization_version_refactor/migration.sql
@@ -23,6 +23,7 @@
   - You are about to drop the column `user_id` on the `users_on_study` table. All the data in the column will be lost.
   - A unique constraint covering the columns `[account_id,step]` on the table `user_checked_steps` will be added. If there are existing duplicate values, this will fail.
   - Made the column `account_id` on table `contributors` required. This step will fail if there are existing NULL values in that column.
+  - Made the column `uploader_account_id` on table `documents` required. This step will fail if there are existing NULL values in that column.
   - Made the column `created_by_account_id` on table `studies` required. This step will fail if there are existing NULL values in that column.
   - Made the column `organizationVersion_id` on table `studies` required. This step will fail if there are existing NULL values in that column.
   - Made the column `account_id` on table `user_checked_steps` required. This step will fail if there are existing NULL values in that column.
@@ -37,6 +38,9 @@ ALTER TABLE "contributors" DROP CONSTRAINT "contributors_user_id_fkey";
 
 -- DropForeignKey
 ALTER TABLE "deactivable_features_statuses" DROP CONSTRAINT "deactivable_features_statuses_updated_by_fkey";
+
+-- DropForeignKey
+ALTER TABLE "documents" DROP CONSTRAINT "documents_uploader_account_id_fkey";
 
 -- DropForeignKey
 ALTER TABLE "documents" DROP CONSTRAINT "documents_uploader_id_fkey";
@@ -90,7 +94,8 @@ ADD CONSTRAINT "contributors_pkey" PRIMARY KEY ("study_id", "account_id", "subPo
 ALTER TABLE "deactivable_features_statuses" DROP COLUMN "updated_by";
 
 -- AlterTable
-ALTER TABLE "documents" DROP COLUMN "uploader_id";
+ALTER TABLE "documents" DROP COLUMN "uploader_id",
+ALTER COLUMN "uploader_account_id" SET NOT NULL;
 
 -- AlterTable
 ALTER TABLE "organizations" DROP COLUMN "activated_licence",
@@ -129,6 +134,9 @@ ADD CONSTRAINT "users_on_study_pkey" PRIMARY KEY ("study_id", "account_id");
 
 -- CreateIndex
 CREATE UNIQUE INDEX "user_checked_steps_account_id_step_key" ON "user_checked_steps"("account_id", "step");
+
+-- AddForeignKey
+ALTER TABLE "documents" ADD CONSTRAINT "documents_uploader_account_id_fkey" FOREIGN KEY ("uploader_account_id") REFERENCES "accounts"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
 -- AddForeignKey
 ALTER TABLE "studies" ADD CONSTRAINT "studies_created_by_account_id_fkey" FOREIGN KEY ("created_by_account_id") REFERENCES "accounts"("id") ON DELETE RESTRICT ON UPDATE CASCADE;


### PR DESCRIPTION
Ca ne change rien en local mais ça permet de fixer une erreur de migrations qu'il y avait avec la branche https://github.com/ABC-TransitionBasCarbone/bilan-carbone/tree/MIGRATE_AND_SCRIPT_BEFORE_ACCOUNT

Il manquait le "?" sur uploader de accountId dans document sur la première PR