### PR TITLE
feat: add cnc version table and logic + script for legacy data

### DIFF
--- a/prisma/schema/migrations/20250915101416_add_cnc_version/migration.sql
+++ b/prisma/schema/migrations/20250915101416_add_cnc_version/migration.sql
@@ -1,0 +1,24 @@
+-- AlterTable
+ALTER TABLE "public"."cncs" ADD COLUMN     "cnc_version_id" TEXT;
+
+-- AlterTable
+ALTER TABLE "public"."study_sites" ADD COLUMN     "cnc_version_id" TEXT;
+
+-- CreateTable
+CREATE TABLE "public"."cnc_versions" (
+    "id" TEXT NOT NULL,
+    "year" INTEGER NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "cnc_versions_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "cnc_versions_year_key" ON "public"."cnc_versions"("year");
+
+-- AddForeignKey
+ALTER TABLE "public"."cncs" ADD CONSTRAINT "cncs_cnc_version_id_fkey" FOREIGN KEY ("cnc_version_id") REFERENCES "public"."cnc_versions"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "public"."study_sites" ADD CONSTRAINT "study_sites_cnc_version_id_fkey" FOREIGN KEY ("cnc_version_id") REFERENCES "public"."cnc_versions"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema/organization.prisma
+++ b/prisma/schema/organization.prisma
@@ -83,8 +83,23 @@ model Site {
   @@map("sites")
 }
 
+model CncVersion {
+  id        String @id @default(uuid())
+  year      Int    @unique
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
+  
+  cncs       Cnc[]
+  studySites StudySite[]
+  
+  @@map("cnc_versions")
+}
+
 model Cnc {
   id String @id @default(uuid())
+
+  cncVersionId String?     @map("cnc_version_id")
+  cncVersion   CncVersion? @relation(fields: [cncVersionId], references: [id])
 
   regionCNC               String?  @map("region_cnc")
   numeroAuto              String?  @unique @map("numero_auto")

--- a/prisma/schema/study.prisma
+++ b/prisma/schema/study.prisma
@@ -300,6 +300,9 @@ model StudySite {
   siteId String @map("site_id")
   site   Site   @relation(fields: [siteId], references: [id])
 
+  cncVersionId String?     @map("cnc_version_id")
+  cncVersion   CncVersion? @relation(fields: [cncVersionId], references: [id])
+
   etp                 Int
   ca                  Float
   StudyEmissionSource StudyEmissionSource[]

--- a/src/db/cnc.ts
+++ b/src/db/cnc.ts
@@ -1,7 +1,27 @@
 import { Prisma } from '@prisma/client'
 import { prismaClient } from './client'
 
-export const upsertCNC = async (data: Prisma.CncCreateInput[]) => {
+export const getOrCreateCncVersion = async (year: number) => {
+  const existingVersion = await prismaClient.cncVersion.findUnique({
+    where: { year },
+  })
+
+  if (existingVersion) {
+    return existingVersion
+  }
+
+  return await prismaClient.cncVersion.create({
+    data: { year },
+  })
+}
+
+export const getLatestCncVersion = async () => {
+  return await prismaClient.cncVersion.findFirst({
+    orderBy: { year: 'desc' },
+  })
+}
+
+export const upsertCNC = async (data: (Prisma.CncCreateManyInput & { cncVersionId: string })[]) => {
   await Promise.all(
     data.map(async (entry) => {
       if (!entry.numeroAuto) {
@@ -20,8 +40,12 @@ export const upsertCNC = async (data: Prisma.CncCreateInput[]) => {
   )
 }
 
-export const findCncByNumeroAuto = async (numeroAuto: string) =>
-  await prismaClient.cnc.findUnique({ where: { numeroAuto } })
+export const findCncByNumeroAuto = async (numeroAuto: string) => {
+  return prismaClient.cnc.findUnique({
+    where: { numeroAuto },
+    include: { cncVersion: true },
+  })
+}
 
 export const findCncById = async (id: string) => await prismaClient.cnc.findUnique({ where: { id } })
 
@@ -41,6 +65,7 @@ export const updateNumberOfProgrammedFilms = async ({
     },
   })
 }
+
 export const getCNCs = async () =>
   await prismaClient.cnc.findMany({
     where: {

--- a/src/db/organization.ts
+++ b/src/db/organization.ts
@@ -58,6 +58,7 @@ export const OrganizationVersionWithOrganizationSelect = {
               semainesActivite: true,
               latitude: true,
               longitude: true,
+              cncVersionId: true,
             },
           },
         },

--- a/src/db/study.ts
+++ b/src/db/study.ts
@@ -180,6 +180,12 @@ const fullStudyInclude = {
           },
         },
       },
+      cncVersion: {
+        select: {
+          id: true,
+          year: true,
+        },
+      },
     },
   },
   emissionFactorVersions: {
@@ -650,6 +656,12 @@ export const getStudiesSitesFromIds = async (siteIds: string[]) =>
               semainesActivite: true,
             },
           },
+        },
+      },
+      cncVersion: {
+        select: {
+          id: true,
+          year: true,
         },
       },
     },

