### PR TITLE
fix progress bar success color

### DIFF
--- a/src/components/study/card/StudyCard.module.css
+++ b/src/components/study/card/StudyCard.module.css
@@ -26,8 +26,8 @@
 
 .progressBar {
   background: var(--warning);
-}
 
-.progressBarSuccess {
-  background: var(--success-100);
+  &.success {
+    background: var(--success-100);
+  }
 }

--- a/src/components/study/card/StudyCard.tsx
+++ b/src/components/study/card/StudyCard.tsx
@@ -34,7 +34,6 @@ const StudyCard = async ({ study, user }: Props) => {
     return null
   }
   const percent = values.validated ? Math.floor((values.validated / values.total) * 100) : 0
-  const progressBarClass = `${styles.progressBar}${percent === 100 ? 'Success' : ''}`
 
   return (
     <li data-testid="study" className="flex">
@@ -66,7 +65,7 @@ const StudyCard = async ({ study, user }: Props) => {
               {t('validatedOnlyDescription')}
             </GlossaryIconModal>
           </p>
-          <ProgressBar value={percent} barClass={progressBarClass} />
+          <ProgressBar value={percent} barClass={`${styles[`progressBar${percent === 100 ? 'Success' : ''}`]}`} />
         </Box>
         <div className="justify-end">
           <LinkButton href={`/etudes/${study.id}${accountRoleOnStudy === 'Contributor' ? '/contributeur' : ''}`}>

--- a/src/components/study/card/StudyCard.tsx
+++ b/src/components/study/card/StudyCard.tsx
@@ -65,7 +65,10 @@ const StudyCard = async ({ study, user }: Props) => {
               {t('validatedOnlyDescription')}
             </GlossaryIconModal>
           </p>
-          <ProgressBar value={percent} barClass={`${styles[`progressBar${percent === 100 ? 'Success' : ''}`]}`} />
+          <ProgressBar
+            value={percent}
+            barClass={classNames(styles.progressBar, { [styles.success]: percent === 100 })}
+          />
         </Box>
         <div className="justify-end">
           <LinkButton href={`/etudes/${study.id}${accountRoleOnStudy === 'Contributor' ? '/contributeur' : ''}`}>

--- a/src/components/study/card/StudyPostsCard.module.css
+++ b/src/components/study/card/StudyPostsCard.module.css
@@ -75,6 +75,6 @@
   background: var(--warning);
 }
 
-.progressBar-success {
+.progressBarSuccess {
   background: var(--success-100);
 }

--- a/src/components/study/card/StudyPostsCard.module.css
+++ b/src/components/study/card/StudyPostsCard.module.css
@@ -73,8 +73,8 @@
 
 .progressBar {
   background: var(--warning);
-}
 
-.progressBarSuccess {
-  background: var(--success-100);
+  &.success {
+    background: var(--success-100);
+  }
 }

--- a/src/components/study/card/StudyPostsCard.tsx
+++ b/src/components/study/card/StudyPostsCard.tsx
@@ -60,7 +60,7 @@ const StudyPostsCard = ({ study, post, userRole, studySite, setSite }: Props) =>
               ),
             })}
           </p>
-          <ProgressBar value={percent} barClass={`${styles.progressBar}${percent === 100 ? '-success' : ''}`} />
+          <ProgressBar value={percent} barClass={styles[`progressBar${percent === 100 ? 'Success' : ''}`]} />
         </Box>
       </Box>
     </div>

--- a/src/components/study/card/StudyPostsCard.tsx
+++ b/src/components/study/card/StudyPostsCard.tsx
@@ -60,7 +60,10 @@ const StudyPostsCard = ({ study, post, userRole, studySite, setSite }: Props) =>
               ),
             })}
           </p>
-          <ProgressBar value={percent} barClass={styles[`progressBar${percent === 100 ? 'Success' : ''}`]} />
+          <ProgressBar
+            value={percent}
+            barClass={classNames(styles.progressBar, { [styles.success]: percent === 100 })}
+          />
         </Box>
       </Box>
     </div>


### PR DESCRIPTION
correction du bug de couleur sur staging quand la progress bar est complète. Suite à de nombreux échecs, j'ai tenté des correctifs que j'ai déployé en live sur staging pour être sûr du résultat (ça marchait aussi avec un yarn build + yarn start) :

![image](https://github.com/user-attachments/assets/890dfeb8-3825-48b3-ba05-230ac48947d1)
