### PR TITLE
change role for cut

### DIFF
--- a/prisma/seed/index.ts
+++ b/prisma/seed/index.ts
@@ -21,6 +21,7 @@ import {
 import { Command } from 'commander'
 import { ACTUALITIES } from '../legacy_data/actualities'
 import { createRealStudy } from './study'
+import { getCutRoleFromBase } from './utils'
 
 const program = new Command()
 type Params = {
@@ -254,14 +255,14 @@ const users = async () => {
     })),
   })
 
+  const crOrganizationVersions = organizationVersions.filter((organization) => organization.isCR)
+  const regularOrganizationVersions = organizationVersions.filter((organization) => !organization.isCR)
+
   const environmentOrganizationVersions = {
-    [Environment.BC]: organizationVersions,
+    [Environment.BC]: regularOrganizationVersions,
     [Environment.CUT]: organizationVersionsCUT,
     [Environment.TILT]: organizationVersionsTILT,
   }
-
-  const crOrganizationVersions = organizationVersions.filter((organization) => organization.isCR)
-  const regularOrganizationVersions = organizationVersions.filter((organization) => !organization.isCR)
 
   const childOrganizations = await prisma.organization.createManyAndReturn({
     data: Array.from({ length: 50 }).map(() => ({
@@ -405,7 +406,7 @@ const users = async () => {
           const account = await prisma.account.create({
             data: {
               organizationVersionId: organizationVersionArray[index % organizationVersionArray.length].id,
-              role: role as Role,
+              role: getCutRoleFromBase(role as Role),
               userId: user.id,
               environment: environment as Environment,
             },
@@ -442,7 +443,7 @@ const users = async () => {
           },
           {
             organizationVersionId: organizationVersionsCUT[index % organizationVersionsCUT.length].id,
-            role: role as Role,
+            role: getCutRoleFromBase(role as Role),
             userId: user.id,
             environment: Environment.CUT,
           },

--- a/prisma/seed/utils.ts
+++ b/prisma/seed/utils.ts
@@ -6,8 +6,6 @@ export const getCutRoleFromBase = (role: Role): Role => {
     case Role.GESTIONNAIRE:
     case Role.SUPER_ADMIN:
       return Role.ADMIN
-    case Role.COLLABORATOR:
-    case Role.DEFAULT:
     default:
       return Role.DEFAULT
   }

--- a/prisma/seed/utils.ts
+++ b/prisma/seed/utils.ts
@@ -1,0 +1,13 @@
+import { Role } from '@prisma/client'
+
+export const getCutRoleFromBase = (role: Role): Role => {
+  const cutRoles = {
+    [Role.ADMIN]: Role.ADMIN,
+    [Role.GESTIONNAIRE]: Role.ADMIN,
+    [Role.COLLABORATOR]: Role.DEFAULT,
+    [Role.DEFAULT]: Role.DEFAULT,
+    [Role.SUPER_ADMIN]: Role.ADMIN,
+  }
+
+  return cutRoles[role] || Role.DEFAULT
+}

--- a/prisma/seed/utils.ts
+++ b/prisma/seed/utils.ts
@@ -1,13 +1,14 @@
 import { Role } from '@prisma/client'
 
 export const getCutRoleFromBase = (role: Role): Role => {
-  const cutRoles = {
-    [Role.ADMIN]: Role.ADMIN,
-    [Role.GESTIONNAIRE]: Role.ADMIN,
-    [Role.COLLABORATOR]: Role.DEFAULT,
-    [Role.DEFAULT]: Role.DEFAULT,
-    [Role.SUPER_ADMIN]: Role.ADMIN,
+  switch (role) {
+    case Role.ADMIN:
+    case Role.GESTIONNAIRE:
+    case Role.SUPER_ADMIN:
+      return Role.ADMIN
+    case Role.COLLABORATOR:
+    case Role.DEFAULT:
+    default:
+      return Role.DEFAULT
   }
-
-  return cutRoles[role] || Role.DEFAULT
 }

--- a/src/app/(dashboard)/equipe/ajouter/page.tsx
+++ b/src/app/(dashboard)/equipe/ajouter/page.tsx
@@ -1,8 +1,8 @@
-import withAuth from '@/components/hoc/withAuth'
+import withAuth, { UserSessionProps } from '@/components/hoc/withAuth'
 import NewMemberPage from '@/components/pages/NewMember'
 
-const NewMember = () => {
-  return <NewMemberPage />
+const NewMember = ({ user }: UserSessionProps) => {
+  return <NewMemberPage user={user} />
 }
 
 export default withAuth(NewMember)

--- a/src/components/pages/NewMember.tsx
+++ b/src/components/pages/NewMember.tsx
@@ -1,9 +1,10 @@
 import { useTranslations } from 'next-intl'
 import Block from '../base/Block'
 import Breadcrumbs from '../breadcrumbs/Breadcrumbs'
+import { UserSessionProps } from '../hoc/withAuth'
 import NewMemberForm from '../team/NewMemberForm'
 
-const NewMemberPage = () => {
+const NewMemberPage = ({ user }: UserSessionProps) => {
   const tNav = useTranslations('nav')
   const t = useTranslations('newMember')
   return (
@@ -16,7 +17,7 @@ const NewMemberPage = () => {
         ]}
       />
       <Block title={t('title')} as="h1">
-        <NewMemberForm />
+        <NewMemberForm environment={user.environment} />
       </Block>
     </>
   )

--- a/src/components/pages/Team.tsx
+++ b/src/components/pages/Team.tsx
@@ -20,7 +20,6 @@ interface Props {
 const TeamPage = ({ user, team, crOrga = false }: Props) => {
   const tNav = useTranslations('nav')
   const t = useTranslations('team')
-  console.log(team)
 
   return (
     <SessionProvider>

--- a/src/components/pages/Team.tsx
+++ b/src/components/pages/Team.tsx
@@ -20,13 +20,14 @@ interface Props {
 const TeamPage = ({ user, team, crOrga = false }: Props) => {
   const tNav = useTranslations('nav')
   const t = useTranslations('team')
+  console.log(team)
 
   return (
     <SessionProvider>
       <Breadcrumbs current={tNav('team')} links={[{ label: tNav('home'), link: '/' }]} />
       <Block title={t('title')} as="h1" />
       <InvitationsToValidate
-        team={team.filter((member) => member.user.status === UserStatus.PENDING_REQUEST)}
+        usersToValidate={team.filter((member) => member.user.status === UserStatus.PENDING_REQUEST)}
         user={user}
       />
       <PendingInvitations team={team.filter((member) => member.user.status === UserStatus.VALIDATED)} user={user} />

--- a/src/components/team/InvitationsToValidate.tsx
+++ b/src/components/team/InvitationsToValidate.tsx
@@ -1,5 +1,5 @@
 import { TeamMember } from '@/db/account'
-import { Role } from '@prisma/client'
+import { canEditMemberRole } from '@/utils/organization'
 import classNames from 'classnames'
 import { UserSession } from 'next-auth'
 import { useFormatter, useTranslations } from 'next-intl'
@@ -9,17 +9,17 @@ import InvitationsToValidateActions from './InvitationsToValidateActions'
 
 interface Props {
   user: UserSession
-  team: TeamMember[]
+  usersToValidate: TeamMember[]
 }
 
-const InvitationsToValidate = ({ user, team }: Props) => {
+const InvitationsToValidate = ({ user, usersToValidate }: Props) => {
   const t = useTranslations('team')
   const format = useFormatter()
 
-  return user.role === Role.COLLABORATOR || team.length === 0 ? null : (
+  return !canEditMemberRole(user) || usersToValidate.length === 0 ? null : (
     <Block title={t('toValidate')}>
       <ul data-testid="invitations-to-validate" className={classNames(styles.members, 'flex-col')}>
-        {team.map((member) => (
+        {usersToValidate.map((member) => (
           <li data-testid="invitation" key={member.user.email} className={classNames(styles.line, 'align-center')}>
             <p>
               <span className={styles.email}>{member.user.email}</span>

--- a/src/components/team/InvitationsToValidateActions.tsx
+++ b/src/components/team/InvitationsToValidateActions.tsx
@@ -24,7 +24,8 @@ const InvitationsToValidateActions = ({ user, member }: Props) => {
   const [validating, setValidating] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const router = useRouter()
-  const role = member.user.level ? member.role : Role.GESTIONNAIRE
+  const role = member.user.level ? member.role : Role.DEFAULT
+
   return (
     <div className={classNames(styles.buttons, 'flex')}>
       <SelectRole

--- a/src/components/team/InvitationsToValidateActions.tsx
+++ b/src/components/team/InvitationsToValidateActions.tsx
@@ -33,6 +33,7 @@ const InvitationsToValidateActions = ({ user, member }: Props) => {
         email={member.user.email}
         currentRole={role}
         level={member.user.level}
+        environment={user.environment}
       />
       <LoadingButton
         data-testid="validate-invitation"

--- a/src/components/team/NewMemberForm.tsx
+++ b/src/components/team/NewMemberForm.tsx
@@ -4,6 +4,7 @@ import Form from '@/components/base/Form'
 import { FormTextField } from '@/components/form/TextField'
 import { addMember } from '@/services/serverFunctions/user'
 import { AddMemberCommand, AddMemberCommandValidation } from '@/services/serverFunctions/user.command'
+import { getEnvironmentRoles } from '@/utils/user'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { MenuItem } from '@mui/material'
 import { Role } from '@prisma/client'
@@ -72,7 +73,7 @@ const NewMemberForm = () => {
         label={t('email')}
       />
       <FormSelect control={form.control} translation={t} name="role" label={t('role')} data-testid="new-member-role">
-        {Object.keys(Role)
+        {Object.keys(getEnvironmentRoles())
           .filter((role) => role !== Role.SUPER_ADMIN)
           .map((key) => (
             <MenuItem key={key} value={key}>

--- a/src/components/team/NewMemberForm.tsx
+++ b/src/components/team/NewMemberForm.tsx
@@ -7,7 +7,7 @@ import { AddMemberCommand, AddMemberCommandValidation } from '@/services/serverF
 import { getEnvironmentRoles } from '@/utils/user'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { MenuItem } from '@mui/material'
-import { Role } from '@prisma/client'
+import { Environment, Role } from '@prisma/client'
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
@@ -18,7 +18,10 @@ import { FormSelect } from '../form/Select'
 
 const contactMail = process.env.NEXT_PUBLIC_ABC_SUPPORT_MAIL
 
-const NewMemberForm = () => {
+interface Props {
+  environment: Environment
+}
+const NewMemberForm = ({ environment }: Props) => {
   const router = useRouter()
   const t = useTranslations('newMember')
   const tRole = useTranslations('role')
@@ -73,7 +76,7 @@ const NewMemberForm = () => {
         label={t('email')}
       />
       <FormSelect control={form.control} translation={t} name="role" label={t('role')} data-testid="new-member-role">
-        {Object.keys(getEnvironmentRoles())
+        {Object.keys(getEnvironmentRoles(environment))
           .filter((role) => role !== Role.SUPER_ADMIN)
           .map((key) => (
             <MenuItem key={key} value={key}>

--- a/src/components/team/PendingInvitations.tsx
+++ b/src/components/team/PendingInvitations.tsx
@@ -1,5 +1,5 @@
 import { TeamMember } from '@/db/account'
-import { Role } from '@prisma/client'
+import { canEditMemberRole } from '@/utils/organization'
 import classNames from 'classnames'
 import { UserSession } from 'next-auth'
 import { useFormatter, useTranslations } from 'next-intl'
@@ -16,7 +16,7 @@ const PendingInvitations = ({ user, team }: Props) => {
   const t = useTranslations('team')
   const format = useFormatter()
 
-  return user.role === Role.COLLABORATOR || team.length === 0 ? null : (
+  return !canEditMemberRole(user) || team.length === 0 ? null : (
     <Block title={t('pending')}>
       <ul className={classNames(styles.members, 'flex-col')}>
         {team

--- a/src/components/team/SelectRole.tsx
+++ b/src/components/team/SelectRole.tsx
@@ -3,7 +3,7 @@
 import { canEditSelfRole } from '@/services/permissions/user'
 import { changeRole } from '@/services/serverFunctions/user'
 import { SEC, TIME_IN_MS } from '@/utils/time'
-import { getEnvironmentRoles, isUntrainedRole } from '@/utils/user'
+import { canBeUntrainedRole, getEnvironmentRoles } from '@/utils/user'
 import { MenuItem, Select, SelectChangeEvent } from '@mui/material'
 import { Level, Role } from '@prisma/client'
 import { useSession } from 'next-auth/react'
@@ -66,7 +66,7 @@ const SelectRole = ({ currentUserEmail, email, currentRole, level }: Props) => {
         </MenuItem>
         {Object.keys(getEnvironmentRoles())
           .filter((role) => role !== Role.SUPER_ADMIN)
-          .filter((role) => level || isUntrainedRole(role as Role))
+          .filter((role) => level || canBeUntrainedRole(role as Role))
           .map((role) => (
             <MenuItem key={role} value={role}>
               {t(role)}

--- a/src/components/team/SelectRole.tsx
+++ b/src/components/team/SelectRole.tsx
@@ -2,8 +2,8 @@
 
 import { canEditSelfRole } from '@/services/permissions/user'
 import { changeRole } from '@/services/serverFunctions/user'
-import { isUntrainedRole } from '@/utils/organization'
 import { SEC, TIME_IN_MS } from '@/utils/time'
+import { getEnvironmentRoles, isUntrainedRole } from '@/utils/user'
 import { MenuItem, Select, SelectChangeEvent } from '@mui/material'
 import { Level, Role } from '@prisma/client'
 import { useSession } from 'next-auth/react'
@@ -64,7 +64,7 @@ const SelectRole = ({ currentUserEmail, email, currentRole, level }: Props) => {
         <MenuItem value={Role.SUPER_ADMIN} className={styles.hidden} aria-hidden="true">
           {t(Role.SUPER_ADMIN)}
         </MenuItem>
-        {Object.keys(Role)
+        {Object.keys(getEnvironmentRoles())
           .filter((role) => role !== Role.SUPER_ADMIN)
           .filter((role) => level || isUntrainedRole(role as Role))
           .map((role) => (

--- a/src/components/team/SelectRole.tsx
+++ b/src/components/team/SelectRole.tsx
@@ -5,7 +5,7 @@ import { changeRole } from '@/services/serverFunctions/user'
 import { SEC, TIME_IN_MS } from '@/utils/time'
 import { canBeUntrainedRole, getEnvironmentRoles } from '@/utils/user'
 import { MenuItem, Select, SelectChangeEvent } from '@mui/material'
-import { Level, Role } from '@prisma/client'
+import { Environment, Level, Role } from '@prisma/client'
 import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import { useRouter } from 'next/navigation'
@@ -18,12 +18,13 @@ interface Props {
   currentRole: Role
   email: string
   level: Level | null
+  environment: Environment
 }
 
 const emptyToast = { text: '', color: 'info' } as const
 const toastPosition = { vertical: 'bottom', horizontal: 'left' } as const
 
-const SelectRole = ({ currentUserEmail, email, currentRole, level }: Props) => {
+const SelectRole = ({ currentUserEmail, email, currentRole, level, environment }: Props) => {
   const t = useTranslations('role')
   const [role, setRole] = useState(currentRole)
   const [toast, setToast] = useState<{ text: string; color: ToastColors; duration?: number }>(emptyToast)
@@ -64,9 +65,9 @@ const SelectRole = ({ currentUserEmail, email, currentRole, level }: Props) => {
         <MenuItem value={Role.SUPER_ADMIN} className={styles.hidden} aria-hidden="true">
           {t(Role.SUPER_ADMIN)}
         </MenuItem>
-        {Object.keys(getEnvironmentRoles())
+        {Object.keys(getEnvironmentRoles(environment))
           .filter((role) => role !== Role.SUPER_ADMIN)
-          .filter((role) => level || canBeUntrainedRole(role as Role))
+          .filter((role) => level || canBeUntrainedRole(role as Role, environment))
           .map((role) => (
             <MenuItem key={role} value={role}>
               {t(role)}

--- a/src/components/team/TeamTable.tsx
+++ b/src/components/team/TeamTable.tsx
@@ -2,7 +2,9 @@
 
 import HelpIcon from '@/components/base/HelpIcon'
 import { TeamMember } from '@/db/account'
+import { CutRole } from '@/services/roles'
 import { deleteOrganizationMember } from '@/services/serverFunctions/organization'
+import { BASE } from '@/store/AppEnvironment'
 import { canEditMemberRole } from '@/utils/organization'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import { Role } from '@prisma/client'
@@ -177,7 +179,7 @@ const TeamTable = ({ user, team, crOrga }: Props) => {
           },
         ]}
       >
-        {Object.keys(Role)
+        {Object.keys(process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT === BASE ? Role : CutRole)
           .filter((role) => role !== Role.SUPER_ADMIN)
           .map((role) => (
             <p key={role} className="mb-2">

--- a/src/components/team/TeamTable.tsx
+++ b/src/components/team/TeamTable.tsx
@@ -62,6 +62,7 @@ const TeamTable = ({ user, team, crOrga }: Props) => {
               currentRole={role}
               email={context.row.original.user.email}
               level={context.row.original.user.level}
+              environment={user.environment}
             />
           ) : (
             <>{tRole(role)}</>
@@ -178,7 +179,7 @@ const TeamTable = ({ user, team, crOrga }: Props) => {
           },
         ]}
       >
-        {Object.keys(getEnvironmentRoles())
+        {Object.keys(getEnvironmentRoles(user.environment))
           .filter((role) => role !== Role.SUPER_ADMIN)
           .map((role) => (
             <p key={role} className="mb-2">

--- a/src/components/team/TeamTable.tsx
+++ b/src/components/team/TeamTable.tsx
@@ -2,10 +2,9 @@
 
 import HelpIcon from '@/components/base/HelpIcon'
 import { TeamMember } from '@/db/account'
-import { CutRole } from '@/services/roles'
 import { deleteOrganizationMember } from '@/services/serverFunctions/organization'
-import { BASE } from '@/store/AppEnvironment'
 import { canEditMemberRole } from '@/utils/organization'
+import { getEnvironmentRoles } from '@/utils/user'
 import DeleteOutlineIcon from '@mui/icons-material/DeleteOutline'
 import { Role } from '@prisma/client'
 import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table'
@@ -179,7 +178,7 @@ const TeamTable = ({ user, team, crOrga }: Props) => {
           },
         ]}
       >
-        {Object.keys(process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT === BASE ? Role : CutRole)
+        {Object.keys(getEnvironmentRoles())
           .filter((role) => role !== Role.SUPER_ADMIN)
           .map((role) => (
             <p key={role} className="mb-2">

--- a/src/i18n/fr-cut.json
+++ b/src/i18n/fr-cut.json
@@ -97,5 +97,5 @@
     "DEFAULT": "Collaborateur",
     "ADMIN_description": "Un administrateur possède tous les droits sur le compte de l'organisation ainsi que sur l'ensemble des études pour son organisation (qu'elles soient publiques ou privées).",
     "DEFAULT_description": "Un collaborateur peut modifier des études. Il n'a pas accès aux paramètres de l'organisation."
-    }
+  }
 }

--- a/src/i18n/fr-cut.json
+++ b/src/i18n/fr-cut.json
@@ -91,5 +91,11 @@
   },
   "actuality": {
     "title": "Les actualités de COUNT"
-  }
+  },
+  "role": {
+    "ADMIN": "Administrateur",
+    "DEFAULT": "Collaborateur",
+    "ADMIN_description": "Un administrateur possède tous les droits sur le compte de l'organisation ainsi que sur l'ensemble des études pour son organisation (qu'elles soient publiques ou privées).",
+    "DEFAULT_description": "Un collaborateur peut modifier des études. Il n'a pas accès aux paramètres de l'organisation."
+    }
 }

--- a/src/i18n/fr-cut.json
+++ b/src/i18n/fr-cut.json
@@ -93,7 +93,6 @@
     "title": "Les actualités de COUNT"
   },
   "role": {
-    "ADMIN": "Administrateur",
     "DEFAULT": "Collaborateur",
     "ADMIN_description": "Un administrateur possède tous les droits sur le compte de l'organisation ainsi que sur l'ensemble des études pour son organisation (qu'elles soient publiques ou privées).",
     "DEFAULT_description": "Un collaborateur peut modifier des études. Il n'a pas accès aux paramètres de l'organisation."

--- a/src/services/permissions/user.test.ts
+++ b/src/services/permissions/user.test.ts
@@ -11,11 +11,11 @@ jest.mock('@/utils/organization', () => ({
   canEditMemberRole: jest.fn(),
 }))
 jest.mock('@/utils/user', () => ({
-  isUntrainedRole: jest.fn(),
+  canBeUntrainedRole: jest.fn(),
 }))
 
 const mockCanEditMemberRole = organizationUtils.canEditMemberRole as jest.Mock
-const mockIsUntrainedRole = userUtils.isUntrainedRole as unknown as jest.Mock
+const mockcanBeUntrainedRole = userUtils.canBeUntrainedRole as unknown as jest.Mock
 
 const adminUser = getMockedAuthUser({ role: Role.ADMIN })
 
@@ -214,7 +214,7 @@ describe('User permission functions', () => {
       const result = canChangeRole(adminUser, null, Role.ADMIN)
       expect(result).toBe(false)
       expect(mockCanEditMemberRole).toBeCalledTimes(0)
-      expect(mockIsUntrainedRole).toBeCalledTimes(0)
+      expect(mockcanBeUntrainedRole).toBeCalledTimes(0)
     })
 
     it('returns false if editing own role without proper rights', () => {
@@ -231,7 +231,7 @@ describe('User permission functions', () => {
       )
       expect(memberResult).toBe(false)
       expect(mockCanEditMemberRole).toBeCalledTimes(0)
-      expect(mockIsUntrainedRole).toBeCalledTimes(0)
+      expect(mockcanBeUntrainedRole).toBeCalledTimes(0)
     })
 
     it('returns false if cannot edit member roles', () => {
@@ -239,7 +239,7 @@ describe('User permission functions', () => {
       const result = canChangeRole(adminUser, getMockedDbAccount() as AccountWithUser, Role.ADMIN)
       expect(result).toBe(false)
       expect(mockCanEditMemberRole).toBeCalledTimes(1)
-      expect(mockIsUntrainedRole).toBeCalledTimes(0)
+      expect(mockcanBeUntrainedRole).toBeCalledTimes(0)
     })
 
     it('returns false if user is from another organization', () => {
@@ -251,7 +251,7 @@ describe('User permission functions', () => {
       )
       expect(result).toBe(false)
       expect(mockCanEditMemberRole).toBeCalledTimes(1)
-      expect(mockIsUntrainedRole).toBeCalledTimes(0)
+      expect(mockcanBeUntrainedRole).toBeCalledTimes(0)
     })
 
     it('returns false if assigning SUPER_ADMIN', () => {
@@ -259,21 +259,21 @@ describe('User permission functions', () => {
       const result = canChangeRole(adminUser, getMockedDbAccount() as AccountWithUser, Role.SUPER_ADMIN)
       expect(result).toBe(false)
       expect(mockCanEditMemberRole).toBeCalledTimes(1)
-      expect(mockIsUntrainedRole).toBeCalledTimes(0)
+      expect(mockcanBeUntrainedRole).toBeCalledTimes(0)
     })
 
     it('returns false if member has no level and role is not untrained', () => {
       mockCanEditMemberRole.mockReturnValue(true)
-      mockIsUntrainedRole.mockReturnValue(false)
+      mockcanBeUntrainedRole.mockReturnValue(false)
       const result = canChangeRole(adminUser, getMockedDbAccount({}, { level: null }) as AccountWithUser, Role.ADMIN)
       expect(result).toBe(false)
       expect(mockCanEditMemberRole).toBeCalledTimes(1)
-      expect(mockIsUntrainedRole).toBeCalledTimes(1)
+      expect(mockcanBeUntrainedRole).toBeCalledTimes(1)
     })
 
     it('returns true when all checks pass', () => {
       mockCanEditMemberRole.mockReturnValue(true)
-      mockIsUntrainedRole.mockReturnValue(true)
+      mockcanBeUntrainedRole.mockReturnValue(true)
       const untrainedResult = canChangeRole(
         adminUser,
         getMockedDbAccount({}, { level: null }) as AccountWithUser,
@@ -281,10 +281,10 @@ describe('User permission functions', () => {
       )
       expect(untrainedResult).toBe(true)
       expect(mockCanEditMemberRole).toBeCalledTimes(1)
-      expect(mockIsUntrainedRole).toBeCalledTimes(1)
+      expect(mockcanBeUntrainedRole).toBeCalledTimes(1)
 
       mockCanEditMemberRole.mockReturnValue(true)
-      mockIsUntrainedRole.mockReturnValue(false)
+      mockcanBeUntrainedRole.mockReturnValue(false)
       const trainedResult = canChangeRole(adminUser, getMockedDbAccount() as AccountWithUser, Role.ADMIN)
       expect(trainedResult).toBe(true)
       expect(mockCanEditMemberRole).toBeCalledTimes(2)

--- a/src/services/permissions/user.test.ts
+++ b/src/services/permissions/user.test.ts
@@ -2,17 +2,20 @@ import { AccountWithUser } from '@/db/account'
 import { mockedOrganizationVersionId } from '@/tests/utils/models/organization'
 import { getMockedAuthUser, getMockedDbAccount, mockedAccountId } from '@/tests/utils/models/user'
 import * as organizationUtils from '@/utils/organization'
+import * as userUtils from '@/utils/user'
 import { expect } from '@jest/globals'
 import { Role, UserStatus } from '@prisma/client'
 import { canAddMember, canChangeRole, canDeleteMember, canEditSelfRole } from './user'
 
 jest.mock('@/utils/organization', () => ({
   canEditMemberRole: jest.fn(),
+}))
+jest.mock('@/utils/user', () => ({
   isUntrainedRole: jest.fn(),
 }))
 
 const mockCanEditMemberRole = organizationUtils.canEditMemberRole as jest.Mock
-const mockIsUntrainedRole = organizationUtils.isUntrainedRole as unknown as jest.Mock
+const mockIsUntrainedRole = userUtils.isUntrainedRole as unknown as jest.Mock
 
 const adminUser = getMockedAuthUser({ role: Role.ADMIN })
 

--- a/src/services/permissions/user.test.ts
+++ b/src/services/permissions/user.test.ts
@@ -15,7 +15,7 @@ jest.mock('@/utils/user', () => ({
 }))
 
 const mockCanEditMemberRole = organizationUtils.canEditMemberRole as jest.Mock
-const mockcanBeUntrainedRole = userUtils.canBeUntrainedRole as unknown as jest.Mock
+const mockCanBeUntrainedRole = userUtils.canBeUntrainedRole as unknown as jest.Mock
 
 const adminUser = getMockedAuthUser({ role: Role.ADMIN })
 
@@ -214,7 +214,7 @@ describe('User permission functions', () => {
       const result = canChangeRole(adminUser, null, Role.ADMIN)
       expect(result).toBe(false)
       expect(mockCanEditMemberRole).toBeCalledTimes(0)
-      expect(mockcanBeUntrainedRole).toBeCalledTimes(0)
+      expect(mockCanBeUntrainedRole).toBeCalledTimes(0)
     })
 
     it('returns false if editing own role without proper rights', () => {
@@ -231,7 +231,7 @@ describe('User permission functions', () => {
       )
       expect(memberResult).toBe(false)
       expect(mockCanEditMemberRole).toBeCalledTimes(0)
-      expect(mockcanBeUntrainedRole).toBeCalledTimes(0)
+      expect(mockCanBeUntrainedRole).toBeCalledTimes(0)
     })
 
     it('returns false if cannot edit member roles', () => {
@@ -239,7 +239,7 @@ describe('User permission functions', () => {
       const result = canChangeRole(adminUser, getMockedDbAccount() as AccountWithUser, Role.ADMIN)
       expect(result).toBe(false)
       expect(mockCanEditMemberRole).toBeCalledTimes(1)
-      expect(mockcanBeUntrainedRole).toBeCalledTimes(0)
+      expect(mockCanBeUntrainedRole).toBeCalledTimes(0)
     })
 
     it('returns false if user is from another organization', () => {
@@ -251,7 +251,7 @@ describe('User permission functions', () => {
       )
       expect(result).toBe(false)
       expect(mockCanEditMemberRole).toBeCalledTimes(1)
-      expect(mockcanBeUntrainedRole).toBeCalledTimes(0)
+      expect(mockCanBeUntrainedRole).toBeCalledTimes(0)
     })
 
     it('returns false if assigning SUPER_ADMIN', () => {
@@ -259,21 +259,21 @@ describe('User permission functions', () => {
       const result = canChangeRole(adminUser, getMockedDbAccount() as AccountWithUser, Role.SUPER_ADMIN)
       expect(result).toBe(false)
       expect(mockCanEditMemberRole).toBeCalledTimes(1)
-      expect(mockcanBeUntrainedRole).toBeCalledTimes(0)
+      expect(mockCanBeUntrainedRole).toBeCalledTimes(0)
     })
 
     it('returns false if member has no level and role is not untrained', () => {
       mockCanEditMemberRole.mockReturnValue(true)
-      mockcanBeUntrainedRole.mockReturnValue(false)
+      mockCanBeUntrainedRole.mockReturnValue(false)
       const result = canChangeRole(adminUser, getMockedDbAccount({}, { level: null }) as AccountWithUser, Role.ADMIN)
       expect(result).toBe(false)
       expect(mockCanEditMemberRole).toBeCalledTimes(1)
-      expect(mockcanBeUntrainedRole).toBeCalledTimes(1)
+      expect(mockCanBeUntrainedRole).toBeCalledTimes(1)
     })
 
     it('returns true when all checks pass', () => {
       mockCanEditMemberRole.mockReturnValue(true)
-      mockcanBeUntrainedRole.mockReturnValue(true)
+      mockCanBeUntrainedRole.mockReturnValue(true)
       const untrainedResult = canChangeRole(
         adminUser,
         getMockedDbAccount({}, { level: null }) as AccountWithUser,
@@ -281,10 +281,10 @@ describe('User permission functions', () => {
       )
       expect(untrainedResult).toBe(true)
       expect(mockCanEditMemberRole).toBeCalledTimes(1)
-      expect(mockcanBeUntrainedRole).toBeCalledTimes(1)
+      expect(mockCanBeUntrainedRole).toBeCalledTimes(1)
 
       mockCanEditMemberRole.mockReturnValue(true)
-      mockcanBeUntrainedRole.mockReturnValue(false)
+      mockCanBeUntrainedRole.mockReturnValue(false)
       const trainedResult = canChangeRole(adminUser, getMockedDbAccount() as AccountWithUser, Role.ADMIN)
       expect(trainedResult).toBe(true)
       expect(mockCanEditMemberRole).toBeCalledTimes(2)

--- a/src/services/permissions/user.ts
+++ b/src/services/permissions/user.ts
@@ -1,5 +1,6 @@
 import { AccountWithUser } from '@/db/account'
-import { canEditMemberRole, isUntrainedRole } from '@/utils/organization'
+import { canEditMemberRole } from '@/utils/organization'
+import { isUntrainedRole } from '@/utils/user'
 import { Prisma, Role, UserStatus } from '@prisma/client'
 import { UserSession } from 'next-auth'
 

--- a/src/services/permissions/user.ts
+++ b/src/services/permissions/user.ts
@@ -70,7 +70,7 @@ export const canChangeRole = (user: UserSession, member: AccountWithUser | null,
     return false
   }
 
-  if (!member.user.level && !canBeUntrainedRole(newRole)) {
+  if (!member.user.level && !canBeUntrainedRole(newRole, user.environment)) {
     return false
   }
 

--- a/src/services/permissions/user.ts
+++ b/src/services/permissions/user.ts
@@ -1,6 +1,6 @@
 import { AccountWithUser } from '@/db/account'
 import { canEditMemberRole } from '@/utils/organization'
-import { isUntrainedRole } from '@/utils/user'
+import { canBeUntrainedRole } from '@/utils/user'
 import { Prisma, Role, UserStatus } from '@prisma/client'
 import { UserSession } from 'next-auth'
 
@@ -70,7 +70,7 @@ export const canChangeRole = (user: UserSession, member: AccountWithUser | null,
     return false
   }
 
-  if (!member.user.level && !isUntrainedRole(newRole)) {
+  if (!member.user.level && !canBeUntrainedRole(newRole)) {
     return false
   }
 

--- a/src/services/roles.ts
+++ b/src/services/roles.ts
@@ -1,0 +1,6 @@
+import { Role } from '@prisma/client'
+
+export const CutRole = {
+  ADMIN: Role.ADMIN,
+  DEFAULT: Role.DEFAULT,
+}

--- a/src/services/roles.ts
+++ b/src/services/roles.ts
@@ -1,6 +1,6 @@
 import { Role } from '@prisma/client'
 
-export const CutRole = {
+export const CutRoles = {
   ADMIN: Role.ADMIN,
   DEFAULT: Role.DEFAULT,
 }

--- a/src/services/serverFunctions/user.ts
+++ b/src/services/serverFunctions/user.ts
@@ -32,6 +32,7 @@ import {
 import { processUsers } from '@/scripts/ftp/userImport'
 import { withServerResponse } from '@/utils/serverResponse'
 import { DAY, HOUR, MIN, TIME_IN_MS } from '@/utils/time'
+import { getRoleToSetForUntrained } from '@/utils/user'
 import { accountWithUserToUserSession, userSessionToDbUser } from '@/utils/userAccounts'
 import { Organization, Role, User, UserChecklist, UserStatus } from '@prisma/client'
 import jwt from 'jsonwebtoken'
@@ -160,7 +161,7 @@ export const addMember = async (member: AddMemberCommand) =>
         source: userFromDb.source,
         accounts: {
           create: {
-            role: role === Role.ADMIN || member.role === Role.GESTIONNAIRE ? Role.GESTIONNAIRE : Role.DEFAULT,
+            role: getRoleToSetForUntrained(role),
             organizationVersionId: session.user.organizationVersionId,
             environment: session.user.environment,
           },
@@ -178,11 +179,7 @@ export const addMember = async (member: AddMemberCommand) =>
         ...member,
         status: UserStatus.VALIDATED,
         level: memberExists.user.level ? memberExists.user.level : null,
-        role: memberExists.user.level
-          ? memberExists.role
-          : member.role === Role.ADMIN || member.role === Role.GESTIONNAIRE
-            ? Role.GESTIONNAIRE
-            : Role.DEFAULT,
+        role: memberExists.user.level ? memberExists.role : getRoleToSetForUntrained(memberExists.role),
         organizationVersionId: session.user.organizationVersionId,
       }
       await updateUser(memberExists.id, updateMember)
@@ -425,7 +422,7 @@ export const changeUserRoleOnOnboarding = async () =>
       return
     }
 
-    const newRole = session.user.level ? Role.ADMIN : Role.GESTIONNAIRE
+    const newRole = session.user.level ? Role.ADMIN : getRoleToSetForUntrained(Role.ADMIN)
     await changeAccountRole(session.user.accountId, newRole)
   })
 

--- a/src/services/serverFunctions/user.ts
+++ b/src/services/serverFunctions/user.ts
@@ -161,7 +161,7 @@ export const addMember = async (member: AddMemberCommand) =>
         source: userFromDb.source,
         accounts: {
           create: {
-            role: getRoleToSetForUntrained(role),
+            role: getRoleToSetForUntrained(role, session.user.environment),
             organizationVersionId: session.user.organizationVersionId,
             environment: session.user.environment,
           },
@@ -179,7 +179,9 @@ export const addMember = async (member: AddMemberCommand) =>
         ...member,
         status: UserStatus.VALIDATED,
         level: memberExists.user.level ? memberExists.user.level : null,
-        role: memberExists.user.level ? memberExists.role : getRoleToSetForUntrained(memberExists.role),
+        role: memberExists.user.level
+          ? memberExists.role
+          : getRoleToSetForUntrained(memberExists.role, session.user.environment),
         organizationVersionId: session.user.organizationVersionId,
       }
       await updateUser(memberExists.id, updateMember)
@@ -422,7 +424,7 @@ export const changeUserRoleOnOnboarding = async () =>
       return
     }
 
-    const newRole = session.user.level ? Role.ADMIN : getRoleToSetForUntrained(Role.ADMIN)
+    const newRole = session.user.level ? Role.ADMIN : getRoleToSetForUntrained(Role.ADMIN, session.user.environment)
     await changeAccountRole(session.user.accountId, newRole)
   })
 

--- a/src/tests/end-to-end/app/team.cy.ts
+++ b/src/tests/end-to-end/app/team.cy.ts
@@ -89,17 +89,17 @@ describe('Team', () => {
         cy.get('input').should('not.be.disabled')
       })
 
-    cy.getByTestId('team-table-line').eq(8).contains('bc-gestionnaire-1@yopmail.com').should('exist')
+    cy.getByTestId('team-table-line').eq(13).contains('bc-gestionnaire-1@yopmail.com').should('exist')
     cy.getByTestId('team-table-line')
-      .eq(8)
+      .eq(13)
       .within(() => {
         cy.get('input').should('have.value', Role.GESTIONNAIRE)
         cy.get('input').should('not.be.disabled')
       })
 
-    cy.getByTestId('team-table-line').eq(9).contains('bc-super_admin-1@yopmail.com').should('exist')
+    cy.getByTestId('team-table-line').eq(14).contains('bc-super_admin-1@yopmail.com').should('exist')
     cy.getByTestId('team-table-line')
-      .eq(9)
+      .eq(14)
       .within(() => {
         cy.get('input').should('have.value', Role.SUPER_ADMIN)
         cy.get('input').should('be.disabled')

--- a/src/utils/organization.ts
+++ b/src/utils/organization.ts
@@ -28,5 +28,3 @@ export const canEditOrganizationVersion = (
 }
 
 export const canEditMemberRole = (account: UserSession) => isAdmin(account.role) || account.role === Role.GESTIONNAIRE
-
-export const isUntrainedRole = (role: Role) => role === Role.GESTIONNAIRE || role === Role.DEFAULT

--- a/src/utils/study.ts
+++ b/src/utils/study.ts
@@ -4,7 +4,7 @@ import { isAdminOnStudyOrga } from '@/services/permissions/study'
 import { Post } from '@/services/posts'
 import { checkLevel } from '@/services/study'
 import { isAdmin } from '@/utils/user'
-import { Level, Role, StudyResultUnit, StudyRole, SubPost, Unit } from '@prisma/client'
+import { Environment, Level, Role, StudyResultUnit, StudyRole, SubPost, Unit } from '@prisma/client'
 import { UserSession } from 'next-auth'
 import { isInOrgaOrParent } from './organization'
 
@@ -13,7 +13,7 @@ export const getUserRoleOnPublicStudy = (user: UserSession, studyLevel: Level) =
     return checkLevel(user.level, studyLevel) ? StudyRole.Validator : StudyRole.Reader
   }
 
-  if (process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT === 'CUT') {
+  if (user.environment === Environment.CUT) {
     return StudyRole.Editor
   }
 

--- a/src/utils/study.ts
+++ b/src/utils/study.ts
@@ -12,6 +12,11 @@ export const getUserRoleOnPublicStudy = (user: UserSession, studyLevel: Level) =
   if (isAdmin(user.role)) {
     return checkLevel(user.level, studyLevel) ? StudyRole.Validator : StudyRole.Reader
   }
+
+  if (process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT === 'CUT') {
+    return StudyRole.Editor
+  }
+
   return user.role === Role.COLLABORATOR && checkLevel(user.level, studyLevel) ? StudyRole.Editor : StudyRole.Reader
 }
 

--- a/src/utils/user.test.ts
+++ b/src/utils/user.test.ts
@@ -77,11 +77,11 @@ describe('userUtils functions', () => {
   })
 
   describe('getEnvironmentRoles', () => {
-    test('should return CutRoles when NEXT_PUBLIC_DEFAULT_ENVIRONMENT is CUT', () => {
+    test('should return CutRoles when environment is CUT', () => {
       expect(getEnvironmentRoles(Environment.CUT)).toEqual(CutRoles)
     })
 
-    test('should return Role when NEXT_PUBLIC_DEFAULT_ENVIRONMENT is not CUT', () => {
+    test('should return Role when environment is not CUT', () => {
       expect(getEnvironmentRoles(Environment.BC)).toEqual(Role)
     })
   })

--- a/src/utils/user.test.ts
+++ b/src/utils/user.test.ts
@@ -12,27 +12,15 @@ const mockCanEditMemberRole = organizationModule.canEditMemberRole as jest.Mock
 
 describe('userUtils functions', () => {
   describe('isAdmin', () => {
-    test('should return true for ADMIN role', () => {
+    test('should return true for ADMIN roles', () => {
       expect(isAdmin(Role.ADMIN)).toBe(true)
-    })
-
-    test('should return true for SUPER_ADMIN role', () => {
       expect(isAdmin(Role.SUPER_ADMIN)).toBe(true)
     })
 
-    test('should return false for GESTIONNAIRE role', () => {
+    test('should return false for non-ADMIN role', () => {
       expect(isAdmin(Role.GESTIONNAIRE)).toBe(false)
-    })
-
-    test('should return false for COLLABORATOR role', () => {
       expect(isAdmin(Role.COLLABORATOR)).toBe(false)
-    })
-
-    test('should return false for DEFAULT role', () => {
       expect(isAdmin(Role.DEFAULT)).toBe(false)
-    })
-
-    test('should return false for any other role', () => {
       expect(isAdmin('OTHER_ROLE' as Role)).toBe(false)
     })
   })

--- a/src/utils/user.test.ts
+++ b/src/utils/user.test.ts
@@ -1,8 +1,7 @@
 import { CutRoles } from '@/services/roles'
-import { BASE, CUT } from '@/store/AppEnvironment'
 import { getMockedAuthUser } from '@/tests/utils/models/user'
 import { expect } from '@jest/globals'
-import { Role, UserStatus } from '@prisma/client'
+import { Environment, Role, UserStatus } from '@prisma/client'
 import * as organizationModule from './organization'
 import { canBeUntrainedRole, findUserInfo, getEnvironmentRoles, getRoleToSetForUntrained, isAdmin } from './user'
 
@@ -79,54 +78,46 @@ describe('userUtils functions', () => {
 
   describe('getEnvironmentRoles', () => {
     test('should return CutRoles when NEXT_PUBLIC_DEFAULT_ENVIRONMENT is CUT', () => {
-      process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT = CUT
-      expect(getEnvironmentRoles()).toEqual(CutRoles)
+      expect(getEnvironmentRoles(Environment.CUT)).toEqual(CutRoles)
     })
 
     test('should return Role when NEXT_PUBLIC_DEFAULT_ENVIRONMENT is not CUT', () => {
-      process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT = BASE
-      expect(getEnvironmentRoles()).toEqual(Role)
+      expect(getEnvironmentRoles(Environment.BC)).toEqual(Role)
     })
   })
 
   describe('getRoleToSetForUntrained', () => {
     test('should return the same role for CUT environment', () => {
-      process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT = CUT
-      expect(getRoleToSetForUntrained(Role.ADMIN)).toBe(Role.ADMIN)
-      expect(getRoleToSetForUntrained(Role.DEFAULT)).toBe(Role.DEFAULT)
+      expect(getRoleToSetForUntrained(Role.ADMIN, Environment.CUT)).toBe(Role.ADMIN)
+      expect(getRoleToSetForUntrained(Role.DEFAULT, Environment.CUT)).toBe(Role.DEFAULT)
     })
 
     test('should return GESTIONNAIRE for ADMIN and GESTIONNAIRE roles in BASE environment', () => {
-      process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT = BASE
-      expect(getRoleToSetForUntrained(Role.ADMIN)).toBe(Role.GESTIONNAIRE)
-      expect(getRoleToSetForUntrained(Role.GESTIONNAIRE)).toBe(Role.GESTIONNAIRE)
+      expect(getRoleToSetForUntrained(Role.ADMIN, Environment.BC)).toBe(Role.GESTIONNAIRE)
+      expect(getRoleToSetForUntrained(Role.GESTIONNAIRE, Environment.BC)).toBe(Role.GESTIONNAIRE)
     })
 
     test('should return DEFAULT for other roles in BASE environment', () => {
-      process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT = BASE
-      expect(getRoleToSetForUntrained(Role.COLLABORATOR)).toBe(Role.DEFAULT)
-      expect(getRoleToSetForUntrained(Role.DEFAULT)).toBe(Role.DEFAULT)
+      expect(getRoleToSetForUntrained(Role.COLLABORATOR, Environment.BC)).toBe(Role.DEFAULT)
+      expect(getRoleToSetForUntrained(Role.DEFAULT, Environment.BC)).toBe(Role.DEFAULT)
     })
   })
 
   describe('canBeUntrainedRole', () => {
     test('should return true for all roles in CUT environment', () => {
-      process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT = CUT
-      expect(canBeUntrainedRole(Role.ADMIN)).toBe(true)
-      expect(canBeUntrainedRole(Role.DEFAULT)).toBe(true)
+      expect(canBeUntrainedRole(Role.ADMIN, Environment.CUT)).toBe(true)
+      expect(canBeUntrainedRole(Role.DEFAULT, Environment.CUT)).toBe(true)
     })
 
     test('should return true for GESTIONNAIRE and DEFAULT roles in BASE environment', () => {
-      process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT = BASE
-      expect(canBeUntrainedRole(Role.GESTIONNAIRE)).toBe(true)
-      expect(canBeUntrainedRole(Role.DEFAULT)).toBe(true)
+      expect(canBeUntrainedRole(Role.GESTIONNAIRE, Environment.BC)).toBe(true)
+      expect(canBeUntrainedRole(Role.DEFAULT, Environment.BC)).toBe(true)
     })
 
     test('should return false for other roles in BASE environment', () => {
-      process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT = BASE
-      expect(canBeUntrainedRole(Role.ADMIN)).toBe(false)
-      expect(canBeUntrainedRole(Role.COLLABORATOR)).toBe(false)
-      expect(canBeUntrainedRole(Role.SUPER_ADMIN)).toBe(false)
+      expect(canBeUntrainedRole(Role.ADMIN, Environment.BC)).toBe(false)
+      expect(canBeUntrainedRole(Role.COLLABORATOR, Environment.BC)).toBe(false)
+      expect(canBeUntrainedRole(Role.SUPER_ADMIN, Environment.BC)).toBe(false)
     })
   })
 })

--- a/src/utils/user.test.ts
+++ b/src/utils/user.test.ts
@@ -1,0 +1,144 @@
+import { CutRoles } from '@/services/roles'
+import { BASE, CUT } from '@/store/AppEnvironment'
+import { getMockedAuthUser } from '@/tests/utils/models/user'
+import { expect } from '@jest/globals'
+import { Role, UserStatus } from '@prisma/client'
+import * as organizationModule from './organization'
+import { canBeUntrainedRole, findUserInfo, getEnvironmentRoles, getRoleToSetForUntrained, isAdmin } from './user'
+
+jest.mock('./organization', () => ({ canEditMemberRole: jest.fn() }))
+
+const mockCanEditMemberRole = organizationModule.canEditMemberRole as jest.Mock
+
+describe('userUtils functions', () => {
+  describe('isAdmin', () => {
+    test('should return true for ADMIN role', () => {
+      expect(isAdmin(Role.ADMIN)).toBe(true)
+    })
+
+    test('should return true for SUPER_ADMIN role', () => {
+      expect(isAdmin(Role.SUPER_ADMIN)).toBe(true)
+    })
+
+    test('should return false for GESTIONNAIRE role', () => {
+      expect(isAdmin(Role.GESTIONNAIRE)).toBe(false)
+    })
+
+    test('should return false for COLLABORATOR role', () => {
+      expect(isAdmin(Role.COLLABORATOR)).toBe(false)
+    })
+
+    test('should return false for DEFAULT role', () => {
+      expect(isAdmin(Role.DEFAULT)).toBe(false)
+    })
+
+    test('should return false for any other role', () => {
+      expect(isAdmin('OTHER_ROLE' as Role)).toBe(false)
+    })
+  })
+
+  describe('findUserInfo', () => {
+    test('should return correct arguments for user find info when user can edit member role', () => {
+      const user = getMockedAuthUser({ role: Role.ADMIN })
+      mockCanEditMemberRole.mockReturnValue(true)
+
+      const result = findUserInfo(user)
+      expect(result).toEqual({
+        select: {
+          user: {
+            select: {
+              email: true,
+              firstName: true,
+              lastName: true,
+              level: true,
+              status: true,
+              updatedAt: true,
+            },
+          },
+          role: true,
+          updatedAt: true,
+        },
+        where: { organizationVersionId: user.organizationVersionId },
+      })
+      expect(mockCanEditMemberRole).toHaveBeenCalledWith(user)
+    })
+
+    test('should return correct arguments for user find info when user cannot edit member role', () => {
+      const user = getMockedAuthUser({ role: Role.DEFAULT })
+      mockCanEditMemberRole.mockReturnValue(false)
+
+      const result = findUserInfo(user)
+      expect(result).toEqual({
+        select: {
+          user: {
+            select: {
+              email: true,
+              firstName: true,
+              lastName: true,
+              level: true,
+              status: true,
+              updatedAt: true,
+            },
+          },
+          role: true,
+          updatedAt: true,
+        },
+        where: { user: { status: UserStatus.ACTIVE }, organizationVersionId: user.organizationVersionId },
+      })
+      expect(mockCanEditMemberRole).toHaveBeenCalledWith(user)
+    })
+  })
+
+  describe('getEnvironmentRoles', () => {
+    test('should return CutRoles when NEXT_PUBLIC_DEFAULT_ENVIRONMENT is CUT', () => {
+      process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT = CUT
+      expect(getEnvironmentRoles()).toEqual(CutRoles)
+    })
+
+    test('should return Role when NEXT_PUBLIC_DEFAULT_ENVIRONMENT is not CUT', () => {
+      process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT = BASE
+      expect(getEnvironmentRoles()).toEqual(Role)
+    })
+  })
+
+  describe('getRoleToSetForUntrained', () => {
+    test('should return the same role for CUT environment', () => {
+      process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT = CUT
+      expect(getRoleToSetForUntrained(Role.ADMIN)).toBe(Role.ADMIN)
+      expect(getRoleToSetForUntrained(Role.DEFAULT)).toBe(Role.DEFAULT)
+    })
+
+    test('should return GESTIONNAIRE for ADMIN and GESTIONNAIRE roles in BASE environment', () => {
+      process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT = BASE
+      expect(getRoleToSetForUntrained(Role.ADMIN)).toBe(Role.GESTIONNAIRE)
+      expect(getRoleToSetForUntrained(Role.GESTIONNAIRE)).toBe(Role.GESTIONNAIRE)
+    })
+
+    test('should return DEFAULT for other roles in BASE environment', () => {
+      process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT = BASE
+      expect(getRoleToSetForUntrained(Role.COLLABORATOR)).toBe(Role.DEFAULT)
+      expect(getRoleToSetForUntrained(Role.DEFAULT)).toBe(Role.DEFAULT)
+    })
+  })
+
+  describe('canBeUntrainedRole', () => {
+    test('should return true for all roles in CUT environment', () => {
+      process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT = CUT
+      expect(canBeUntrainedRole(Role.ADMIN)).toBe(true)
+      expect(canBeUntrainedRole(Role.DEFAULT)).toBe(true)
+    })
+
+    test('should return true for GESTIONNAIRE and DEFAULT roles in BASE environment', () => {
+      process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT = BASE
+      expect(canBeUntrainedRole(Role.GESTIONNAIRE)).toBe(true)
+      expect(canBeUntrainedRole(Role.DEFAULT)).toBe(true)
+    })
+
+    test('should return false for other roles in BASE environment', () => {
+      process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT = BASE
+      expect(canBeUntrainedRole(Role.ADMIN)).toBe(false)
+      expect(canBeUntrainedRole(Role.COLLABORATOR)).toBe(false)
+      expect(canBeUntrainedRole(Role.SUPER_ADMIN)).toBe(false)
+    })
+  })
+})

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -1,6 +1,5 @@
 import { CutRoles } from '@/services/roles'
-import { CUT } from '@/store/AppEnvironment'
-import { Prisma, Role, UserStatus } from '@prisma/client'
+import { Environment, Prisma, Role, UserStatus } from '@prisma/client'
 import { UserSession } from 'next-auth'
 import { canEditMemberRole } from './organization'
 
@@ -27,27 +26,28 @@ export const findUserInfo = (user: UserSession) =>
       : { user: { status: UserStatus.ACTIVE }, organizationVersionId: user.organizationVersionId },
   }) satisfies Prisma.AccountFindManyArgs
 
-export const getEnvironmentRoles = () => {
-  if (process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT === CUT) {
+export const getEnvironmentRoles = (environment: Environment) => {
+  if (environment === Environment.CUT) {
     return CutRoles
   }
   return Role
 }
 
-export const getRoleToSetForUntrained = (role: Exclude<Role, 'SUPER_ADMIN'>) => {
-  if (process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT === CUT) {
+export const getRoleToSetForUntrained = (role: Exclude<Role, 'SUPER_ADMIN'>, environment: Environment) => {
+  if (environment === Environment.CUT) {
     return role
   }
 
   return role === Role.ADMIN || role === Role.GESTIONNAIRE ? Role.GESTIONNAIRE : Role.DEFAULT
 }
 
-const getUntrainedRoles = () => {
-  if (process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT === CUT) {
+const getUntrainedRoles = (environment: Environment) => {
+  if (environment === Environment.CUT) {
     return Object.keys(CutRoles)
   }
 
   return [Role.GESTIONNAIRE, Role.DEFAULT]
 }
 
-export const canBeUntrainedRole = (role: Role) => getUntrainedRoles().includes(role)
+export const canBeUntrainedRole = (role: Role, environment: Environment) =>
+  getUntrainedRoles(environment).includes(role)

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -1,5 +1,8 @@
+import { CutRole } from '@/services/roles'
+import { CUT } from '@/store/AppEnvironment'
 import { Prisma, Role, UserStatus } from '@prisma/client'
 import { UserSession } from 'next-auth'
+import { canEditMemberRole } from './organization'
 
 export const isAdmin = (userRole: Role) => userRole === Role.ADMIN || userRole === Role.SUPER_ADMIN
 
@@ -19,8 +22,31 @@ export const findUserInfo = (user: UserSession) =>
       role: true,
       updatedAt: true,
     },
-    where:
-      user.role === Role.COLLABORATOR
-        ? { user: { status: UserStatus.ACTIVE }, organizationVersionId: user.organizationVersionId }
-        : { organizationVersionId: user.organizationVersionId },
+    where: canEditMemberRole(user)
+      ? { organizationVersionId: user.organizationVersionId }
+      : { user: { status: UserStatus.ACTIVE }, organizationVersionId: user.organizationVersionId },
   }) satisfies Prisma.AccountFindManyArgs
+
+export const getEnvironmentRoles = () => {
+  if (process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT === CUT) {
+    return CutRole
+  }
+  return Role
+}
+
+export const getRoleToSetForUntrained = (role: Exclude<Role, 'SUPER_ADMIN'>) => {
+  if (process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT === CUT) {
+    return role
+  }
+
+  return role === Role.ADMIN || role === Role.GESTIONNAIRE ? Role.GESTIONNAIRE : Role.DEFAULT
+}
+
+const getUntrainedRoles = () => {
+  if (process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT === CUT) {
+    return CutRole
+  }
+  return [Role.GESTIONNAIRE, Role.DEFAULT]
+}
+
+export const isUntrainedRole = (role: Role) => Object.keys(getUntrainedRoles()).includes(role)

--- a/src/utils/user.ts
+++ b/src/utils/user.ts
@@ -1,4 +1,4 @@
-import { CutRole } from '@/services/roles'
+import { CutRoles } from '@/services/roles'
 import { CUT } from '@/store/AppEnvironment'
 import { Prisma, Role, UserStatus } from '@prisma/client'
 import { UserSession } from 'next-auth'
@@ -29,7 +29,7 @@ export const findUserInfo = (user: UserSession) =>
 
 export const getEnvironmentRoles = () => {
   if (process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT === CUT) {
-    return CutRole
+    return CutRoles
   }
   return Role
 }
@@ -44,9 +44,10 @@ export const getRoleToSetForUntrained = (role: Exclude<Role, 'SUPER_ADMIN'>) => 
 
 const getUntrainedRoles = () => {
   if (process.env.NEXT_PUBLIC_DEFAULT_ENVIRONMENT === CUT) {
-    return CutRole
+    return Object.keys(CutRoles)
   }
+
   return [Role.GESTIONNAIRE, Role.DEFAULT]
 }
 
-export const isUntrainedRole = (role: Role) => Object.keys(getUntrainedRoles()).includes(role)
+export const canBeUntrainedRole = (role: Role) => getUntrainedRoles().includes(role)


### PR DESCRIPTION
Link to #881 

Je pense que ce serait bien que cette PR soit relu par 1 personne côté CUT + @fortinlouis 
PR à tester

Ce que je n'ai pas géré dans cette PR car je suppose que ce sera fait ailleurs @RomainCrevecoeur 
- Modale d'onboarding 
- Checklist
- L'ajout d'un utilisateur dans une étude (à priori géré par la PR de @jilink)

Choix tech : 
Les validations zod sont plus larges que ce que l'on devrait accepter niveau role pour CUT. Cependnat je n'ai pas trouvé de manière simple de faire autrement vu que notre type est défini via zod et donc impossible de savoir l'environnement.

Question : 
Il n'y a pas besoin d'une traduction de cut en anglais ? Est-ce que c'est bien prévu de bloquer la possibilité ? @RomainCrevecoeur 

J'ai une erreur de lint sur fr-cut mais j'ai toujours un problème en local qui fait que je ne peux pas savoir quoi et je n'arrive pas à trouver. Est-ce que quelqu'un peut regarder ? 

