### PR TITLE
feat: tilt sample button for studyFlow

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -649,7 +649,9 @@
       "noFlows": "No mapping to display",
       "notAuthorized": "Action not authorized",
       "removeFlow": "Remove mapping",
-      "Not authorized": "You are not allowed to do this action"
+      "Not authorized": "You are not allowed to do this action",
+      "info": "You can download a sample flow mapping to help you build your own. Afterwards, if you wish to submit your flow mapping so that other users can use it as an example and help other associations, please send it to methodologie@abc-transitionbascarbone.fr",
+      "downloadSample": "Download sample"
     },
     "delete": {
       "cancel": "Cancel",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -649,7 +649,9 @@
       "noFlows": "Aucune cartographie des flux à afficher",
       "notAuthorized": "Action non authorisée",
       "removeFlow": "Supprimer la cartographie",
-      "Not authorized": "Vous n'avez pas les droits pour effectuer cette action"
+      "Not authorized": "Vous n'avez pas les droits pour effectuer cette action",
+      "info": "Vous pouvez télécharger un exemple de cartographie des flux pour vous aider à construire la votre. Par la suite, si vous souhaitez soumettre votre cartographie des flux pour que d'autres utilisateurs puissent l'utiliser en exemple et aider d'autres association, merci de la soumettre à methodologie@abc-transitionbascarbone.fr",
+      "downloadSample": "Télécharger un exemple"
     },
     "delete": {
       "cancel": "Annuler",

--- a/src/services/permissions/environment.ts
+++ b/src/services/permissions/environment.ts
@@ -21,3 +21,6 @@ export const hasAccessToDuplicateStudy = (environment: Environment) =>
 
 export const hasAccessToCreateEmissionSourceTag = async (environment: Environment) =>
   ([Environment.BC, Environment.TILT] as Environment[]).includes(environment)
+
+export const hasAccessToStudyFlowExample = (environment: Environment) =>
+  ([Environment.TILT] as Environment[]).includes(environment)

--- a/src/services/permissions/study.ts
+++ b/src/services/permissions/study.ts
@@ -356,7 +356,7 @@ export const canReadStudyDetail = async (user: UserSession, study: FullStudy) =>
   return true
 }
 
-const canAccessStudyFlows = async (studyId: string) => {
+export const canAccessStudyFlows = async (studyId: string) => {
   const session = await dbActualizedAuth()
 
   if (!session || !session.user) {

--- a/src/services/serverFunctions/studyFlow.ts
+++ b/src/services/serverFunctions/studyFlow.ts
@@ -1,0 +1,15 @@
+'use server'
+
+import { withServerResponse } from '@/utils/serverResponse'
+import { canAccessStudyFlows } from '../permissions/study'
+import { getFileUrlFromBucket } from './scaleway'
+
+export const getStudyFlowSampleDocumentUrl = async (studyId: string) =>
+  withServerResponse('getStudyFlowSampleDocumentUrl', async () => {
+    if (!(await canAccessStudyFlows(studyId))) {
+      return ''
+    }
+    console.log('proaacess', process.env.STUDY_FLOW_EXAMPLE_KEY)
+    const res = await getFileUrlFromBucket(process.env.STUDY_FLOW_EXAMPLE_KEY || '')
+    return res.success ? res.data : ''
+  })


### PR DESCRIPTION
- https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/1455

Je n'ai pas vraiment pu tester en local si le bouton de téléchargement fonctionne car je pense que scaleway ne m'y autorise pas

J'ai ajouté une variable d'environnement avec la clef du fichier d'exemple, dites moi si c'est ok pour vous, voilà la clef à mettre sur staging :

`STUDY_FLOW_EXAMPLE_KEY=dd3e3d12-d875-4418-85a7-9f33b6eecfad`