### PR TITLE
L’unité `KEURO` n’est pas géré pour CUT 

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "cypress:gui": "cypress open",
     "db:test:reset": "dotenv -e .env.test -- prisma migrate reset --force",
     "seed:import": "prisma db seed -- -i",
+    "question:import:google": "npx tsx src/scripts/cut/question/add.ts -s google -f",
+    "question:import:excel": "npx tsx src/scripts/cut/question/add.ts -f",
     "user:import": "tsx src/scripts/ftp/importUsers.ts"
   },
   "prisma": {

--- a/src/scripts/cut/question/utils.ts
+++ b/src/scripts/cut/question/utils.ts
@@ -73,7 +73,7 @@ export function validateRow(
   const titre = generateIdIntern(row[HEADERS.TITRE])
   const label = row[HEADERS.QUESTION]
   const type = row[HEADERS.TYPE] === '' ? QuestionType.TEXT : row[HEADERS.TYPE].toUpperCase()
-  const unit = row[HEADERS.UNIT]
+  const unit = row[HEADERS.UNIT].toUpperCase()
   const subPost = enumMap[normalizeLabel(row[HEADERS.SUB_POST])]
 
   const titreError = checkRequiredField(

--- a/src/services/unit.ts
+++ b/src/services/unit.ts
@@ -14,6 +14,7 @@ const UnitCommon = {
   METER: Unit.METER,
   GO: Unit.GO,
   KG: Unit.KG,
+  KEURO: Unit.KEURO,
 }
 
 export const BCUnit = {
@@ -30,7 +31,6 @@ export const BCUnit = {
   HA_YEAR: Unit.HA_YEAR,
   HA_CLEMENTINE: Unit.HA_CLEMENTINE,
   HOUR: Unit.HOUR,
-  KEURO: Unit.KEURO,
   KEURO_2019_HT: Unit.KEURO_2019_HT,
   KEURO_2020_HT: Unit.KEURO_2020_HT,
   KEURO_2021_HT: Unit.KEURO_2021_HT,


### PR DESCRIPTION
# 📝 Contexte

Lors de l’importations des questions dans l’environnements `CUT`, nous voulons que l’unité `KEURO` soit disponible

# 💡 Solution proposée

- Déplacer l’unité souhaité de `BCUnit` à `CommonUnit` permettant l’utilisation de `KEURO` dans les deux environnements
- De plus, lors de l’import mettre l’unité reçu du fichier (excel ou csv) en majuscule pour contrer les potentiels erreurs humaines.
- Ajouter une commande dans le `package.json` pour simplifier l’import des questions

# ✅ Check-list

- [x] 🧹 Code respecte les conventions
- [x] 🔄 Branche synchronisée avec la branche principale

# 🔗 Références
- #1437 