### PR TITLE
fix: fixing disapearing onboarding modal

### DIFF
--- a/src/components/onboarding/Onboarding.tsx
+++ b/src/components/onboarding/Onboarding.tsx
@@ -16,8 +16,10 @@ const Onboarding = ({ organizationVersion, user }: Props) => {
   const [open, setOpen] = useState(true)
 
   useEffect(() => {
-    setOnboardedOrganizationVersion(organizationVersion.id)
-  }, [])
+    if (!open) {
+      setOnboardedOrganizationVersion(organizationVersion.id)
+    }
+  }, [open])
 
   const onClose = () => setOpen(false)
 


### PR DESCRIPTION
https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/1144

_Le problème venait du fait qu'on passait le user de non onboardé à onboardé directement dans le useEffect de la modal (donc dès qu'elle s'ouvre)

Pour une raison inconnue avant ça ne posait pas de soucis mais peut être qu'il y a un nouvel élément qui rafraichi certains composants et du coup ça crée ce bug de faire disparaitre la modal directement

Du coup si ça vous va maintenant on peut passer le user en onboardé si il a au moins fermé la modal_

Finalement chercher la cause du rerender
![image_480](https://github.com/user-attachments/assets/ee729fe7-2a1e-4e8c-877b-7e29c101d1f5)


Cause du Rerender = Switch d'environnement des cookies
Pour l'instant utile, potentiellement à creuser prochainement

Résolution pour l'onboarding condition open = false dans le useEffect
