### PR TITLE
fix: typo footer + removing horizontal scrollbar

### DIFF
--- a/src/environments/cut/layout/Footer.module.css
+++ b/src/environments/cut/layout/Footer.module.css
@@ -1,5 +1,5 @@
 .container {
-  width: 100vw;
+  width: 100%;
   min-height: 236px;
   padding: 2rem 0;
   @media screen and (max-width: 75rem) {

--- a/src/environments/cut/layout/Footer.tsx
+++ b/src/environments/cut/layout/Footer.tsx
@@ -2,11 +2,13 @@
 import { Box, Grid, Typography, useTheme } from '@mui/material'
 import { common } from '@mui/material/colors'
 import classNames from 'classnames'
+import { useTranslations } from 'next-intl'
 import Image from 'next/image'
 import styles from './Footer.module.css'
 
 const Footer = () => {
   const { palette } = useTheme()
+  const t = useTranslations('footer.message')
   const size = { xs: 12, sm: 6, md: 6, lg: 3 }
   return (
     <Grid
@@ -21,7 +23,7 @@ const Footer = () => {
       <Grid className="flex justify-center align-center" size={size}>
         <Box className="flex-col" gap={2}>
           <Typography className={styles.text} color={common.white}>
-            Cet outil a été développé par l'association
+            {t('0')}
           </Typography>
           <Box display="flex">
             <Image width={86.23} height={55} src="/logos/cut/CUT.svg" alt="Cut Logo" />
@@ -32,9 +34,7 @@ const Footer = () => {
       <Grid className="flex justify-center align-center" size={size}>
         <Box component="article" className="flex-col" gap={2}>
           <Typography className={styles.text} color={common.white}>
-            En coopération avec l'ABC,
-            <br />
-            association pour la transition bas carbone
+            {t.rich('1', { br: () => <br /> })}
           </Typography>
           <Image width={154} height={55} src="/logos/cut/ABC.svg" alt="ABC Logo" />
         </Box>
@@ -43,17 +43,14 @@ const Footer = () => {
         <Box component="article" className="flex align-center" gap={2}>
           <Image width={92} height={90} src="/logos/cut/France3_2025_blanc.png" alt="Logo de France 3" />
           <Typography className={styles.text} color={common.white}>
-            Opération soutenue par l’État dans le cadre du <br />
-            dispositif « Soutenir les alternatives vertes 2 » <br />
-            de France 2030, opéré par la Banque des <br />
-            territoires (Caisse des Dépôts)
+            {t.rich('2', { br: () => <br /> })}
           </Typography>
         </Box>
       </Grid>
       <Grid className="flex justify-center align-center" size={size}>
         <Box component="article" className="flex-col" gap={2}>
           <Typography className={styles.text} color={common.white}>
-            CUT! bénéficie du soutien du CNC
+            {t('3')}
           </Typography>
           <Image width={172} height={37} src="/logos/cut/CNC.svg" alt="CNC Logo" />
         </Box>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -184,6 +184,14 @@
       "siretOrCNC": "Please enter a Siret/CNC number"
     }
   },
+  "footer": {
+    "message": {
+      "0": "",
+      "1": "",
+      "2": "",
+      "3": ""
+    }
+  },
   "navigation": {
     "factors": "Emission factors",
     "fe": "EF",

--- a/src/i18n/fr-cut.json
+++ b/src/i18n/fr-cut.json
@@ -13,6 +13,14 @@
       "3": "Construire une trajectoire de réduction"
     }
   },
+  "footer": {
+    "message": {
+      "0": "Cet outil a été développé par l'Association",
+      "1": "En coopération avec l'ABC, <br></br> Association pour la transition Bas Carbone",
+      "2": "Opération soutenue par l'État dans le cadre du <br></br> dispositif « Soutenir les alternatives vertes 2 » <br></br> de France 2030, opéré par la Banque des <br></br> territoires (Caisse des Dépôts)",
+      "3": "CUT! bénéficie du soutien du CNC"
+    }
+  },
   "study": {
     "create": "Ajouter un Bilan",
     "myCollaborations": "Mes collaborations",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -184,6 +184,14 @@
       "siretOrCNC": "Veuillez entrer un Siret/CNC"
     }
   },
+  "footer": {
+    "message": {
+      "0": "",
+      "1": "",
+      "2": "",
+      "3": ""
+    }
+  },
   "navigation": {
     "factors": "Facteurs d'émission",
     "fe": "FE",


### PR DESCRIPTION
- https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/1023

J'ai passé la witdh à 100% au lieu de 100vw car sinon bizarrement ça prenait un peu plus que la largeur et y avait une scrollbar en bas (probablement l'espace blanc dont parlait Gabriel dans le ticket)