### PR TITLE
[CUT] Changer le mot `Bilan` par `Empreinte`

### DIFF
--- a/src/i18n/fr-cut.json
+++ b/src/i18n/fr-cut.json
@@ -1,11 +1,11 @@
 {
   "navigation": {
-    "organizations": "Mes Bilans",
+    "organizations": "Mes Empreintes",
     "information": "Mes cinémas",
     "team": "Mes collaborateurs"
   },
   "home": {
-    "title": "Faire votre bilan d’impact vous permettra de :",
+    "title": "Faire votre Empreinte d’impact vous permettra de :",
     "info": {
       "0": "Comprendre la mesure d’impact de votre établissement",
       "1": "Indentifier les priorités d’action",
@@ -13,7 +13,7 @@
     },
     "message": {
       "core": "Bienvenue sur COUNT le premier calculateur d'impact écologique dédié aux salles de cinéma.\nCet outil a été développé par l'association CUT ! Cinéma Uni pour la transition, en coopération avec l'ABC, association pour la transition bas carbone\nOpération soutenue par l'État dans le cadre du dispositif « Soutenir les alternatives vertes 2 » de France 2030, opéré par la Banque des territoires (Caisse des Dépôts)\nCUT bénéficie du soutien du CNC",
-      "0": "Faire votre bilan d'impact vous permettra de :",
+      "0": "Faire votre Empreinte d'impact vous permettra de :",
       "1": "Comprendre la mesure d'impact de votre établissement",
       "2": "Identifier les priorités d'action",
       "3": "Construire une trajectoire de réduction"
@@ -28,22 +28,22 @@
     }
   },
   "study": {
-    "create": "Ajouter un Bilan",
+    "create": "Ajouter une Empreinte",
     "myCollaborations": "Mes collaborations",
-    "myStudies": "Mes Bilans",
-    "createFirstStudy": "Créer mon premier Bilan",
-    "see": "Voir mon Bilan",
+    "myStudies": "Mes Empreintes",
+    "createFirstStudy": "Créer ma première Empreinte",
+    "see": "Voir mon Empreinte",
     "validatedSources": "<data>{validated} / {total}</data> Questions répondues",
-    "validatedOnlyDescription": "Pour chaque Bilan, un ou plusieurs validateurs peuvent être définis. Ceux-ci ont la responsabilité de valider les sources d'émission lorsque celles-ci auront été renseignées par les contributeurs et éditeurs de l'étude. Par défaut, seules les émissions validées apparaissent au sein de vos résultats, mais vous pouvez changer ce comportement via le menu \"Paramètres\".",
+    "validatedOnlyDescription": "Pour chaque Empreinte, un ou plusieurs validateurs peuvent être définis. Ceux-ci ont la responsabilité de valider les sources d'émission lorsque celles-ci auront été renseignées par les contributeurs et éditeurs de l'étude. Par défaut, seules les émissions validées apparaissent au sein de vos résultats, mais vous pouvez changer ce comportement via le menu \"Paramètres\".",
     "selectSite": "Avant de remplir les données, choisissez un cinéma",
     "navigation": {
       "framing": "Données générales",
       "organizations": "Mes cinémas",
       "team": "Mes collaborateurs",
-      "accounting": "Mes Bilans"
+      "accounting": "Mes Empreintes"
     },
     "new": {
-      "studyDates": "Année de référence du Bilan"
+      "studyDates": "Année de référence de l’Empreinte"
     },
     "perimeter": {
       "editSites": "Modifier la liste de cinémas",
@@ -55,7 +55,7 @@
       "export": "Exporter mes cinémas"
     },
     "results": {
-      "info": "Cette empreinte carbone simplifiée vise à estimer les émissions de gaz à effet de serre de votre activité, et par conséquent votre contribution au dérèglement climatique ainsi que vos potentielles dépendance aux énergies fossiles qui sont des vulnérabilités. \n\nL'Union Européenne s'est engagée, en ratifiant l'Accord de Paris, à la neutralité carbone d'ici 2050. Pour contribuer à cet objectif, votre cinéma devrait réduire son impact de 5% par an. \n\nNous vous invitons donc à refaire cette empreinte carbone simplifiée l'année prochaine pour vérifier que vous êtes sur la bonne trajectoire !"
+      "info": "Cette Empreinte carbone simplifiée vise à estimer les émissions de gaz à effet de serre de votre activité, et par conséquent votre contribution au dérèglement climatique ainsi que vos potentielles dépendance aux énergies fossiles qui sont des vulnérabilités. \n\nL'Union Européenne s'est engagée, en ratifiant l'Accord de Paris, à la neutralité carbone d'ici 2050. Pour contribuer à cet objectif, votre cinéma devrait réduire son impact de 5% par an. \n\nNous vous invitons donc à refaire cette Empreinte carbone simplifiée l'année prochaine pour vérifier que vous êtes sur la bonne trajectoire !"
     },
     "rights": {
       "title": "Données générales de l'étude : {name}"
@@ -99,9 +99,9 @@
   },
   "checklist": {
     "title": "Bien démarrer sur COUNT",
-    "AddClientDetails": "Ajouter votre premier client afin de commencer vos Bilans",
-    "CreateFirstStudy": "Créer votre premier Bilan",
-    "CreateFirstStudyDetails": "C'est parti pour votre premier Bilan ! Remplissez les premières informations comme la date, le nom...",
+    "AddClientDetails": "Ajouter votre premier client afin de commencer vos Empreintes",
+    "CreateFirstStudy": "Créer votre première Empreinte",
+    "CreateFirstStudyDetails": "C'est parti pour votre première Empreinte ! Remplissez les premières informations comme la date, le nom...",
     "CreateFirstEmissionSource": "Répondez aux premières questions",
     "CreateFirstEmissionSourceDetails": "Rendez-vous dans le premier poste/sous poste que vous souhaitez renseigner ! Répondez aux questions.",
     "finished": "Vous êtes prêt à commencer votre utilisation du COUNT ! N'hésitez pas à consulter la <faq>FAQ</faq> ou à nous contacter en cas de besoin."


### PR DESCRIPTION
# 📝 Contexte

Le terme `Bilan` est utilisé par et pour `BC+` mais l’environnement `CUT` souhaite utiliser le terme `Empreinte`

# 💡 Solution proposée

Remplacer le mot `Bilan` dans tout le fichier de traduction pour `CUT`

# ✅ Check-list

- [  ] 🧹 Code respecte les conventions
- [*] 🔄 Branche synchronisée avec la branche principale

# 🔗 Références
#1333 