### PR TITLE
Tilt/feature/960 tag emission source

### DIFF
--- a/prisma/schema/migrations/20250721081153_emission_source_tag_for_study/migration.sql
+++ b/prisma/schema/migrations/20250721081153_emission_source_tag_for_study/migration.sql
@@ -1,0 +1,20 @@
+-- AlterTable
+ALTER TABLE "study_emission_sources" ADD COLUMN     "emission_source_tag_id" TEXT;
+
+-- CreateTable
+CREATE TABLE "emission_source_tag" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "study_id" TEXT NOT NULL,
+
+    CONSTRAINT "emission_source_tag_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "emission_source_tag_name_study_id_key" ON "emission_source_tag"("name", "study_id");
+
+-- AddForeignKey
+ALTER TABLE "emission_source_tag" ADD CONSTRAINT "emission_source_tag_study_id_fkey" FOREIGN KEY ("study_id") REFERENCES "studies"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "study_emission_sources" ADD CONSTRAINT "study_emission_sources_emission_source_tag_id_fkey" FOREIGN KEY ("emission_source_tag_id") REFERENCES "emission_source_tag"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema/study.prisma
+++ b/prisma/schema/study.prisma
@@ -73,6 +73,19 @@ model OpeningHours {
   @@map("opening_hours")
 }
 
+model EmissionSourceTag {
+  id String @id @default(uuid())
+
+  name String
+
+  studyId             String                @map("study_id")
+  study               Study                 @relation(fields: [studyId], references: [id])
+  StudyEmissionSource StudyEmissionSource[]
+
+  @@unique([name, studyId])
+  @@map("emission_source_tag")
+}
+
 model Study {
   id      String  @id @default(uuid())
   oldBCId String? @map("old_bc_id")
@@ -100,6 +113,8 @@ model Study {
   flows           Document[]
 
   emissionFactorVersions StudyEmissionFactorVersion[]
+
+  emissionSourceTags EmissionSourceTag[]
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
@@ -203,6 +218,9 @@ model StudyEmissionSource {
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
 
   answerEmissionSources AnswerEmissionSource[]
+
+  emissionSourceTagId String?            @map("emission_source_tag_id")
+  emissionSourceTag   EmissionSourceTag? @relation(fields: [emissionSourceTagId], references: [id])
 
   @@map("study_emission_sources")
 }

--- a/src/components/pages/StudyPerimeter.tsx
+++ b/src/components/pages/StudyPerimeter.tsx
@@ -11,6 +11,7 @@ import { UserSession } from 'next-auth'
 import { getTranslations } from 'next-intl/server'
 import Block from '../base/Block'
 import Breadcrumbs from '../breadcrumbs/Breadcrumbs'
+import EmissionSourceTags from '../study/perimeter/EmissionSourceTags'
 import StudyFlow from '../study/perimeter/flow/StudyFlow'
 import StudyPerimeter from '../study/perimeter/StudyPerimeter'
 
@@ -57,6 +58,7 @@ const StudyPerimeterPage = async ({ study, organizationVersion, user }: Props) =
           caUnit={caUnit}
         />
       </Block>
+      <EmissionSourceTags studyId={study.id} />
       <StudyFlow
         canAddFlow={canAddFlow}
         documents={documents}

--- a/src/components/study/perimeter/EmissionSourceTag.module.css
+++ b/src/components/study/perimeter/EmissionSourceTag.module.css
@@ -1,0 +1,10 @@
+.tags {
+  display: flex;
+  gap: 0.5rem;
+  overflow-x: scroll;
+  margin-bottom: 0.5rem;
+}
+
+.form {
+  max-width: 400px;
+}

--- a/src/components/study/perimeter/EmissionSourceTags.tsx
+++ b/src/components/study/perimeter/EmissionSourceTags.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import Block from '@/components/base/Block'
+import Button from '@/components/base/Button'
+import Form from '@/components/base/Form'
+import { FormTextField } from '@/components/form/TextField'
+import {
+  createEmissionSourceTag,
+  deleteEmissionSourceTag,
+  getEmissionSourceTagsByStudyId,
+} from '@/services/serverFunctions/emissionSource'
+import {
+  NewEmissionSourceTagCommand,
+  NewEmissionSourceTagCommandValidation,
+} from '@/services/serverFunctions/emissionSource.command'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Chip, FormControl } from '@mui/material'
+import { EmissionSourceTag } from '@prisma/client'
+import { useTranslations } from 'next-intl'
+import { useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import styles from './EmissionSourceTag.module.css'
+
+interface Props {
+  studyId: string
+}
+
+const EmissionSourceTags = ({ studyId }: Props) => {
+  const t = useTranslations('study.perimeter')
+
+  const [tags, setTags] = useState<EmissionSourceTag[]>([])
+
+  useEffect(() => {
+    getEmissionSourceTags()
+  }, [studyId])
+
+  const getEmissionSourceTags = async () => {
+    const response = await getEmissionSourceTagsByStudyId(studyId)
+    if (response.success && response.data) {
+      setTags(response.data)
+    }
+  }
+
+  const { getValues, control, handleSubmit, setValue } = useForm<NewEmissionSourceTagCommand>({
+    resolver: zodResolver(NewEmissionSourceTagCommandValidation),
+    mode: 'onSubmit',
+    reValidateMode: 'onChange',
+    defaultValues: {
+      studyId,
+    },
+  })
+
+  const onSubmit = async () => {
+    const createTag = await createEmissionSourceTag(getValues())
+    if (createTag.success) {
+      setTags((prevTags) => [...prevTags, createTag.data])
+      setValue('name', '')
+    }
+  }
+
+  const onDelete = async (tagId: string) => {
+    const deleteTag = await deleteEmissionSourceTag(tagId)
+    if (deleteTag.success) {
+      setTags((prevTags) => prevTags.filter((tag) => tag.id !== tagId))
+    }
+  }
+
+  return (
+    <Block title={t('emissionSourceTags')}>
+      {tags.length > 0 && (
+        <div className={styles.tags}>
+          {tags.map((tag) => (
+            <Chip onDelete={() => onDelete(tag.id)} color="primary" key={tag.id} label={tag.name} />
+          ))}
+        </div>
+      )}
+
+      <Form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
+        <FormControl>
+          <FormTextField
+            control={control}
+            translation={t}
+            name="name"
+            label={t('emissionSourceTag')}
+            placeholder={t('emissionSourceTagsPlaceholder')}
+            data-testid="create-emission-source-tags"
+          />
+          <Button data-testid="submit-button" type="submit" fullWidth>
+            {t('validate')}
+          </Button>
+        </FormControl>
+      </Form>
+    </Block>
+  )
+}
+
+export default EmissionSourceTags

--- a/src/constants/emissionSourceTags.ts
+++ b/src/constants/emissionSourceTags.ts
@@ -1,0 +1,9 @@
+import { Environment } from '@prisma/client'
+
+export const defaultEmissionSourceTags = {
+  [Environment.TILT]: [
+    { name: 'Périmètre Interne' },
+    { name: 'Périmètre Bénévoles' },
+    { name: 'Périmètre Bénéficiaires' },
+  ],
+}

--- a/src/db/emissionSource.ts
+++ b/src/db/emissionSource.ts
@@ -18,3 +18,10 @@ export const updateEmissionSourceOnStudy = (
   })
 
 export const deleteEmissionSourceOnStudy = (id: string) => prismaClient.studyEmissionSource.delete({ where: { id } })
+
+export const createEmissionSourceTagOnStudy = (emissionSourceTag: Prisma.EmissionSourceTagCreateInput) =>
+  prismaClient.emissionSourceTag.create({
+    data: emissionSourceTag,
+  })
+
+export const deleteEmissionSourceTagOnStudy = (id: string) => prismaClient.emissionSourceTag.delete({ where: { id } })

--- a/src/db/study.ts
+++ b/src/db/study.ts
@@ -177,6 +177,13 @@ const fullStudyInclude = {
       },
     },
   },
