### PR TITLE
fix user source on creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bilan-carbone",
-  "version": "2.6.0",
+  "version": "2.6.2",
   "private": true,
   "engines": {
     "node": "22",

--- a/src/db/organization.ts
+++ b/src/db/organization.ts
@@ -78,7 +78,10 @@ export const onboardOrganization = async (
   if (!dbUser) {
     return
   }
-  const newCollaborators: Pick<User, 'firstName' | 'lastName' | 'email' | 'role' | 'status' | 'organizationId'>[] = []
+  const newCollaborators: Pick<
+    User,
+    'firstName' | 'lastName' | 'email' | 'role' | 'status' | 'organizationId' | 'source'
+  >[] = []
   for (const collaborator of collaborators) {
     newCollaborators.push({
       firstName: '',
@@ -86,6 +89,7 @@ export const onboardOrganization = async (
       email: collaborator.email?.toLowerCase() || '',
       role: collaborator.role === Role.ADMIN ? Role.GESTIONNAIRE : (collaborator.role ?? Role.DEFAULT),
       status: UserStatus.VALIDATED,
+      source: dbUser.source,
       organizationId,
     })
   }

--- a/src/services/serverFunctions/study.ts
+++ b/src/services/serverFunctions/study.ts
@@ -37,7 +37,7 @@ import {
   updateStudySites,
   updateUserOnStudy,
 } from '@/db/study'
-import { addUser, getUserApplicationSettings } from '@/db/user'
+import { addUser, getUserApplicationSettings, getUserSourceById } from '@/db/user'
 import { getUserByEmail } from '@/db/userImport'
 import { LocaleType } from '@/i18n/config'
 import { getLocale } from '@/i18n/locale'
@@ -422,6 +422,7 @@ const getOrCreateUserAndSendStudyInvite = async (
 ) => {
   let userId = ''
   const t = await getTranslations('study.role')
+  const creatorDBUser = await getUserSourceById(creator.id)
 
   if (!existingUser) {
     const newUser = await addUser({
@@ -430,6 +431,7 @@ const getOrCreateUserAndSendStudyInvite = async (
       role: Role.COLLABORATOR,
       firstName: '',
       lastName: '',
+      source: creatorDBUser?.source,
     })
 
     await sendInvitation(email, study, organization, creator, role ? t(role).toLowerCase() : '')


### PR DESCRIPTION
Problème de source à la création (CRON par défaut, ne prend pas la valeur du créateur)

Cas OK :
- Création d'utilisateur dans l'équipe
- Import depuis le script d'import manuel

Cas NOK (corrigés) :
- Ajout lors de l'onboarding
- Ajout d'un compte inexistant dans une étude (membre ou contributeur)