### PR TITLE
Multiple fixes fe posts and beges

### DIFF
--- a/src/components/study/EmissionSourceFactor.tsx
+++ b/src/components/study/EmissionSourceFactor.tsx
@@ -205,7 +205,7 @@ const EmissionSourceFactor = ({
         <EmissionSourceFactorModal
           open={advancedSearch}
           close={() => setAdvancedSearch(false)}
-          emissionFactors={emissionFactorsFilteredBySubPosts}
+          emissionFactors={emissionFactors}
           subPost={subPost}
           selectEmissionFactor={(emissionFactor) => {
             update('emissionFactorId', emissionFactor.id)

--- a/src/services/emissionSource.ts
+++ b/src/services/emissionSource.ts
@@ -406,22 +406,16 @@ export const financialCaracterisations: CaracterisationsBySubPost = {
   [SubPost.DeplacementsDomicileTravail]: [
     EmissionSourceCaracterisation.Held,
     EmissionSourceCaracterisation.NotHeldSimpleRent,
-    EmissionSourceCaracterisation.NotHeldSupported,
-    EmissionSourceCaracterisation.NotHeldNotSupported,
     EmissionSourceCaracterisation.NotHeldOther,
   ],
   [SubPost.DeplacementsProfessionnels]: [
     EmissionSourceCaracterisation.Held,
     EmissionSourceCaracterisation.NotHeldSimpleRent,
-    EmissionSourceCaracterisation.NotHeldSupported,
-    EmissionSourceCaracterisation.NotHeldNotSupported,
     EmissionSourceCaracterisation.NotHeldOther,
   ],
   [SubPost.DeplacementsVisiteurs]: [
     EmissionSourceCaracterisation.Held,
     EmissionSourceCaracterisation.NotHeldSimpleRent,
-    EmissionSourceCaracterisation.NotHeldSupported,
-    EmissionSourceCaracterisation.NotHeldNotSupported,
     EmissionSourceCaracterisation.NotHeldOther,
   ],
   [SubPost.Batiments]: [EmissionSourceCaracterisation.Held],
@@ -431,7 +425,6 @@ export const financialCaracterisations: CaracterisationsBySubPost = {
   [SubPost.UtilisationEnResponsabilite]: [
     EmissionSourceCaracterisation.Rented,
     EmissionSourceCaracterisation.FinalClient,
-    EmissionSourceCaracterisation.UsedByIntermediary,
   ],
   [SubPost.UtilisationEnDependance]: [],
   [SubPost.InvestissementsFinanciersRealises]: [EmissionSourceCaracterisation.Held],


### PR DESCRIPTION
lié à #811 @fortinlouis c'est normal qu'il n'y ait rien dans achats de service (c'est un sous poste pour les utilisateurs mais ils doivent y ajouter leurs FE) parcontre y avait bien un autre bug (on ne pouvait pas voir les FEs qui n'étaient pas ceux du sous poste de base) que j'ai corrigé 

Lié  à #1118 