### PR TITLE
feat: map cnc fields to study site data

### DIFF
--- a/src/constants/emissionFactorMap.ts
+++ b/src/constants/emissionFactorMap.ts
@@ -59,7 +59,6 @@ export const SITE_DEPENDENT_FIELDS = [
   'numberOfSessions',
   'numberOfTickets',
   'numberOfOpenDays',
-  'distanceToParis',
   'numberOfProgrammedFilms',
 ] as const
 
@@ -242,7 +241,7 @@ export const emissionFactorMap: Record<string, EmissionFactorInfo> = {
   [SHORT_DISTANCE_QUESTION_ID]: {
     isSpecial: true,
     relatedQuestions: [LONG_DISTANCE_QUESTION_ID],
-    dependentFields: ['numberOfTickets', 'distanceToParis'],
+    dependentFields: ['numberOfTickets'],
     conditionalRules: [
       {
         idIntern: MOBILIY_SURVEY_QUESTION_ID,
@@ -310,7 +309,7 @@ export const emissionFactorMap: Record<string, EmissionFactorInfo> = {
   [LONG_DISTANCE_QUESTION_ID]: {
     isSpecial: true,
     relatedQuestions: [SHORT_DISTANCE_QUESTION_ID],
-    dependentFields: ['numberOfTickets', 'distanceToParis'],
+    dependentFields: ['numberOfTickets'],
     conditionalRules: [
       {
         idIntern: MOBILIY_SURVEY_QUESTION_ID,
@@ -344,7 +343,6 @@ export const emissionFactorMap: Record<string, EmissionFactorInfo> = {
   [MOVIE_TEAM_QUESTION_ID]: {
     emissionFactors: { transport: '43256', meal: '20682' },
     isSpecial: true,
-    dependentFields: ['distanceToParis'],
   },
   // Matériel technique
   '10-decrivez-les-differentes-salles-du-cinema': {},
@@ -388,7 +386,7 @@ export const emissionFactorMap: Record<string, EmissionFactorInfo> = {
   [MOVIE_DEMAT_QUESTION_ID]: {
     isSpecial: true,
     emissionFactorImportedId: '142',
-    dependentFields: ['distanceToParis', 'numberOfProgrammedFilms'],
+    dependentFields: ['numberOfProgrammedFilms'],
   },
   [MOVIE_DCP_QUESTION_ID]: { isSpecial: true, emissionFactorImportedId: '143' },
   'combien-de-donnees-stockez-vous-dans-un-cloud': { emissionFactorImportedId: '141' },

--- a/src/db/organization.ts
+++ b/src/db/organization.ts
@@ -53,6 +53,11 @@ export const OrganizationVersionWithOrganizationSelect = {
           cnc: {
             select: {
               numeroAuto: true,
+              seances: true,
+              entrees2023: true,
+              semainesActivite: true,
+              latitude: true,
+              longitude: true,
             },
           },
         },

--- a/src/environments/cut/study/StudyRights.tsx
+++ b/src/environments/cut/study/StudyRights.tsx
@@ -52,7 +52,6 @@ const StudyRights = ({ user, study, editionDisabled, emissionFactorSources }: Pr
     numberOfSessions: number
     numberOfTickets: number
     numberOfOpenDays: number
-    distanceToParis: number
     numberOfProgrammedFilms: number
   } | null>(null)
 
@@ -96,7 +95,6 @@ const StudyRights = ({ user, study, editionDisabled, emissionFactorSources }: Pr
       numberOfOpenDays: siteData?.numberOfOpenDays ?? 0,
       numberOfSessions: siteData?.numberOfSessions ?? 0,
       numberOfTickets: siteData?.numberOfTickets ?? 0,
-      distanceToParis: siteData?.distanceToParis ?? 0,
     },
   })
 
@@ -114,7 +112,6 @@ const StudyRights = ({ user, study, editionDisabled, emissionFactorSources }: Pr
             numberOfOpenDays: newSiteData.numberOfOpenDays ?? 0,
             numberOfSessions: newSiteData.numberOfSessions ?? 0,
             numberOfTickets: newSiteData.numberOfTickets ?? 0,
-            distanceToParis: newSiteData.distanceToParis ?? 0,
             numberOfProgrammedFilms: newSiteData.site.cnc?.numberOfProgrammedFilms ?? 0,
           }
 
@@ -183,7 +180,6 @@ const StudyRights = ({ user, study, editionDisabled, emissionFactorSources }: Pr
           numberOfSessions: data.numberOfSessions ?? 0,
           numberOfTickets: data.numberOfTickets ?? 0,
           numberOfOpenDays: data.numberOfOpenDays ?? 0,
-          distanceToParis: data.distanceToParis ?? 0,
           numberOfProgrammedFilms: data.numberOfProgrammedFilms ?? 0,
         })
       }
@@ -199,7 +195,6 @@ const StudyRights = ({ user, study, editionDisabled, emissionFactorSources }: Pr
         numberOfSessions: originalValues.numberOfSessions,
         numberOfTickets: originalValues.numberOfTickets,
         numberOfOpenDays: originalValues.numberOfOpenDays,
-        distanceToParis: originalValues.distanceToParis,
         numberOfProgrammedFilms: originalValues.numberOfProgrammedFilms,
       })
     }
@@ -215,7 +210,6 @@ const StudyRights = ({ user, study, editionDisabled, emissionFactorSources }: Pr
           numberOfSessions: pendingSiteChanges.pendingData.numberOfSessions ?? 0,
           numberOfTickets: pendingSiteChanges.pendingData.numberOfTickets ?? 0,
           numberOfOpenDays: pendingSiteChanges.pendingData.numberOfOpenDays ?? 0,
-          distanceToParis: pendingSiteChanges.pendingData.distanceToParis ?? 0,
           numberOfProgrammedFilms: pendingSiteChanges.pendingData.numberOfProgrammedFilms ?? 0,
         })
         setPendingSiteChanges(null)
@@ -302,16 +296,6 @@ const StudyRights = ({ user, study, editionDisabled, emissionFactorSources }: Pr
                 name="numberOfOpenDays"
                 data-testid="new-study-number-of-open-days"
                 label={labelWithYear('numberOfOpenDays')}
-                translation={t}
-                type="number"
-                className={styles.formTextField}
-                onBlur={onStudyCinemaUpdate}
-              />
-              <FormTextField
-                control={form.control}
-                name="distanceToParis"
-                data-testid="new-study-distance-to-paris"
-                label={t('distanceToParis')}
                 translation={t}
                 type="number"
                 className={styles.formTextField}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -353,7 +353,6 @@
       "isPublicTitle": "Study visibility",
       "numberOfSessions": "Number of sessions (in {year})",
       "numberOfTickets": "Number of tickets (in {year})",
-      "distanceToParis": "Distance to Paris (km)",
       "numberOfProgrammedFilms": "Number of scheduled films (in {year})",
       "numberOfOpenDays": "Number of opening days (in {year})",
       "openingHours": "Opening hours",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -356,7 +356,6 @@
       "resultsUnit": "Unité des resultats de l'étude",
       "numberOfSessions": "Nombre de séances (en {year})",
       "numberOfTickets": "Nombre d'entrées (en {year})",
-      "distanceToParis": "Distance à Paris (km)",
       "numberOfProgrammedFilms": "Nombre de films programmés (en {year})",
       "numberOfOpenDays": "Nombre de jours d'ouverture (en {year})",
       "openingHours": "Horaires d'ouverture",

--- a/src/scripts/cut/cnc/add.ts
+++ b/src/scripts/cut/cnc/add.ts
@@ -5,6 +5,14 @@ import { parse } from 'csv-parse'
 import fs from 'fs'
 import { getEncoding } from '../../../utils/csv'
 
+const parseInteger = (value: string | number | undefined): number | undefined => {
+  return value ? parseInt(value.toString().replace(/\s+/g, ''), 10) : undefined
+}
+
+const parseDecimal = (value: string | number | undefined): number | undefined => {
+  return value ? parseFloat(value.toString().replace(/\s+/g, '')) : undefined
+}
+
 const addCNC = async (file: string) => {
   const cncs: Prisma.CncCreateInput[] = []
   await new Promise<void>((resolve, reject) => {
@@ -85,19 +93,19 @@ const addCNC = async (file: string) => {
             codeInsee: row.codeinsee,
             commune: row.commune,
             dep: row.dep,
-            ecrans: row.ecrans ? parseInt(row.ecrans.toString(), 10) : undefined,
-            fauteuils: row.fauteuils ? parseInt(row.fauteuils.toString(), 10) : undefined,
-            semainesActivite: row.semainesdactivite ? parseInt(row.semainesdactivite.toString(), 10) : undefined,
-            seances: row.seances ? parseInt(row.seances.toString(), 10) : undefined,
-            entrees2023: row.entrees2023 ? parseInt(row.entrees2023.toString(), 10) : undefined,
-            entrees2022: row.entrees2022 ? parseInt(row.entrees2022.toString(), 10) : undefined,
-            evolutionEntrees: row.evolutionentrees ? parseFloat(row.evolutionentrees.toString()) : undefined,
+            ecrans: parseInteger(row.ecrans),
+            fauteuils: parseInteger(row.fauteuils),
+            semainesActivite: parseInteger(row.semainesdactivite),
+            seances: parseInteger(row.seances),
+            entrees2023: parseInteger(row.entrees2023),
+            entrees2022: parseInteger(row.entrees2022),
+            evolutionEntrees: parseDecimal(row.evolutionentrees),
             trancheEntrees: row.tranchedentrees,
             genre: row.genre,
             multiplexe: row.multiplexe === 'OUI',
-            latitude: row.latitude ? parseFloat(row.latitude.toString()) : undefined,
-            longitude: row.longitude ? parseFloat(row.longitude.toString()) : undefined,
-            numberOfProgrammedFilms: row.nombredefilmsprogrammes ? Number(row.nombredefilmsprogrammes.toString()) : 0,
+            latitude: parseDecimal(row.latitude),
+            longitude: parseDecimal(row.longitude),
+            numberOfProgrammedFilms: parseInteger(row.nombredefilmsprogrammes) || 0,
           })
         },
       )

--- a/src/scripts/fillStudySiteDataFromCNC.ts
+++ b/src/scripts/fillStudySiteDataFromCNC.ts
@@ -1,0 +1,95 @@
+'use server'
+
+import { prismaClient } from '@/db/client'
+import { mapCncToStudySite } from '@/utils/cnc'
+
+const fillStudySiteDataFromCNC = async () => {
+  try {
+    console.log('Starting CNC data backfill process...')
+
+    // Find all study sites that have CNC data but missing fields
+    const studySites = await prismaClient.studySite.findMany({
+      where: {
+        site: {
+          cnc: {
+            isNot: null,
+          },
+        },
+        OR: [
+          { distanceToParis: null },
+          { numberOfSessions: null },
+          { numberOfTickets: null },
+          { numberOfOpenDays: null },
+        ],
+      },
+      include: {
+        site: {
+          include: {
+            cnc: {
+              select: {
+                id: true,
+                latitude: true,
+                longitude: true,
+                seances: true,
+                entrees2023: true,
+                semainesActivite: true,
+              },
+            },
+          },
+        },
+      },
+    })
+
+    console.log(`Found ${studySites.length} study sites to update`)
+
+    if (studySites.length === 0) {
+      console.log('No study sites need CNC data backfill.')
+      return
+    }
+
+    let updatedCount = 0
+
+    // Process each study site
+    for (const studySite of studySites) {
+      const cncData = studySite.site.cnc
+      if (!cncData) {
+        continue
+      }
+
+      const updateData = mapCncToStudySite(cncData, studySite)
+
+      // Only update if we have changes
+      if (Object.keys(updateData).length > 0) {
+        await prismaClient.studySite.update({
+          where: { id: studySite.id },
+          data: updateData,
+        })
+
+        updatedCount++
+        console.log(`✓ Updated study site ${studySite.id}`)
+      }
+    }
+
+    console.log(`✅ Successfully updated ${updatedCount} study sites with CNC data`)
+  } catch (error) {
+    console.error('❌ Error filling CNC data:', error)
+    throw error
+  } finally {
+    await prismaClient.$disconnect()
+  }
+}
+
+// Run the script if called directly
+if (require.main === module) {
+  fillStudySiteDataFromCNC()
+    .then(() => {
+      console.log('🎉 CNC data backfill completed successfully!')
+      process.exit(0)
+    })
+    .catch((error) => {
+      console.error('💥 CNC data backfill failed:', error)
+      process.exit(1)
+    })
+}
+
+export { fillStudySiteDataFromCNC }

--- a/src/services/serverFunctions/study.command.ts
+++ b/src/services/serverFunctions/study.command.ts
@@ -171,7 +171,6 @@ export const ChangeStudyCinemaValidation = z.object({
   numberOfSessions: z.number({ invalid_type_error: 'invalidNumber' }).optional().nullable(),
   numberOfTickets: z.number({ invalid_type_error: 'invalidNumber' }).optional().nullable(),
   numberOfOpenDays: z.number({ invalid_type_error: 'invalidNumber' }).optional().nullable(),
-  distanceToParis: z.number({ invalid_type_error: 'invalidNumber' }).optional().nullable(),
   numberOfProgrammedFilms: z.number({ invalid_type_error: 'invalidNumber' }).optional().nullable(),
 })
 

--- a/src/services/serverFunctions/study.ts
+++ b/src/services/serverFunctions/study.ts
@@ -61,6 +61,8 @@ import {
 import { addUser, getUserApplicationSettings, getUserByEmail, getUserSourceById, UserWithAccounts } from '@/db/user'
 import { LocaleType } from '@/i18n/config'
 import { getLocale } from '@/i18n/locale'
+import { mapCncToStudySite } from '@/utils/cnc'
+import { calculateDistanceFromParis } from '@/utils/distance'
 import { CA_UNIT_VALUES, defaultCAUnit } from '@/utils/number'
 import { withServerResponse } from '@/utils/serverResponse'
 import {
@@ -270,13 +272,21 @@ export const createStudyCommand = async (
               if (!organizationSite) {
                 return undefined
               }
-              return {
+
+              const cncData = organizationSite.cnc
+              const studySiteData: Prisma.StudySiteCreateManyStudyInput = {
                 siteId: site.id,
                 etp: site.etp || organizationSite.etp,
                 ca: site.ca ? site.ca * caUnit : organizationSite.ca,
                 volunteerNumber: site.volunteerNumber || organizationSite.volunteerNumber,
                 beneficiaryNumber: site.beneficiaryNumber || organizationSite.beneficiaryNumber,
               }
+
+              if (cncData) {
+                Object.assign(studySiteData, mapCncToStudySite(cncData))
+              }
+
+              return studySiteData
             })
             .filter((site) => site !== undefined),
         },
@@ -412,9 +422,19 @@ export const changeStudyCinema = async (studySiteId: string, cncId: string, data
       throw new Error(NOT_AUTHORIZED)
     }
 
-    // Detect changes in fields with dependencies
+    // Detect changes in fields with dependencies and calculate distanceToParis
     const currentSite = studySites[0]
     const changedFields: SiteDependentField[] = []
+    let calculatedDistanceToParis: number | undefined
+
+    // Calculate distanceToParis if CNC data with coordinates is available
+    const cncData = currentSite.site.cnc
+    if (cncData?.latitude && cncData?.longitude) {
+      calculatedDistanceToParis = calculateDistanceFromParis({
+        latitude: cncData.latitude,
+        longitude: cncData.longitude,
+      })
+    }
 
     for (const field of SITE_DEPENDENT_FIELDS) {
       if (field === 'numberOfProgrammedFilms') {
@@ -429,9 +449,24 @@ export const changeStudyCinema = async (studySiteId: string, cncId: string, data
       }
     }
 
+    // Prefill fields from CNC data if they are not already set
+    const enhancedUpdateData: Record<string, number | null | undefined> = { ...updateData }
+
+    if (cncData) {
+      // Calculate distance to Paris only if not already set (calculated once and remains fixed)
+      if (calculatedDistanceToParis !== undefined && currentSite.distanceToParis == null) {
+        enhancedUpdateData.distanceToParis = calculatedDistanceToParis
+      }
+
+      // Prefill other fields from CNC data only if they are null/undefined in current data
+      Object.assign(enhancedUpdateData, mapCncToStudySite(cncData, currentSite))
+    }
+
+    const finalUpdateData = enhancedUpdateData
+
     await updateNumberOfProgrammedFilms({ cncId, numberOfProgrammedFilms })
     await updateStudyOpeningHours(studySiteId, openingHours, openingHoursHoliday)
-    await updateStudySiteData(studySiteId, updateData)
+    await updateStudySiteData(studySiteId, finalUpdateData)
 
     // Recalculate emissions for affected emissions if dependent fields changed
     if (changedFields.length > 0 && informations.user.organizationVersionId) {

--- a/src/utils/cnc.ts
+++ b/src/utils/cnc.ts
@@ -1,0 +1,74 @@
+import { calculateDistanceFromParis } from './distance'
+
+/**
+ * CNC data interface for the minimal fields we need for StudySite mapping
+ */
+export interface CncData {
+  seances?: number | null
+  entrees2023?: number | null
+  semainesActivite?: number | null
+  latitude?: number | null
+  longitude?: number | null
+}
+
+/**
+ * Current StudySite data interface for checking what fields are already set
+ */
+export interface StudySiteData {
+  numberOfSessions?: number | null
+  numberOfTickets?: number | null
+  numberOfOpenDays?: number | null
+  distanceToParis?: number | null
+}
+
+/**
+ * Maps CNC data to StudySite fields
+ */
+export interface CncToStudySiteMapping {
+  numberOfSessions?: number
+  numberOfTickets?: number
+  numberOfOpenDays?: number
+  distanceToParis?: number
+}
+
+const DEFAULT_STUDY_SITE_DATA: StudySiteData = {
+  numberOfSessions: null,
+  numberOfTickets: null,
+  numberOfOpenDays: null,
+  distanceToParis: null,
+}
+
+/**
+ * Maps CNC data to StudySite fields, but only for fields that are null/undefined in the target
+ */
+export const mapCncToStudySite = (
+  cncData: CncData | null | undefined,
+  currentData: StudySiteData = DEFAULT_STUDY_SITE_DATA,
+): CncToStudySiteMapping => {
+  if (!cncData) {
+    return {}
+  }
+
+  const mapping: CncToStudySiteMapping = {}
+
+  if (currentData.numberOfSessions == null && cncData.seances != null) {
+    mapping.numberOfSessions = cncData.seances
+  }
+
+  if (currentData.numberOfTickets == null && cncData.entrees2023 != null) {
+    mapping.numberOfTickets = cncData.entrees2023
+  }
+
+  if (currentData.numberOfOpenDays == null && cncData.semainesActivite != null) {
+    mapping.numberOfOpenDays = cncData.semainesActivite * 7
+  }
+
+  if (currentData.distanceToParis == null && cncData.latitude && cncData.longitude) {
+    mapping.distanceToParis = calculateDistanceFromParis({
+      latitude: cncData.latitude,
+      longitude: cncData.longitude,
+    })
+  }
+
+  return mapping
+}

--- a/src/utils/distance.ts
+++ b/src/utils/distance.ts
@@ -1,0 +1,26 @@
+const PARIS_LATITUDE = 48.8533249
+const PARIS_LONGITUDE = 2.3488596
+const EARTH_RADIUS_KM = 6371
+
+export interface Coordinates {
+  latitude: number
+  longitude: number
+}
+
+export const calculateHaversineDistance = (lat1: number, lng1: number, lat2: number, lng2: number): number => {
+  const φ1 = (lat1 * Math.PI) / 180
+  const φ2 = (lat2 * Math.PI) / 180
+  const Δφ = ((lat2 - lat1) * Math.PI) / 180
+  const Δλ = ((lng2 - lng1) * Math.PI) / 180
+
+  const a = Math.sin(Δφ / 2) * Math.sin(Δφ / 2) + Math.cos(φ1) * Math.cos(φ2) * Math.sin(Δλ / 2) * Math.sin(Δλ / 2)
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+
+  return EARTH_RADIUS_KM * c
+}
+
+export const calculateDistanceFromParis = (coordinates: Coordinates): number => {
+  return Math.round(
+    calculateHaversineDistance(coordinates.latitude, coordinates.longitude, PARIS_LATITUDE, PARIS_LONGITUDE),
+  )
+}


### PR DESCRIPTION
Dans cette PR :
- mapping des données CNC avec le study site à la création d'une étude ou à l'ajout d'un site à une étude
- script pour remplir les study site existants avec les infos de leur CNC (à voir si on veut faire ça, sachant que ça ne recalculera pas les sources d'émissions)
- calcul de la distance à Paris par rapport aux lat et long
- champ distanceToParis enlevé des formulaires
- ⚠️ fix du script `cnc/add.ts` qui ne formatait pas bien les nombres. Ex : pour le champ `entree2023` à `5 137`, la valeur en DB est de `5` à cause de l'espace.