### PR TITLE
fix: support case where objective's rate is negative

### DIFF
--- a/src/utils/trajectory.ts
+++ b/src/utils/trajectory.ts
@@ -918,8 +918,6 @@ export const calculateTrajectoriesWithHistory = ({
       sbtiWB2CEnabled,
     )
 
-    console.log('maxYearFromTrajectories', maxYearFromTrajectories)
-
     const customTrajectoriesData: Array<{ id: string; data: TrajectoryData }> = []
     for (const traj of trajectories.filter((t) => selectedCustomTrajectoryIds.includes(t.id))) {
       const referenceTrajectory = calculateCustomTrajectory({


### PR DESCRIPTION
### Fix
On lançait une erreur au cas où le `yearlyReduction`, qui représente la quantité de CO2 à diminuer chaque année, était négatif (donc ça augmente au lieu de diminuer) car je pensais que c'était un cas qui ne devait pas arriver.

Durant la démo, on a mis un taux de réduction négatif pour tester et ça a produit l'erreur. On considère que c'est possible et que ça ne doit pas générer d'erreur.

### Tests

- [X] J'ai bien testé ma PR sur tous les environnements concernés
- [X] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
