### PR TITLE
La gestion des calculs hardcodés contenaient des `idIntern` erronés

### DIFF
--- a/src/constants/emissionFactorMap.ts
+++ b/src/constants/emissionFactorMap.ts
@@ -346,10 +346,6 @@ export const emissionFactorMap: Record<string, EmissionFactorInfo> = {
     },
   },
   // CommunicationDigitale
-  'combien-de-newsletters-ont-ete-envoyees': { emissionFactorImportedId: '120' },
-  'combien-de-caissons-daffichage-dynamique-sont-presents-dans-le-cinema': { emissionFactorImportedId: '121' },
-  'combien-decrans-se-trouvent-dans-les-espaces-de-circulation': { emissionFactorImportedId: '27006' },
-  'le-cinema-dispose-t-il-dun-affichage-exterieur-si-oui-quelle-surface': { emissionFactorImportedId: '122' },
   [NEWSLETTER_QUESTION_ID]: {
     emissionFactorImportedId: '120',
     isSpecial: true,
@@ -360,6 +356,9 @@ export const emissionFactorMap: Record<string, EmissionFactorInfo> = {
     isSpecial: true,
     relatedQuestions: [NEWSLETTER_QUESTION_ID],
   },
+  'combien-de-caissons-daffichage-dynamique-sont-presents-dans-le-cinema': { emissionFactorImportedId: '121' },
+  'combien-decrans-se-trouvent-dans-les-espaces-de-circulation': { emissionFactorImportedId: '27006' },
+  'le-cinema-dispose-t-il-dun-affichage-exterieur-si-oui-quelle-surface': { emissionFactorImportedId: '122' },
   // CaissesEtBornes
   'de-combien-de-bornes-de-caisse-libre-service-dispose-le-cinema': { emissionFactorImportedId: '123' },
   'de-combien-de-systemes-de-caisse-classique-dispose-le-cinema': { emissionFactorImportedId: '124' },


### PR DESCRIPTION
# 📝 Contexte

Les questions était non fonctionnel car l’`idIntern` dans la gestion des calculs hardcoder contenait des erreurs :
- Combien de caissons d’affichage dynamique sont présents dans le cinéma ?
- Combien d’écrans se trouvent dans les espaces de circulation ?
- Le cinéma dispose-t-il d’un affichage extérieur ? Si oui, quelle surface

# 💡 Solution proposée

Remplacer les idInterns erronés par les `idIntern` valide.

# ✅ Check-list

- [x] 🧹 Code respecte les conventions
- [x] 🔄 Branche synchronisée avec la branche principale

# 🔗 Références
- #1433 