### PR TITLE
Fix/1811 orga img

### DIFF
--- a/src/components/study/StudiesContainer.tsx
+++ b/src/components/study/StudiesContainer.tsx
@@ -71,7 +71,7 @@ const StudiesContainer = async ({ user, organizationVersionId, isCR }: Props) =>
     <MUIBox component="section">
       <div className="justify-center">
         <Box className={classNames(styles.firstStudyCard, 'flex-col align-center')}>
-          <Image src="/img/orga.png" alt="cr.png" width={177} height={119} />
+          <Image src="/img/orga.png" alt="orga.png" width={177} height={119} />
           <h5>{t('createFirstStudy')}</h5>
           <p>{t('firstStudyMessage')}</p>
           <LinkButton data-testid="new-study" className={classNames('w100 justify-center mb1')} href={creationUrl}>

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,6 +6,7 @@ const COUNT_ROUTE = '/count'
 const TILT_ROUTE = '/tilt'
 const ENV_ROUTES = [COUNT_ROUTE, TILT_ROUTE]
 const publicRoutes = ['/login', '/reset-password', '/activation', '/preview', ...ENV_ROUTES]
+const assetsRoutes = ['/_next', '/img']
 
 const bucketName = process.env.SCW_BUCKET_NAME as string
 const region = process.env.SCW_REGION
@@ -21,12 +22,7 @@ export async function middleware(req: NextRequest) {
     return NextResponse.redirect(countLoginUrl)
   }
 
-  if (
-    !publicRoutes.find((route) => req.nextUrl.pathname.startsWith(route)) &&
-    !req.nextUrl.pathname.startsWith('/_next') &&
-    !req.nextUrl.pathname.startsWith('/img') &&
-    !req.nextUrl.pathname.startsWith('/favicon.ico')
-  ) {
+  if (![...publicRoutes, ...assetsRoutes].find((route) => req.nextUrl.pathname.startsWith(route))) {
     const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET })
 
     if (!token) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -21,7 +21,12 @@ export async function middleware(req: NextRequest) {
     return NextResponse.redirect(countLoginUrl)
   }
 
-  if (!publicRoutes.find((route) => req.nextUrl.pathname.startsWith(route))) {
+  if (
+    !publicRoutes.find((route) => req.nextUrl.pathname.startsWith(route)) &&
+    !req.nextUrl.pathname.startsWith('/_next') &&
+    !req.nextUrl.pathname.startsWith('/img') &&
+    !req.nextUrl.pathname.startsWith('/favicon.ico')
+  ) {
     const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET })
 
     if (!token) {


### PR DESCRIPTION
#1811 

Image présente en local, ce serait scalingo qui la bloque dans le middleware (la commande `curl -I https://bilancarbone-staging.osc-fr1.scalingo.io/img/orga.png`) renvoit vers le /login. J'ai donc autorisé les images dans le middleware

Déployé et testé en direct sur staging

PR liée au(x) ticket(s) :

### Tests

- [x] J'ai bien testé ma PR sur tous les environnements concernés
- [ ] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés - RAS
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique - RAS

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP - RAS
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées - RAS
