### PR TITLE
fix study creation re-rendering

### DIFF
--- a/src/components/study/organization/Select.tsx
+++ b/src/components/study/organization/Select.tsx
@@ -35,19 +35,22 @@ const SelectOrganization = ({ organizationVersions, selectOrganizationVersion, f
   )
 
   useEffect(() => {
-    if (organizationVersion) {
-      form.setValue(
-        'sites',
-        organizationVersion.organization.sites.map((site) => ({
-          ...site,
-          ca: site.ca ? displayCA(site.ca, CA_UNIT_VALUES[caUnit]) : 0,
-          selected: false,
-          postalCode: site.postalCode ?? '',
-          city: site.city ?? '',
-        })),
-      )
-    } else {
+    if (!organizationVersion) {
       form.setValue('sites', [])
+    } else {
+      const newSites = organizationVersion.organization.sites.map((site) => site.id)
+      if (JSON.stringify(form.getValues('sites').map((site) => site.id)) !== JSON.stringify(newSites)) {
+        form.setValue(
+          'sites',
+          organizationVersion.organization.sites.map((site) => ({
+            ...site,
+            ca: site.ca ? displayCA(site.ca, CA_UNIT_VALUES[caUnit]) : 0,
+            selected: false,
+            postalCode: site.postalCode ?? '',
+            city: site.city ?? '',
+          })),
+        )
+      }
     }
   }, [organizationVersion, caUnit])
 
@@ -94,7 +97,11 @@ const SelectOrganization = ({ organizationVersions, selectOrganizationVersion, f
               defaultComponent={<Sites sites={sites} form={form} caUnit={caUnit} withSelection />}
             />
             <div className="mt2">
-              <Button data-testid="new-study-organization-button" onClick={next}>
+              <Button
+                disabled={!sites.some((site) => site.selected)}
+                data-testid="new-study-organization-button"
+                onClick={next}
+              >
                 {t('next')}
               </Button>
               {error && <FormHelperText error>{error}</FormHelperText>}

--- a/src/tests/end-to-end/app/create-emission-source.cy.ts
+++ b/src/tests/end-to-end/app/create-emission-source.cy.ts
@@ -96,6 +96,7 @@ describe('Create study emission source', () => {
       cy.getByTestId('validated-emission-source-name').should('have.text', 'My emission source name')
     })
     cy.getByTestId('emission-source-validate').click()
+    cy.getByTestId('emission-source-status').invoke('text').should('contain', 'À vérifier')
 
     // Editor can add source, edit but not validate
     cy.logout()

--- a/src/tests/end-to-end/app/create-study.cy.ts
+++ b/src/tests/end-to-end/app/create-study.cy.ts
@@ -16,8 +16,10 @@ describe('Create study', () => {
 
     cy.getByTestId('new-study-organization-title').should('be.visible')
     cy.getByTestId('new-study-organization-select').should('not.exist')
+    cy.getByTestId('new-study-organization-button').should('be.disabled')
     cy.getByTestId('organization-sites-checkbox').first().click()
 
+    cy.getByTestId('new-study-organization-button').should('not.be.disabled')
     cy.getByTestId('new-study-organization-button').click()
 
     cy.getByTestId('new-study-name').type('My new study')


### PR DESCRIPTION
Le test `should create a study on your organization as a simple user` était en erreur sur la CI depuis le merge de la PR https://github.com/ABC-TransitionBasCarbone/bilan-carbone/pull/1078 (pour aucune raison apparente, pas de problème en local). Les screenshots semblent indiquer que le sélecteur de sites pour l'étude s'est rechargé après la sélection du site de l'étude, mais avant le clic sur la validation. J'ai cherché d'où pouvait venir ce re-render et pense l'avoir corrigé
![Create study -- should create a study on your organization as a simple user (failed)](https://github.com/user-attachments/assets/b81858c0-9b6a-4dc6-8e31-e9713d38ae81)

