### PR TITLE
fix: set reduction rate value to 2 digits max

### DIFF
--- a/src/components/study/trajectory/TrajectoryCreationModal.tsx
+++ b/src/components/study/trajectory/TrajectoryCreationModal.tsx
@@ -76,7 +76,7 @@ const TrajectoryCreationModal = ({
         description: trajectory.description || '',
         objectives: trajectory.objectives.map((obj) => ({
           targetYear: obj.targetYear.toString(),
-          reductionRate: Math.round(obj.reductionRate * 100),
+          reductionRate: Number((obj.reductionRate * 100).toFixed(2)),
         })),
       })
     }
@@ -112,7 +112,7 @@ const TrajectoryCreationModal = ({
         .map((obj) => ({
           id: obj.id,
           targetYear: getYearFromDateStr(obj.targetYear!),
-          reductionRate: Number(obj.reductionRate) / 100,
+          reductionRate: Number((obj.reductionRate! / 100).toFixed(4)), // Keep precision of 2 digits percentage so 0.01% = 0.0001 => 4 digits
         }))
 
       await callServerFunction(
@@ -149,7 +149,7 @@ const TrajectoryCreationModal = ({
     if (data.trajectoryType === TrajectoryType.CUSTOM) {
       input.objectives = data.objectives.map((obj) => ({
         targetYear: getYearFromDateStr(obj.targetYear!),
-        reductionRate: Number(obj.reductionRate) / 100,
+        reductionRate: Number((obj.reductionRate! / 100).toFixed(4)), // Keep precision of 2 digits percentage so 0.01% = 0.0001 => 4 digits
       }))
     } else if (data.trajectoryType === TrajectoryType.SBTI_15) {
       input.objectives = getDefaultObjectivesForTrajectoryType(TrajectoryType.SBTI_15)

--- a/src/components/study/trajectory/TrajectoryObjectivesTable.tsx
+++ b/src/components/study/trajectory/TrajectoryObjectivesTable.tsx
@@ -5,6 +5,7 @@ import { TableActionButton } from '@/components/base/TableActionButton'
 import { TrajectoryWithObjectives } from '@/db/transitionPlan'
 import { useServerFunction } from '@/hooks/useServerFunction'
 import { deleteObjective, deleteTrajectory } from '@/services/serverFunctions/trajectory'
+import { formatNumber } from '@/utils/number'
 import { getTrajectoryTypeLabel } from '@/utils/trajectory'
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
 import KeyboardArrowRightIcon from '@mui/icons-material/KeyboardArrowRight'
@@ -190,7 +191,7 @@ const TrajectoryObjectivesTable = ({ trajectories, canEdit, transitionPlanId, st
             return null
           }
 
-          return rate !== undefined ? `${(rate * 100).toFixed(1)}%` : null
+          return rate !== undefined ? `${formatNumber(rate * 100, 2)}%` : null
         },
       },
       {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2173,7 +2173,8 @@
     "positiveNumber": "Please enter a positive number",
     "tooSmall": "Please enter a larger value",
     "tooBig": "Please enter a smaller value",
-    "studyYearMustBeBeforeCurrent": "The study year must be before the current study year"
+    "studyYearMustBeBeforeCurrent": "The study year must be before the current study year",
+    "maxTwoDecimals": "The reduction rate must have at most 2 decimal places"
   },
   "common": {
     "actions": {

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -2173,7 +2173,8 @@
     "positiveNumber": "Veuillez saisir un nombre positif",
     "tooSmall": "Veuillez saisir une valeur plus grande",
     "tooBig": "Veuillez saisir une valeur plus petite",
-    "studyYearMustBeBeforeCurrent": "L'année de l'étude doit être antérieure à l'année de l'étude actuelle"
+    "studyYearMustBeBeforeCurrent": "L'année de l'étude doit être antérieure à l'année de l'étude actuelle",
+    "maxTwoDecimals": "Le taux de réduction doit avoir au maximum 2 décimales"
   },
   "common": {
     "actions": {

--- a/src/services/serverFunctions/trajectory.command.ts
+++ b/src/services/serverFunctions/trajectory.command.ts
@@ -7,7 +7,18 @@ export const createObjectiveSchema = () =>
     .object({
       id: z.string().optional(),
       targetYear: z.string().optional().nullable(),
-      reductionRate: z.number().optional().nullable(),
+      reductionRate: z
+        .number()
+        .optional()
+        .nullable()
+        .refine((val) => {
+          if (val === null || val === undefined) {
+            return true
+          }
+          // Check if the number has at most 2 decimal places
+          const decimalPlaces = (val.toString().split('.')[1] || '').length
+          return decimalPlaces <= 2
+        }, setCustomMessage('maxTwoDecimals')),
     })
     .refine((data) => {
       const hasTargetYear = data.targetYear !== undefined && data.targetYear !== null


### PR DESCRIPTION
Je force le taux de réduction des objectifs à 2 chiffres après la virgule maximum pour éviter les problèmes d'imprécision float en javascript.

### Tests

- [X] J'ai bien testé ma PR sur tous les environnements concernés
- [X] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