+  emissionSourceTags: {
+    select: {
+      id: true,
+      name: true,
+      studyId: true,
+    },
+  },
 } satisfies Prisma.StudyInclude
 
 const normalizeAllowedUsers = (

--- a/src/db/study.ts
+++ b/src/db/study.ts
@@ -87,6 +87,13 @@ const fullStudyInclude = {
           },
         },
       },
+      emissionSourceTag: {
+        select: {
+          id: true,
+          name: true,
+          studyId: true,
+        },
+      },
     },
     orderBy: [{ createdAt: 'asc' }, { name: 'asc' }],
   },

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -536,6 +536,10 @@
       "validSites": "Validate changes",
       "exports": "Exports",
       "control": "Control mode",
+      "emissionSourceTags": "Tags",
+      "emissionSourceTag": "Create a tag",
+      "emissionSourceTagsPlaceholder": "Your tag",
+      "validate": "Validate",
       "deleteDialog": {
         "accept": "Yes",
         "decline": "No",
@@ -607,6 +611,7 @@
       "sourceSurface": "Surface (ha)",
       "sourceUnit": "Emission source unit",
       "sourceValue": "Emission source value",
+      "sourceTag": "Emission source tag",
       "subPost": "Sub post",
       "total": "Total",
       "uncertainty": "Uncertainty",
@@ -1359,7 +1364,9 @@
       "quality": "Quality",
       "expand": "Expand qualities",
       "shrink": "Shrink qualities",
-      "comment": "Comments"
+      "comment": "Comments",
+      "tag": "Tag",
+      "create": "Create {tag}"
     },
     "cut": {
       "form": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -536,6 +536,10 @@
       "validSites": "Valider les changements",
       "exports": "Exports",
       "control": "Mode de contrôle",
+      "emissionSourceTags": "Tags",
+      "emissionSourceTag": "Créer un tag",
+      "emissionSourceTagsPlaceholder": "Votre tag",
+      "validate": "Valider",
       "deleteDialog": {
         "accept": "Oui",
         "decline": "Non",
@@ -607,6 +611,7 @@
       "sourceSurface": "Surface (ha)",
       "sourceUnit": "Unité de la source d'émission",
       "sourceValue": "Valeur de la source d'émission",
+      "sourceTag": "Tag de la source d'émission",
       "subPost": "Sous poste",
       "total": "Total",
       "uncertainty": "Incertitude",
@@ -1359,7 +1364,9 @@
       "quality": "Qualité",
       "expand": "Développer les qualités",
       "shrink": "Simplifier les qualités",
-      "comment": "Commentaires"
+      "comment": "Commentaires",
+      "tag": "Tag",
+      "create": "Créer {tag}"
     },
     "cut": {
       "form": {

--- a/src/services/emissionSource.test.ts
+++ b/src/services/emissionSource.test.ts
@@ -42,6 +42,7 @@ const defaultEmissionSource = {
   depreciationPeriod: null,
   duration: null,
   hectare: null,
+  emissionSourceTag: null,
 } satisfies FullStudy['emissionSources'][0]
 
 describe('emissionSource Service', () => {

--- a/src/services/permissions/emissionSource.ts
+++ b/src/services/permissions/emissionSource.ts
@@ -65,6 +65,8 @@ export const canCreateEmissionSource = async (account: AccountWithUser, emission
   switch (account.environment) {
     case 'BC':
       return canCreateEmissionSourceBC(account, emissionSource)
+    case 'TILT':
+      return canCreateEmissionSourceBC(account, emissionSource)
     case 'CUT':
       return canCreateEmissionSourceCUT(account, emissionSource)
     default:
@@ -132,6 +134,8 @@ export const canUpdateEmissionSource = async (
 ) => {
   switch (account.environment) {
     case 'BC':
+      return canUpdateEmissionSourceBC(account, emissionSource, change, study)
+    case 'TILT':
       return canUpdateEmissionSourceBC(account, emissionSource, change, study)
     case 'CUT':
       return canUpdateEmissionSourceCUT(account, emissionSource)

--- a/src/services/permissions/environment.ts
+++ b/src/services/permissions/environment.ts
@@ -18,3 +18,6 @@ export const hasAccessToCreateOrganization = (environment: Environment) => envir
 
 export const hasAccessToDuplicateStudy = (environment: Environment) =>
   ([Environment.BC, Environment.TILT] as Environment[]).includes(environment)
+
+export const hasAccessToCreateEmissionSourceTag = async (environment: Environment) =>
+  ([Environment.BC, Environment.TILT] as Environment[]).includes(environment)

--- a/src/services/permissions/study.ts
+++ b/src/services/permissions/study.ts
@@ -126,6 +126,8 @@ export const canCreateSpecificStudy = async (
       return canCreateSpecificStudyCUT(user.accountId, study, organizationVersionId)
     case Environment.BC:
       return canCreateSpecificStudyBC(user.accountId, study, organizationVersionId)
+    case Environment.TILT:
+      return canCreateSpecificStudyBC(user.accountId, study, organizationVersionId)
     default:
       return false
   }

--- a/src/services/serverFunctions/emissionSource.command.ts
+++ b/src/services/serverFunctions/emissionSource.command.ts
@@ -38,6 +38,7 @@ export const UpdateEmissionSourceCommandValidation = z.object({
   feGeographicRepresentativeness: z.number().nullable().optional(),
   feTemporalRepresentativeness: z.number().nullable().optional(),
   feCompleteness: z.number().nullable().optional(),
+  emissionSourceTagId: z.string().optional(),
 })
 export type UpdateEmissionSourceCommand = z.infer<typeof UpdateEmissionSourceCommandValidation>
 

--- a/src/services/serverFunctions/emissionSource.command.ts
+++ b/src/services/serverFunctions/emissionSource.command.ts
@@ -40,3 +40,10 @@ export const UpdateEmissionSourceCommandValidation = z.object({
   feCompleteness: z.number().nullable().optional(),
 })
 export type UpdateEmissionSourceCommand = z.infer<typeof UpdateEmissionSourceCommandValidation>
+
+export const NewEmissionSourceTagCommandValidation = z.object({
+  studyId: z.string(),
+  name: z.string(),
+})
+
+export type NewEmissionSourceTagCommand = z.infer<typeof NewEmissionSourceTagCommandValidation>

--- a/src/services/serverFunctions/emissionSource.ts
+++ b/src/services/serverFunctions/emissionSource.ts
@@ -207,7 +207,7 @@ export const createEmissionSourceTag = async ({ studyId, name }: NewEmissionSour
       throw new Error(NOT_AUTHORIZED)
     }
 
-    await createEmissionSourceTagOnStudy({
+    return await createEmissionSourceTagOnStudy({
       study: { connect: { id: studyId } },
       name,
     })

--- a/src/services/serverFunctions/study.ts
+++ b/src/services/serverFunctions/study.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { StudyContributorDeleteParams } from '@/components/study/rights/StudyContributorsTable'
+import { defaultEmissionSourceTags } from '@/constants/emissionSourceTags'
 import {
   AccountWithUser,
   addAccount,
@@ -213,6 +214,15 @@ export const createStudyCommand = async (
     const userCAUnit = (await getUserApplicationSettings(session.user.accountId))?.caUnit
     const caUnit = CA_UNIT_VALUES[userCAUnit || defaultCAUnit]
 
+    const emissionSourceTags = {
+      createMany: {
+        data:
+          session.user.environment in defaultEmissionSourceTags
+            ? defaultEmissionSourceTags[session.user.environment as keyof typeof defaultEmissionSourceTags]
+            : [],
+      },
+    }
+
     const study = {
       ...command,
       createdBy: { connect: { id: session.user.accountId } },
@@ -251,6 +261,7 @@ export const createStudyCommand = async (
             .filter((site) => site !== undefined),
         },
       },
+      emissionSourceTags,
     } satisfies Prisma.StudyCreateInput
 
     if (!(await canCreateSpecificStudy(session.user, study, organizationVersionId))) {

--- a/src/services/study.ts
+++ b/src/services/study.ts
@@ -109,6 +109,7 @@ const getEmissionSourcesRows = (
       'sourceDuration',
       'sourceUnit',
       'sourceQuality',
+      'sourceTag',
       'activityDataValue',
       'activityDataUnit',
       'activityDataQuality',
@@ -137,6 +138,7 @@ const getEmissionSourcesRows = (
         initCols.push(tPost(emissionSource.subPost))
       }
       const emissionSourceSD = getStandardDeviation(emissionSource)
+      console.log('CONSOLE', emissionSourceSD)
 
       const withDeprecation = subPostsByPost[Post.Immobilisations].includes(emissionSource.subPost)
 
@@ -153,6 +155,7 @@ const getEmissionSourcesRows = (
           isCAS(emissionSource) ? emissionSource.duration || '1' : ' ',
           tResultUnits(resultsUnit),
           emissionSourceSD ? getQuality(getStandardDeviationRating(emissionSourceSD), tQuality) : '',
+          emissionSource.emissionSourceTag?.name || '',
           emissionSource.value || '0',
           emissionFactor?.unit ? tUnit(emissionFactor.unit) : '',
           getQuality(getQualityRating(emissionSource), tQuality),

--- a/src/tests/utils/models/emissionSource.ts
+++ b/src/tests/utils/models/emissionSource.ts
@@ -35,6 +35,7 @@ export const mockedDbEmissionSource = {
   feGeographicRepresentativeness: null,
   feTemporalRepresentativeness: null,
   feCompleteness: null,
+  emissionSourceTagId: null,
 }
 
 export const getMockedEmissionSource = (props?: Partial<StudyEmissionSource>): StudyEmissionSource => ({

--- a/src/tests/utils/models/study.ts
+++ b/src/tests/utils/models/study.ts
@@ -34,6 +34,7 @@ export const mockedFullStudy = {
   emissionFactorVersions: [],
   exports: [],
   organizationVersion: mockedOrganizationVersion,
+  emissionSourceTags: [],
 }
 
 export const mockedStudySite = {


### PR DESCRIPTION
https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/960

# Infos / remarques

Au final je n'ai pas trop vu l'utilité de rajouter des tests @cmolle  dis moi ce que tu en penses 🤔

J'ai aussi ajouté quelques autorisations au utilisateurs TILT dans la PR (dont ils avaient besoin pour créer les études et les souces d'émission), à voir si c'est ok que ce soit la même fonction que le BC mais je suppose que oui

Hésitez pas à me faire des remarques sur le front je vous mets les screen ci dessous

# Front
## Perimeter
Depuis cette page on peut voir, créer et supprimer les tags
<img width="1780" height="802" alt="image" src="https://github.com/user-attachments/assets/4cdb8e9c-ad42-4393-909c-78642051d776" />

## Source d'émission
Ici on a un autocomplete pour selectionner un tag, j'ai pris un petit temps pour aussi rajouter la possibilité de créer un nouveau tag d'ici

<img width="1287" height="442" alt="image" src="https://github.com/user-attachments/assets/f0031090-4292-4df6-91ba-88919a5effcd" />
