### PR TITLE
Tilt/feature/960 better tag emission source

### DIFF
--- a/prisma/schema/migrations/20250728123925_color_option_for_tag/migration.sql
+++ b/prisma/schema/migrations/20250728123925_color_option_for_tag/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "emission_source_tag" ADD COLUMN     "color" TEXT;

--- a/prisma/schema/migrations/20250729071546_multiple_tag_on_emission_source/migration.sql
+++ b/prisma/schema/migrations/20250729071546_multiple_tag_on_emission_source/migration.sql
@@ -1,0 +1,28 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `emission_source_tag_id` on the `study_emission_sources` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "study_emission_sources" DROP CONSTRAINT "study_emission_sources_emission_source_tag_id_fkey";
+
+-- AlterTable
+ALTER TABLE "study_emission_sources" DROP COLUMN "emission_source_tag_id";
+
+-- CreateTable
+CREATE TABLE "_TagToEmissionSource" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+
+    CONSTRAINT "_TagToEmissionSource_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE INDEX "_TagToEmissionSource_B_index" ON "_TagToEmissionSource"("B");
+
+-- AddForeignKey
+ALTER TABLE "_TagToEmissionSource" ADD CONSTRAINT "_TagToEmissionSource_A_fkey" FOREIGN KEY ("A") REFERENCES "emission_source_tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_TagToEmissionSource" ADD CONSTRAINT "_TagToEmissionSource_B_fkey" FOREIGN KEY ("B") REFERENCES "study_emission_sources"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema/study.prisma
+++ b/prisma/schema/study.prisma
@@ -76,7 +76,8 @@ model OpeningHours {
 model EmissionSourceTag {
   id String @id @default(uuid())
 
-  name String
+  name  String
+  color String?
 
   studyId             String                @map("study_id")
   study               Study                 @relation(fields: [studyId], references: [id])

--- a/prisma/schema/study.prisma
+++ b/prisma/schema/study.prisma
@@ -81,7 +81,7 @@ model EmissionSourceTag {
 
   studyId             String                @map("study_id")
   study               Study                 @relation(fields: [studyId], references: [id])
-  StudyEmissionSource StudyEmissionSource[]
+  StudyEmissionSource StudyEmissionSource[] @relation("TagToEmissionSource")
 
   @@unique([name, studyId])
   @@map("emission_source_tag")
@@ -220,8 +220,7 @@ model StudyEmissionSource {
 
   answerEmissionSources AnswerEmissionSource[]
 
-  emissionSourceTagId String?            @map("emission_source_tag_id")
-  emissionSourceTag   EmissionSourceTag? @relation(fields: [emissionSourceTagId], references: [id])
+  emissionSourceTags EmissionSourceTag[] @relation("TagToEmissionSource")
 
   @@map("study_emission_sources")
 }

--- a/src/components/study/EmissionSource.tsx
+++ b/src/components/study/EmissionSource.tsx
@@ -88,7 +88,7 @@ const EmissionSource = ({
   const canValidate = userRoleOnStudy === StudyRole.Validator
 
   const update = useCallback(
-    async (key: Path<UpdateEmissionSourceCommand>, value: string | number | boolean | null) => {
+    async (key: Path<UpdateEmissionSourceCommand>, value: string | number | boolean | null | string[]) => {
       if (key) {
         if (value === emissionSource[key as keyof typeof emissionSource]) {
           return

--- a/src/components/study/EmissionSourceForm.tsx
+++ b/src/components/study/EmissionSourceForm.tsx
@@ -21,7 +21,7 @@ import AddIcon from '@mui/icons-material/Add'
 import CopyIcon from '@mui/icons-material/ContentCopy'
 import EditIcon from '@mui/icons-material/Edit'
 import HideIcon from '@mui/icons-material/VisibilityOff'
-import { Autocomplete, FormControl, InputLabel, MenuItem, TextField } from '@mui/material'
+import { Autocomplete, Chip, FormControl, InputLabel, MenuItem, TextField } from '@mui/material'
 import {
   EmissionSourceCaracterisation,
   EmissionSourceTag,
@@ -49,7 +49,7 @@ import EmissionSourceFactor from './EmissionSourceFactor'
 import emissionFactorStyles from './EmissionSourceFactor.module.css'
 import QualitySelectGroup from './QualitySelectGroup'
 
-type Option = { label: string; value: string }
+type Option = { label: string; value: string; color?: string | null }
 
 const getDetail = (metadata: Exclude<EmissionFactorWithMetaData['metaData'], undefined>) =>
   [metadata.attribute, metadata.comment, metadata.location].filter(Boolean).join(' - ')
@@ -389,15 +389,32 @@ const EmissionSourceForm = ({
           multiple
           disabled={!canEdit}
           data-testid="emission-source-tag"
-          options={tags.map((tag) => ({ label: tag.name, value: tag.id }))}
-          value={emissionSource.emissionSourceTags.map((tag) => ({ label: tag.name, value: tag.id }))}
+          options={tags.map((tag) => ({ label: tag.name, value: tag.id, color: tag.color }))}
+          value={emissionSource.emissionSourceTags.map((tag) => ({ label: tag.name, value: tag.id, color: tag.color }))}
           onChange={(_, options: Option[]) => {
             update(
               'emissionSourceTags',
               options.map((tag) => tag.value),
             )
           }}
+          renderOption={(props, option) => {
+            const { key, ...optionProps } = props
+
+            return (
+              <li key={key} {...optionProps}>
+                <Chip label={option.label} size="small" sx={{ bgcolor: option.color }} />
+              </li>
+            )
+          }}
           renderInput={(params) => <TextField {...params} label={t('form.tag')} />}
+          renderValue={(value: Option[], getItemProps) =>
+            value.map((option: Option, index: number) => {
+              const { key, ...itemProps } = getItemProps({ index })
+              return (
+                <Chip variant="outlined" label={option.label} key={key} sx={{ bgcolor: option.color }} {...itemProps} />
+              )
+            })
+          }
         />
         <div className={classNames(styles.gapped, styles.optionnalFields, 'grow flex')}>
           <TextField

--- a/src/components/study/perimeter/EmissionSourceTag.module.css
+++ b/src/components/study/perimeter/EmissionSourceTag.module.css
@@ -1,10 +1,19 @@
 .tags {
   display: flex;
   gap: 0.5rem;
-  overflow-x: scroll;
   margin-bottom: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .form {
-  max-width: 400px;
+  max-width: 300px;
+}
+
+.colorInput {
+  max-height: fit-content;
+}
+
+.preview {
+  align-self: center;
+  margin-bottom: 1rem;
 }

--- a/src/components/study/perimeter/EmissionSourceTag.module.css
+++ b/src/components/study/perimeter/EmissionSourceTag.module.css
@@ -1,8 +1,17 @@
 .tags {
-  display: flex;
+  display: grid;
+  grid-auto-flow: column;
+  grid-template-rows: repeat(3, auto);
   gap: 0.5rem;
-  margin-bottom: 0.5rem;
-  flex-wrap: wrap;
+  max-height: 8rem;
+  overflow-x: auto;
+  padding-bottom: 0.5rem;
+  width: max-content;
+}
+
+.tag {
+  max-width: 250px;
+  width: fit-content;
 }
 
 .form {
@@ -13,7 +22,15 @@
   max-height: fit-content;
 }
 
+.container {
+  display: flex;
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+  justify-content: space-between;
+  width: max-content;
+  gap: 1rem;
+}
+
 .preview {
   align-self: center;
-  margin-bottom: 1rem;
 }

--- a/src/components/study/perimeter/EmissionSourceTag.module.css
+++ b/src/components/study/perimeter/EmissionSourceTag.module.css
@@ -30,7 +30,3 @@
   width: max-content;
   gap: 1rem;
 }
-
-.preview {
-  align-self: center;
-}

--- a/src/components/study/perimeter/EmissionSourceTags.tsx
+++ b/src/components/study/perimeter/EmissionSourceTags.tsx
@@ -19,7 +19,7 @@ import { Box, Chip, FormControl, MenuItem, Select } from '@mui/material'
 import { EmissionSourceTag } from '@prisma/client'
 import { useTranslations } from 'next-intl'
 import { useEffect, useState } from 'react'
-import { Controller, useForm, useWatch } from 'react-hook-form'
+import { Controller, useForm } from 'react-hook-form'
 import styles from './EmissionSourceTag.module.css'
 
 interface Props {
@@ -52,9 +52,6 @@ const EmissionSourceTags = ({ studyId }: Props) => {
     },
   })
 
-  const name = useWatch({ control, name: 'name', defaultValue: 'Preview' })
-  const color = useWatch({ control, name: 'color', defaultValue: emissionSourceTagColors.GREY })
-
   const onSubmit = async () => {
     const createTag = await createEmissionSourceTag(getValues())
     if (createTag.success) {
@@ -69,8 +66,6 @@ const EmissionSourceTags = ({ studyId }: Props) => {
       setTags((prevTags) => prevTags.filter((tag) => tag.id !== tagId))
     }
   }
-
-  console.log('EmissionSourceTags', tags)
 
   return (
     <Block title={t('emissionSourceTags')}>
@@ -131,7 +126,6 @@ const EmissionSourceTags = ({ studyId }: Props) => {
               placeholder={t('emissionSourceTagsPlaceholder')}
               data-testid="create-emission-source-tags"
             />
-            <Chip className={styles.preview} sx={{ bgcolor: color }} label={name || 'Preview'} />
           </div>
           <Button data-testid="submit-button" type="submit">
             {t('createEmissionSourceTag')}

--- a/src/components/study/perimeter/EmissionSourceTags.tsx
+++ b/src/components/study/perimeter/EmissionSourceTags.tsx
@@ -4,6 +4,7 @@ import Block from '@/components/base/Block'
 import Button from '@/components/base/Button'
 import Form from '@/components/base/Form'
 import { FormTextField } from '@/components/form/TextField'
+import { emissionSourceTagColors } from '@/constants/emissionSourceTags'
 import {
   createEmissionSourceTag,
   deleteEmissionSourceTag,
@@ -14,11 +15,11 @@ import {
   NewEmissionSourceTagCommandValidation,
 } from '@/services/serverFunctions/emissionSource.command'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { Chip, FormControl } from '@mui/material'
+import { Box, Chip, FormControl, MenuItem, Select } from '@mui/material'
 import { EmissionSourceTag } from '@prisma/client'
 import { useTranslations } from 'next-intl'
 import { useEffect, useState } from 'react'
-import { useForm } from 'react-hook-form'
+import { Controller, useForm, useWatch } from 'react-hook-form'
 import styles from './EmissionSourceTag.module.css'
 
 interface Props {
@@ -47,8 +48,12 @@ const EmissionSourceTags = ({ studyId }: Props) => {
     reValidateMode: 'onChange',
     defaultValues: {
       studyId,
+      color: emissionSourceTagColors.GREY,
     },
   })
+
+  const name = useWatch({ control, name: 'name', defaultValue: 'preview' })
+  const color = useWatch({ control, name: 'color', defaultValue: emissionSourceTagColors.GREY })
 
   const onSubmit = async () => {
     const createTag = await createEmissionSourceTag(getValues())
@@ -65,26 +70,63 @@ const EmissionSourceTags = ({ studyId }: Props) => {
     }
   }
 
+  console.log('EmissionSourceTags', tags)
+
   return (
     <Block title={t('emissionSourceTags')}>
       {tags.length > 0 && (
         <div className={styles.tags}>
           {tags.map((tag) => (
-            <Chip onDelete={() => onDelete(tag.id)} color="primary" key={tag.id} label={tag.name} />
+            <Chip onDelete={() => onDelete(tag.id)} sx={{ bgcolor: tag.color }} key={tag.id} label={tag.name} />
           ))}
         </div>
       )}
 
       <Form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
         <FormControl>
-          <FormTextField
-            control={control}
-            translation={t}
-            name="name"
-            label={t('emissionSourceTag')}
-            placeholder={t('emissionSourceTagsPlaceholder')}
-            data-testid="create-emission-source-tags"
-          />
+          <div className="flex justify-between mb-2">
+            <Controller
+              control={control}
+              name="color"
+              defaultValue={emissionSourceTagColors.GREY}
+              render={({ field }) => (
+                <FormControl className="inputContainer">
+                  <div className="mb-2">
+                    <span className="inputLabel bold">{t('color')}</span>
+                  </div>
+                  <Select
+                    className={styles.colorInput}
+                    {...field}
+                    displayEmpty
+                    data-testid="create-emission-source-tag-color"
+                  >
+                    {Object.values(emissionSourceTagColors).map((color) => (
+                      <MenuItem key={color} value={color}>
+                        <Box
+                          sx={{
+                            width: 16,
+                            height: 16,
+                            borderRadius: '50%',
+                            backgroundColor: color,
+                            border: '1px solid #ccc',
+                          }}
+                        />
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              )}
+            />
+            <FormTextField
+              control={control}
+              translation={t}
+              name="name"
+              label={t('emissionSourceTag')}
+              placeholder={t('emissionSourceTagsPlaceholder')}
+              data-testid="create-emission-source-tags"
+            />
+          </div>
+          <Chip className={styles.preview} sx={{ bgcolor: color }} label={name || 'preview'} />
           <Button data-testid="submit-button" type="submit" fullWidth>
             {t('validate')}
           </Button>

--- a/src/components/study/perimeter/EmissionSourceTags.tsx
+++ b/src/components/study/perimeter/EmissionSourceTags.tsx
@@ -52,7 +52,7 @@ const EmissionSourceTags = ({ studyId }: Props) => {
     },
   })
 
-  const name = useWatch({ control, name: 'name', defaultValue: 'preview' })
+  const name = useWatch({ control, name: 'name', defaultValue: 'Preview' })
   const color = useWatch({ control, name: 'color', defaultValue: emissionSourceTagColors.GREY })
 
   const onSubmit = async () => {
@@ -77,14 +77,20 @@ const EmissionSourceTags = ({ studyId }: Props) => {
       {tags.length > 0 && (
         <div className={styles.tags}>
           {tags.map((tag) => (
-            <Chip onDelete={() => onDelete(tag.id)} sx={{ bgcolor: tag.color }} key={tag.id} label={tag.name} />
+            <Chip
+              className={styles.tag}
+              onDelete={() => onDelete(tag.id)}
+              sx={{ bgcolor: tag.color }}
+              key={tag.id}
+              label={tag.name}
+            />
           ))}
         </div>
       )}
 
       <Form onSubmit={handleSubmit(onSubmit)} className={styles.form}>
         <FormControl>
-          <div className="flex justify-between mb-2">
+          <div className={styles.container}>
             <Controller
               control={control}
               name="color"
@@ -121,14 +127,14 @@ const EmissionSourceTags = ({ studyId }: Props) => {
               control={control}
               translation={t}
               name="name"
-              label={t('emissionSourceTag')}
+              label={t('emissionSourceTagLabel')}
               placeholder={t('emissionSourceTagsPlaceholder')}
               data-testid="create-emission-source-tags"
             />
+            <Chip className={styles.preview} sx={{ bgcolor: color }} label={name || 'Preview'} />
           </div>
-          <Chip className={styles.preview} sx={{ bgcolor: color }} label={name || 'preview'} />
-          <Button data-testid="submit-button" type="submit" fullWidth>
-            {t('validate')}
+          <Button data-testid="submit-button" type="submit">
+            {t('createEmissionSourceTag')}
           </Button>
         </FormControl>
       </Form>

--- a/src/constants/emissionSourceTags.ts
+++ b/src/constants/emissionSourceTags.ts
@@ -14,12 +14,20 @@ type DefaultEmissionSourceTags = {
   }[]
 }
 
+export enum emissionSourceTagColors {
+  GREY = '#9fbff3',
+  GREEN = '#94EBBF',
+  RED = '#e04949',
+  ORANGE = '#fc8514',
+  BLUE = '#606af5',
+}
+
 export const defaultEmissionSourceTags: DefaultEmissionSourceTags = {
   [Environment.TILT]: [
-    { name: DefaultEmissionSourceTag.PERIMETRE_INTERNE, color: 'success' },
-    { name: DefaultEmissionSourceTag.PERIMETRE_BENEVOLES, color: 'error' },
-    { name: DefaultEmissionSourceTag.PERIMETRE_BENEFICIAIRES, color: 'warning' },
-    { name: DefaultEmissionSourceTag.NUMERIQUE, color: 'info' },
+    { name: DefaultEmissionSourceTag.PERIMETRE_INTERNE, color: emissionSourceTagColors.GREEN },
+    { name: DefaultEmissionSourceTag.PERIMETRE_BENEVOLES, color: emissionSourceTagColors.RED },
+    { name: DefaultEmissionSourceTag.PERIMETRE_BENEFICIAIRES, color: emissionSourceTagColors.ORANGE },
+    { name: DefaultEmissionSourceTag.NUMERIQUE, color: emissionSourceTagColors.BLUE },
   ],
 }
 type EmissionSourceTagMap = {

--- a/src/constants/emissionSourceTags.ts
+++ b/src/constants/emissionSourceTags.ts
@@ -1,9 +1,106 @@
-import { Environment } from '@prisma/client'
+import { Environment, SubPost } from '@prisma/client'
 
-export const defaultEmissionSourceTags = {
+export enum DefaultEmissionSourceTag {
+  PERIMETRE_INTERNE = 'Périmètre Interne',
+  PERIMETRE_BENEVOLES = 'Périmètre Bénévoles',
+  PERIMETRE_BENEFICIAIRES = 'Périmètre Bénéficiaires',
+}
+
+type DefaultEmissionSourceTags = {
+  [key in Environment]?: {
+    name: string
+    color: string
+  }[]
+}
+
+export const defaultEmissionSourceTags: DefaultEmissionSourceTags = {
   [Environment.TILT]: [
-    { name: 'Périmètre Interne' },
-    { name: 'Périmètre Bénévoles' },
-    { name: 'Périmètre Bénéficiaires' },
+    { name: DefaultEmissionSourceTag.PERIMETRE_INTERNE, color: 'success' },
+    { name: DefaultEmissionSourceTag.PERIMETRE_BENEVOLES, color: 'error' },
+    { name: DefaultEmissionSourceTag.PERIMETRE_BENEFICIAIRES, color: 'warning' },
   ],
+}
+type EmissionSourceTagMap = {
+  [key in Environment]?: {
+    [key in DefaultEmissionSourceTag]?: SubPost[]
+  }
+}
+
+export const emissionSourceTagMap: EmissionSourceTagMap = {
+  [Environment.TILT]: {
+    [DefaultEmissionSourceTag.PERIMETRE_INTERNE]: [
+      SubPost.Batiment,
+      SubPost.AutresInfrastructures,
+      SubPost.CombustiblesFossiles,
+      SubPost.CombustiblesOrganiques,
+      SubPost.ReseauxDeChaleurEtDeVapeur,
+      SubPost.ReseauxDeFroid,
+      SubPost.Electricite,
+
+      SubPost.DechetsDEmballagesEtPlastiques,
+      SubPost.DechetsOrganiques,
+      SubPost.DechetsOrduresMenageres,
+      SubPost.DechetsDangereux,
+      SubPost.DechetsBatiments,
+      SubPost.FuitesOuEmissionsNonEnergetiques,
+      SubPost.EauxUsees,
+      SubPost.AutresDechets,
+
+      SubPost.ActivitesAgricoles,
+      SubPost.EmissionsLieesAuChangementDAffectationDesSolsCas,
+      SubPost.ActivitesIndustrielles,
+
+      SubPost.DeplacementsDomicileTravailSalaries,
+      SubPost.DeplacementsDansLeCadreDUneMissionAssociativeSalaries,
+      SubPost.DeplacementsFabricationDesVehicules,
+
+      SubPost.Entrant,
+      SubPost.Interne,
+      SubPost.Sortant,
+      SubPost.TransportFabricationDesVehicules,
+
+      SubPost.MetauxPlastiquesEtVerre,
+      SubPost.PapiersCartons,
+      SubPost.MateriauxDeConstruction,
+      SubPost.ProduitsChimiquesEtHydrogene,
+      SubPost.MatiereDestineeAuxEmballages,
+      SubPost.AutresIntrants,
+      SubPost.BiensEtMatieresEnApprocheMonetaire,
+
+      SubPost.RepasPrisParLesSalaries,
+
+      SubPost.AchatsDeServices,
+      SubPost.UsagesNumeriques,
+      SubPost.ServicesEnApprocheMonetaire,
+
+      SubPost.Equipements,
+      SubPost.Informatique,
+
+      SubPost.InvestissementsFinanciersRealises,
+
+      SubPost.TeletravailSalaries,
+    ],
+    [DefaultEmissionSourceTag.PERIMETRE_BENEVOLES]: [
+      SubPost.DeplacementsDomicileTravailBenevoles,
+      SubPost.DeplacementsDansLeCadreDUneMissionAssociativeBenevoles,
+      SubPost.RepasPrisParLesBenevoles,
+      SubPost.TeletravailBenevoles,
+    ],
+    [DefaultEmissionSourceTag.PERIMETRE_BENEFICIAIRES]: [
+      SubPost.DeplacementsDesBeneficiaires,
+      SubPost.UtilisationEnResponsabiliteConsommationDeBiens,
+      SubPost.UtilisationEnResponsabiliteConsommationNumerique,
+      SubPost.UtilisationEnResponsabiliteConsommationDEnergie,
+      SubPost.UtilisationEnResponsabiliteFuitesEtAutresConsommations,
+      SubPost.UtilisationEnDependanceConsommationDeBiens,
+      SubPost.UtilisationEnDependanceConsommationNumerique,
+      SubPost.UtilisationEnDependanceConsommationDEnergie,
+      SubPost.UtilisationEnDependanceFuitesEtAutresConsommations,
+
+      SubPost.ConsommationDEnergieEnFinDeVie,
+      SubPost.TraitementDesDechetsEnFinDeVie,
+      SubPost.FuitesOuEmissionsNonEnergetiques,
+      SubPost.TraitementDesEmballagesEnFinDeVie,
+    ],
+  },
 }

--- a/src/constants/emissionSourceTags.ts
+++ b/src/constants/emissionSourceTags.ts
@@ -4,6 +4,7 @@ export enum DefaultEmissionSourceTag {
   PERIMETRE_INTERNE = 'Périmètre Interne',
   PERIMETRE_BENEVOLES = 'Périmètre Bénévoles',
   PERIMETRE_BENEFICIAIRES = 'Périmètre Bénéficiaires',
+  NUMERIQUE = 'Numérique',
 }
 
 type DefaultEmissionSourceTags = {
@@ -18,6 +19,7 @@ export const defaultEmissionSourceTags: DefaultEmissionSourceTags = {
     { name: DefaultEmissionSourceTag.PERIMETRE_INTERNE, color: 'success' },
     { name: DefaultEmissionSourceTag.PERIMETRE_BENEVOLES, color: 'error' },
     { name: DefaultEmissionSourceTag.PERIMETRE_BENEFICIAIRES, color: 'warning' },
+    { name: DefaultEmissionSourceTag.NUMERIQUE, color: 'info' },
   ],
 }
 type EmissionSourceTagMap = {
@@ -101,6 +103,10 @@ export const emissionSourceTagMap: EmissionSourceTagMap = {
       SubPost.TraitementDesDechetsEnFinDeVie,
       SubPost.FuitesOuEmissionsNonEnergetiques,
       SubPost.TraitementDesEmballagesEnFinDeVie,
+    ],
+    [DefaultEmissionSourceTag.NUMERIQUE]: [
+      SubPost.UtilisationEnResponsabiliteConsommationNumerique,
+      SubPost.UtilisationEnDependanceConsommationNumerique,
     ],
   },
 }

--- a/src/db/study.ts
+++ b/src/db/study.ts
@@ -87,7 +87,7 @@ const fullStudyInclude = {
           },
         },
       },
-      emissionSourceTag: {
+      emissionSourceTags: {
         select: {
           id: true,
           name: true,
@@ -191,6 +191,7 @@ const fullStudyInclude = {
     select: {
       id: true,
       name: true,
+      color: true,
       studyId: true,
     },
   },

--- a/src/db/study.ts
+++ b/src/db/study.ts
@@ -91,6 +91,7 @@ const fullStudyInclude = {
         select: {
           id: true,
           name: true,
+          color: true,
           studyId: true,
         },
       },

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -556,8 +556,10 @@
       "exports": "Exports",
       "control": "Control mode",
       "emissionSourceTags": "Tags",
-      "emissionSourceTag": "Create a tag",
+      "emissionSourceTagLabel": "Label",
+      "color": "Color",
       "emissionSourceTagsPlaceholder": "Your tag",
+      "createEmissionSourceTag": "Create my tag",
       "validate": "Validate",
       "deleteDialog": {
         "accept": "Yes",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -556,8 +556,10 @@
       "exports": "Exports",
       "control": "Mode de contrôle",
       "emissionSourceTags": "Tags",
-      "emissionSourceTag": "Créer un tag",
+      "emissionSourceTagLabel": "Libellé",
+      "color": "Couleur",
       "emissionSourceTagsPlaceholder": "Votre tag",
+      "createEmissionSourceTag": "Créer mon tag",
       "validate": "Valider",
       "deleteDialog": {
         "accept": "Oui",

--- a/src/services/emissionSource.test.ts
+++ b/src/services/emissionSource.test.ts
@@ -42,7 +42,7 @@ const defaultEmissionSource = {
   depreciationPeriod: null,
   duration: null,
   hectare: null,
-  emissionSourceTag: null,
+  emissionSourceTags: [],
 } satisfies FullStudy['emissionSources'][0]
 
 describe('emissionSource Service', () => {

--- a/src/services/serverFunctions/emissionSource.command.ts
+++ b/src/services/serverFunctions/emissionSource.command.ts
@@ -38,7 +38,7 @@ export const UpdateEmissionSourceCommandValidation = z.object({
   feGeographicRepresentativeness: z.number().nullable().optional(),
   feTemporalRepresentativeness: z.number().nullable().optional(),
   feCompleteness: z.number().nullable().optional(),
-  emissionSourceTagId: z.string().optional(),
+  emissionSourceTags: z.array(z.string()).optional(),
 })
 export type UpdateEmissionSourceCommand = z.infer<typeof UpdateEmissionSourceCommandValidation>
 

--- a/src/services/serverFunctions/emissionSource.command.ts
+++ b/src/services/serverFunctions/emissionSource.command.ts
@@ -45,6 +45,7 @@ export type UpdateEmissionSourceCommand = z.infer<typeof UpdateEmissionSourceCom
 export const NewEmissionSourceTagCommandValidation = z.object({
   studyId: z.string(),
   name: z.string(),
+  color: z.string().optional(),
 })
 
 export type NewEmissionSourceTagCommand = z.infer<typeof NewEmissionSourceTagCommandValidation>

--- a/src/services/serverFunctions/emissionSource.ts
+++ b/src/services/serverFunctions/emissionSource.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { DefaultEmissionSourceTag, emissionSourceTagMap } from '@/constants/emissionSourceTags'
 import { AccountWithUser, getAccountById } from '@/db/account'
 import { getEmissionFactorById } from '@/db/emissionFactors'
 import {
@@ -12,7 +13,7 @@ import {
 } from '@/db/emissionSource'
 import { getStudyById } from '@/db/study'
 import { withServerResponse } from '@/utils/serverResponse'
-import { Import, UserChecklist } from '@prisma/client'
+import { EmissionSourceTag, Import, SubPost, UserChecklist } from '@prisma/client'
 import { auth } from '../auth'
 import { NOT_AUTHORIZED } from '../permissions/check'
 import {
@@ -64,8 +65,15 @@ export const createEmissionSource = async ({
       throw new Error(NOT_AUTHORIZED)
     }
 
+    let defaultTags: string[] = []
+    const tags = await getDefaultEmissionSourceTags(command.subPost, studyId)
+    if (tags && tags.success) {
+      defaultTags = tags.data as string[]
+    }
+
     return await createEmissionSourceOnStudy({
       ...command,
+      emissionSourceTags: { connect: defaultTags.map((id) => ({ id })) },
       ...(emissionFactorId ? { emissionFactor: { connect: { id: emissionFactorId } } } : {}),
       studySite: { connect: { id: studySiteId } },
       study: { connect: { id: studyId } },
@@ -120,7 +128,13 @@ export const updateEmissionSource = async ({
     )
 
     const data = {
-      ...command,
+      ...{
+        ...command,
+        emissionSourceTags:
+          command.emissionSourceTags && Array.isArray(command.emissionSourceTags)
+            ? { set: command.emissionSourceTags.map((id) => ({ id })) }
+            : command.emissionSourceTags,
+      },
       ...(emissionFactorId !== undefined
         ? {
             ...(emissionFactorId
@@ -250,4 +264,41 @@ export const getEmissionSourceTagsByStudyId = async (studyId: string) =>
     }
 
     return study.emissionSourceTags
+  })
+
+const getDefaultEmissionSourceTags = async (subPost: SubPost, studyId: string) =>
+  withServerResponse('getDefaultEmissionSourceTag', async () => {
+    const session = await auth()
+    if (!session || !session.user) {
+      return []
+    }
+
+    const account = await getAccountById(session.user.accountId)
+    if (!account) {
+      return []
+    }
+
+    const study = await getStudyById(studyId, account.organizationVersionId)
+    if (!study) {
+      return []
+    }
+
+    if (!(account.environment in emissionSourceTagMap)) {
+      return []
+    }
+    const tagObj = emissionSourceTagMap[account.environment]
+    if (!tagObj) {
+      return []
+    }
+    const studyTags = study.emissionSourceTags || ([] as EmissionSourceTag[])
+    const defaultTags = []
+    for (const tag of Object.keys(tagObj)) {
+      if (tagObj[tag as DefaultEmissionSourceTag]?.includes(subPost)) {
+        const tagData = studyTags?.find((studyTag) => studyTag.name === tag)
+        if (tagData) {
+          defaultTags.push(tagData.id)
+        }
+      }
+    }
+    return defaultTags
   })

--- a/src/services/serverFunctions/emissionSource.ts
+++ b/src/services/serverFunctions/emissionSource.ts
@@ -199,7 +199,7 @@ export const getEmissionSourcesByStudyId = async (studyId: string) =>
     return study.emissionSources
   })
 
-export const createEmissionSourceTag = async ({ studyId, name }: NewEmissionSourceTagCommand) =>
+export const createEmissionSourceTag = async ({ studyId, name, color }: NewEmissionSourceTagCommand) =>
   withServerResponse('createEmissionSourceTag', async () => {
     const session = await auth()
     if (!session || !session.user) {
@@ -224,6 +224,7 @@ export const createEmissionSourceTag = async ({ studyId, name }: NewEmissionSour
     return await createEmissionSourceTagOnStudy({
       study: { connect: { id: studyId } },
       name,
+      color,
     })
   })
 

--- a/src/services/serverFunctions/study.ts
+++ b/src/services/serverFunctions/study.ts
@@ -218,7 +218,7 @@ export const createStudyCommand = async (
       createMany: {
         data:
           session.user.environment in defaultEmissionSourceTags
-            ? defaultEmissionSourceTags[session.user.environment as keyof typeof defaultEmissionSourceTags]
+            ? defaultEmissionSourceTags[session.user.environment as keyof typeof defaultEmissionSourceTags] || []
             : [],
       },
     }

--- a/src/services/study.ts
+++ b/src/services/study.ts
@@ -155,7 +155,7 @@ const getEmissionSourcesRows = (
           isCAS(emissionSource) ? emissionSource.duration || '1' : ' ',
           tResultUnits(resultsUnit),
           emissionSourceSD ? getQuality(getStandardDeviationRating(emissionSourceSD), tQuality) : '',
-          emissionSource.emissionSourceTag?.name || '',
+          emissionSource.emissionSourceTags.map((tag) => tag.name).join(', ') || '',
           emissionSource.value || '0',
           emissionFactor?.unit ? tUnit(emissionFactor.unit) : '',
           getQuality(getQualityRating(emissionSource), tQuality),

--- a/src/tests/utils/models/emissionSource.ts
+++ b/src/tests/utils/models/emissionSource.ts
@@ -35,7 +35,7 @@ export const mockedDbEmissionSource = {
   feGeographicRepresentativeness: null,
   feTemporalRepresentativeness: null,
   feCompleteness: null,
-  emissionSourceTagId: null,
+  emissionSourceTags: [],
 }
 
 export const getMockedEmissionSource = (props?: Partial<StudyEmissionSource>): StudyEmissionSource => ({


### PR DESCRIPTION
https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/960#issuecomment-3126914876

Nouvelle PR pour améliorer les tags voilà ce que ça donne côté front : 

https://github.com/user-attachments/assets/9c8187d2-eb50-4929-b994-f925c4a01724


j'ai limité à ces couleurs là pour le test dites moi ce que vous en pensez, si c'est ok comme système et celles que je dois rajouter

```
export enum emissionSourceTagColors {
  GREY = "#9fbff3",
  GREEN = '#94EBBF',
  RED = '#e04949',
  ORANGE = '#fc8514',
  BLUE = '#606af5',
}
```

On le voit pas dans la vidéo mais j'ai également ajouté et attribué le tag "Numérique" comme il était dans le tableau
