### PR TITLE
Une `Unite` peut être une chaîne vide

### DIFF
--- a/src/scripts/cut/question/utils.ts
+++ b/src/scripts/cut/question/utils.ts
@@ -138,7 +138,7 @@ export function validateRow(
       order: Number(row[HEADERS.ORDER]),
       type,
       possibleAnswers: row[HEADERS.POSSIBLE_ANSWER].split('§').map((s) => s.trim()),
-      unit: unit as CUTUnit,
+      unit: unit === '' ? null : (unit as CUTUnit),
       required: Boolean(row[HEADERS.REQUIRED]) || false,
     },
   }


### PR DESCRIPTION
# 📝 Contexte

L’utilisation de script d’import, si dans le fichier `CSV`, un champ de la colonne `Unité` est vide, le `Parser` le voit comme une chaîne vide. Ce qui ne fait pas partie de l’enum prisma.

# 💡 Solution proposée

Ajouter une condition si `unit` est une chaîne vide alors renvoyer `null` sinon renvoyer `unit`

# ✅ Check-list

- [ ] 🧹 Code respecte les conventions
- [ ] 🔄 Branche synchronisée avec la branche principale

# 🔗 Références
- #1323 