--- a/src/environments/cut/organization/Sites.tsx
+++ b/src/environments/cut/organization/Sites.tsx
@@ -59,7 +59,7 @@ const Sites = <T extends SitesCommand>({ sites, form, withSelection }: Props<T>)
         return
       }
 
-      if (!numeroAuto || numeroAuto.length < 2) {
+      if (!numeroAuto || numeroAuto.length < 1) {
         // Clear all fields if input is too short
         setValue(`sites.${index}.cncId`, '')
         setValue(`sites.${index}.name`, '')

--- a/src/environments/cut/study/StudyRights.tsx
+++ b/src/environments/cut/study/StudyRights.tsx
@@ -38,7 +38,6 @@ interface Props {
 }
 
 const StudyRights = ({ user, study, editionDisabled, emissionFactorSources }: Props) => {
-  const cncYear = 2023 // TODO: replace when ticket is done: https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/1750
   const t = useTranslations('study.new')
   const { callServerFunction } = useServerFunction()
   const { studySite, setSite } = useStudySite(study)
@@ -266,7 +265,7 @@ const StudyRights = ({ user, study, editionDisabled, emissionFactorSources }: Pr
           <CircularProgress variant="indeterminate" color="primary" size={100} className="flex mt2" />
         ) : (
           <>
-            <div className="my2">{t('cncInfo', { year: cncYear })}</div>
+            <div className="my2">{t('cncInfo', { year: siteData?.cncVersion?.year ?? 2023 })}</div>
             <div>
               <FormTextField
                 control={form.control}

--- a/src/scripts/cut/cnc/migrate-cnc-version.ts
+++ b/src/scripts/cut/cnc/migrate-cnc-version.ts
@@ -1,0 +1,112 @@
+/**
+ * Migration script to link existing CNC records to the default 2023 version
+ *
+ * This script:
+ * 1. Creates CncVersion for 2023 if it doesn't exist
+ * 2. Links all existing CNC records without a version to the 2023 version
+ * 3. Links all StudySites without a cncVersion but with CNC-linked sites to the 2023 version
+ *
+ * Run with: npx tsx src/scripts/migrations/link-existing-cncs-to-version.ts
+ */
+
+import { prismaClient } from '@/db/client'
+import { getOrCreateCncVersion } from '@/db/cnc'
+import { Environment } from '@prisma/client'
+
+const MIGRATION_YEAR = 2023
+
+const linkExistingCncsToVersion = async () => {
+  console.log('🚀 Starting CNC version linking migration...')
+
+  try {
+    // Step 1: Get or create the 2023 CNC version
+    const cncVersion = await getOrCreateCncVersion(MIGRATION_YEAR)
+
+    if (!cncVersion) {
+      console.error('❌ Failed to get or create CNC version for year 2023')
+      return
+    }
+
+    // Step 2: Find CNC records without a version
+    const cncsWithoutVersion = await prismaClient.cnc.findMany({
+      where: { cncVersionId: null },
+    })
+
+    console.log(`📊 Found ${cncsWithoutVersion.length} CNC records without a version`)
+
+    // Step 3: Link them to the 2023 version
+    if (cncsWithoutVersion.length > 0) {
+      console.log('🔄 Linking existing CNC records to version...')
+      const updateResult = await prismaClient.cnc.updateMany({
+        where: { cncVersionId: null },
+        data: { cncVersionId: cncVersion.id },
+      })
+      console.log(`✅ Linked ${updateResult.count} CNC records to version ${MIGRATION_YEAR}`)
+    }
+
+    // Step 4: Find StudySites without a cncVersion but with CNC-linked sites (CUT environment only)
+    const studySitesWithCncButNoVersion = await prismaClient.studySite.findMany({
+      where: {
+        cncVersionId: null,
+        site: {
+          cnc: {
+            isNot: null,
+          },
+        },
+        study: {
+          organizationVersion: {
+            environment: Environment.CUT,
+          },
+        },
+      },
+      include: {
+        site: {
+          include: {
+            cnc: true,
+          },
+        },
+        study: {
+          select: {
+            organizationVersion: {
+              select: {
+                environment: true,
+              },
+            },
+          },
+        },
+      },
+    })
+
+    console.log(`📊 Found ${studySitesWithCncButNoVersion.length} StudySites with CNC data but no version`)
+
+    // Step 5: Link StudySites to the 2023 version
+    if (studySitesWithCncButNoVersion.length > 0) {
+      console.log('🔄 Linking existing StudySites to CNC version...')
+      const updatePromises = studySitesWithCncButNoVersion.map((studySite) =>
+        prismaClient.studySite.update({
+          where: { id: studySite.id },
+          data: { cncVersionId: cncVersion.id },
+        }),
+      )
+
+      await Promise.all(updatePromises)
+      console.log(`✅ Linked ${studySitesWithCncButNoVersion.length} StudySites to version ${MIGRATION_YEAR}`)
+    }
+
+    console.log('🎉 CNC version linking migration completed successfully!')
+
+    // Summary
+    console.log('\n📋 Migration Summary:')
+    console.log(`- CNC version ${MIGRATION_YEAR} is ready`)
+    console.log(`- Linked ${cncsWithoutVersion.length} existing CNC records`)
+    console.log(`- Linked ${studySitesWithCncButNoVersion.length} existing StudySites`)
+    console.log(`- Future CNC imports will automatically use versioning`)
+  } catch (error) {
+    console.error('❌ Migration failed:', error)
+    throw error
+  } finally {
+    await prismaClient.$disconnect()
+  }
+}
+
+linkExistingCncsToVersion()

--- a/src/services/serverFunctions/study.ts
+++ b/src/services/serverFunctions/study.ts
@@ -284,6 +284,7 @@ export const createStudyCommand = async (
 
               if (cncData) {
                 Object.assign(studySiteData, mapCncToStudySite(cncData))
+                studySiteData.cncVersionId = cncData.cncVersionId
               }
 
               return studySiteData

--- a/src/utils/cnc.ts
+++ b/src/utils/cnc.ts
@@ -9,6 +9,7 @@ export interface CncData {
   semainesActivite?: number | null
   latitude?: number | null
   longitude?: number | null
+  cncVersionId?: string | null
 }
 
 /**
@@ -19,6 +20,7 @@ export interface StudySiteData {
   numberOfTickets?: number | null
   numberOfOpenDays?: number | null
   distanceToParis?: number | null
+  cncVersionId?: string | null
 }
 
 /**
@@ -29,6 +31,7 @@ export interface CncToStudySiteMapping {
   numberOfTickets?: number
   numberOfOpenDays?: number
   distanceToParis?: number
+  cncVersionId?: string | null
 }
 
 const DEFAULT_STUDY_SITE_DATA: StudySiteData = {
@@ -68,6 +71,10 @@ export const mapCncToStudySite = (
       latitude: cncData.latitude,
       longitude: cncData.longitude,
     })
+  }
+
+  if (currentData.cncVersionId == null && cncData.cncVersionId != null) {
+    mapping.cncVersionId = cncData.cncVersionId
   }
 
   return mapping


### PR DESCRIPTION
✅ Fait : 
- Nouvelle table `CncVersion`
- Relation `cncVersion` ajoutée au `StudySite` et au `Cnc`
- Adaptation du script `scripts/cut/cnc/add.ts` pour ajouter le paramètre `--year` pour créer une nouvelle version des CNC ou mettre à jour une existante
- Nouveau script `script/cut/cnc/migrate-cnc-version.ts` pour ajouter une version CNC par défaut à 2023 en staging en prod pour les `StudySite` (uniquement CUT) et CNC sans version
- Utilisation dynamique de `studySite.cncVersion.year` pour la phrase au début de la page "Données générales" CUT 
- Fix concernant l'autocompletion de données de site avec minimum 2 chiffres de numéro auto et non 3.

⚠️ MEP :
- Vérifier que la migration Prisma passe bien
- Après la MEP : lancer le script `npx tsx src/scripts/cut/cnc/migrate-cnc-version.ts`