### PR TITLE
feat: add alert message above graph if non validated sources in actua…

### DIFF
--- a/src/components/pages/TrajectoryReductionPage.tsx
+++ b/src/components/pages/TrajectoryReductionPage.tsx
@@ -144,6 +144,33 @@ const TrajectoryReductionPage = ({
     [linkedStudies, linkedExternalStudies, withDependencies, validatedOnly],
   )
 
+  const unvalidatedSourcesInfo = useMemo(() => {
+    let totalCount = 0
+    const currentStudyUnvalidatedCount = study.emissionSources.filter((source) => !source.validated).length
+
+    totalCount += currentStudyUnvalidatedCount
+
+    const linkedStudiesWithUnvalidatedSources = linkedStudies
+      .map((linkedStudy) => {
+        const unvalidatedCount = linkedStudy.emissionSources.filter((source) => !source.validated).length
+        totalCount += unvalidatedCount
+        return unvalidatedCount > 0
+          ? {
+              id: linkedStudy.id,
+              name: linkedStudy.name,
+              unvalidatedCount,
+            }
+          : null
+      })
+      .filter((study) => study !== null) as Array<{ id: string; name: string; unvalidatedCount: number }>
+
+    return {
+      currentStudyCount: currentStudyUnvalidatedCount,
+      linkedStudies: linkedStudiesWithUnvalidatedSources,
+      totalCount,
+    }
+  }, [study.emissionSources, linkedStudies])
+
   const trajectoryData = useMemo(() => {
     const studyStartYear = study.startDate.getFullYear()
 
@@ -361,6 +388,8 @@ const TrajectoryReductionPage = ({
             withDependencies={withDependencies}
             setWithDependencies={setWithDependencies}
             pastStudies={pastStudies}
+            validatedOnly={validatedOnly}
+            unvalidatedSourcesInfo={unvalidatedSourcesInfo}
           />
 
           {transitionPlan && (

--- a/src/components/study/transitionPlan/TrajectoryGraph.tsx
+++ b/src/components/study/transitionPlan/TrajectoryGraph.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { getYearsToDisplay, PastStudy, TrajectoryData } from '@/utils/trajectory'
-import { Typography } from '@mui/material'
+import { Alert, Typography } from '@mui/material'
 import { LineChart, LineSeries } from '@mui/x-charts/LineChart'
 import { useTranslations } from 'next-intl'
+import Link from 'next/link'
 import { useCallback, useMemo } from 'react'
 import DependenciesSwitch from '../results/DependenciesSwitch'
 
@@ -27,6 +28,12 @@ interface Props {
   withDependencies: boolean
   setWithDependencies: (value: boolean) => void
   pastStudies: PastStudy[]
+  validatedOnly: boolean
+  unvalidatedSourcesInfo: {
+    currentStudyCount: number
+    linkedStudies: Array<{ id: string; name: string; unvalidatedCount: number }>
+    totalCount: number
+  }
 }
 
 const TrajectoryGraph = ({
@@ -40,6 +47,8 @@ const TrajectoryGraph = ({
   withDependencies,
   setWithDependencies,
   pastStudies = [],
+  validatedOnly,
+  unvalidatedSourcesInfo,
 }: Props) => {
   const t = useTranslations('study.transitionPlan.trajectories.graph')
 
@@ -336,13 +345,35 @@ const TrajectoryGraph = ({
   ])
 
   return (
-    <div className="w100 mb2">
-      <div className="flex align-center justify-between mb1">
+    <div className="w100 flex-col gapped1 mb2">
+      <div className="flex align-center justify-between">
         <Typography variant="h5" component="h2" fontWeight={600}>
           {t('title')}
         </Typography>
         <DependenciesSwitch withDependencies={withDependencies} setWithDependencies={setWithDependencies} />
       </div>
+      {validatedOnly && unvalidatedSourcesInfo.totalCount > 0 && (
+        <Alert severity="warning">
+          {unvalidatedSourcesInfo.currentStudyCount > 0 && (
+            <div>{t('unvalidatedSourcesWarning', { count: unvalidatedSourcesInfo.currentStudyCount })}</div>
+          )}
+          {unvalidatedSourcesInfo.linkedStudies.length > 0 && (
+            <div className="mt1">
+              {t('unvalidatedSourcesLinkedStudiesWarning', {
+                count: unvalidatedSourcesInfo.linkedStudies.reduce((sum, s) => sum + s.unvalidatedCount, 0),
+              })}{' '}
+              {unvalidatedSourcesInfo.linkedStudies.map((study, index) => (
+                <span key={study.id}>
+                  <Link href={`/etudes/${study.id}`}>{study.name}</Link>
+                  {t('unvalidatedSourcesLinkedStudyCount', { count: study.unvalidatedCount })}
+                  {index < unvalidatedSourcesInfo.linkedStudies.length - 1 && ', '}
+                </span>
+              ))}
+              .
+            </div>
+          )}
+        </Alert>
+      )}
       <Typography variant="body2" color="text.secondary">
         {t('subtitle')}
       </Typography>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -930,7 +930,10 @@
           "trajectory15": "SBTi 1.5°C",
           "trajectoryWB2C": "SBTi WB2C",
           "yAxisLabel": "Emissions (tCO2e)",
-          "actionBasedTrajectory": "Action-based trajectory"
+          "actionBasedTrajectory": "Action-based trajectory",
+          "unvalidatedSourcesWarning": "{count, plural, =1 {One emission source is not validated in the current study and is therefore not taken into account in the trajectory calculations.} other {{count} emission sources are not validated in the current study and are therefore not taken into account in the trajectory calculations.}}",
+          "unvalidatedSourcesLinkedStudiesWarning": "{count, plural, =1 {One emission source is not validated in the following past study:} other {{count} emission sources are not validated in the following past studies:}}",
+          "unvalidatedSourcesLinkedStudyCount": " ({count, plural, =1 {1 unvalidated source} other {{count} unvalidated sources}})"
         },
         "linkedStudies": {
           "linked": "Linked studies",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -930,7 +930,10 @@
           "trajectory15": "SBTi 1,5°C",
           "trajectoryWB2C": "SBTi WB2C",
           "actionBasedTrajectory": "Courbe prévisionnelle",
-          "yAxisLabel": "Émissions (tCO2e)"
+          "yAxisLabel": "Émissions (tCO2e)",
+          "unvalidatedSourcesWarning": "{count, plural, =1 {Une source d'émissions n'est pas validée dans l'étude actuelle et n'est donc pas prise en compte dans le calcul des trajectoires.} other {{count} sources d'émissions ne sont pas validées dans l'étude actuelle et ne sont donc pas prises en compte dans le calcul des trajectoires.}}",
+          "unvalidatedSourcesLinkedStudiesWarning": "{count, plural, =1 {Une source d'émissions n'est pas validée dans l' étude passée suivante :} other {{count} sources d'émissions ne sont pas validées dans les études passées suivantes :}}",
+          "unvalidatedSourcesLinkedStudyCount": " ({count, plural, =1 {1 source non validée} other {{count} sources non validées}})"
         },
         "linkedStudies": {
           "linked": "Études liées",


### PR DESCRIPTION
### Fonctionnalités

- Suite de https://github.com/ABC-TransitionBasCarbone/bilan-carbone/pull/2002

Uniquement si l'option pour ne voir que les sources validées est activée, on doit voir une alerte incluant le nombre de sources non validées sur l'étude actuelle et les études liées passées :

<img width="1348" height="694" alt="image" src="https://github.com/user-attachments/assets/5df5a3d1-5199-49f4-833a-a7d6c8dcf8a2" />


### Tests

- [X] J'ai bien testé ma PR sur tous les environnements concernés
- [X] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
