### PR TITLE
fix client deletion

### DIFF
--- a/prisma/schema/study.prisma
+++ b/prisma/schema/study.prisma
@@ -125,7 +125,6 @@ model StudyExport {
 }
 
 model UserOnStudy {
-  // @@id([studyId, accountId]) // TO UNCOMMENT
   study     Study   @relation(fields: [studyId], references: [id])
   studyId   String  @map("study_id")
   account   Account @relation(fields: [accountId], references: [id])

--- a/src/db/organization.ts
+++ b/src/db/organization.ts
@@ -258,7 +258,7 @@ export const deleteClient = async (id: string) => {
   }
   return prismaClient.$transaction(async (transaction) => {
     const studies = await transaction.study.findMany({
-      where: { organizationVersionId: organizationVersion.organizationId },
+      where: { organizationVersionId: organizationVersion.id },
     })
     await Promise.all(studies.map((study) => deleteStudy(study.id)))
     await transaction.organizationVersion.delete({ where: { id } })

--- a/src/db/study.ts
+++ b/src/db/study.ts
@@ -466,6 +466,7 @@ export const deleteStudy = async (id: string) => {
       transaction.document.deleteMany({ where: { studyId: id } }),
       transaction.studyEmissionFactorVersion.deleteMany({ where: { studyId: id } }),
       transaction.studyExport.deleteMany({ where: { studyId: id } }),
+      transaction.openingHours.deleteMany({ where: { studyId: id } }),
     ])
     await transaction.study.delete({ where: { id } })
   })


### PR DESCRIPTION
#1036 (cf https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/1036#issuecomment-2934369206)

L'erreur venait des clients avec des études, ces dernières ne sont pas supprimées car le critère study.organizationVersionId  n'était pas le bon