### PR TITLE
Fix/2073 cut colors

### DIFF
--- a/src/components/study/card/StudyPostsCard.module.css
+++ b/src/components/study/card/StudyPostsCard.module.css
@@ -7,25 +7,6 @@
   margin: 0 2rem;
 }
 
-.post {
-  border-radius: 1rem;
-  color: white;
-  max-width: var(--card-max-length);
-
-  &.post-darkBlue {
-    background-color: var(--post-darkBlue-light);
-  }
-  &.post-green {
-    background-color: var(--post-green-light);
-  }
-  &.post-blue {
-    background-color: var(--post-blue-light);
-  }
-  &.post-orange {
-    background-color: var(--post-orange-light);
-  }
-}
-
 .header {
   position: relative;
   color: white;
@@ -33,10 +14,6 @@
   @media screen and (max-width: 64rem) {
     padding: 1rem 0.5rem;
   }
-}
-
-.progress {
-  border-radius: 1rem;
 }
 
 .content {
@@ -69,13 +46,5 @@
 
   &.success {
     color: var(--success-100);
-  }
-}
-
-.progressBar {
-  background: var(--warning);
-
-  &.success {
-    background: var(--success-100);
   }
 }

--- a/src/components/study/card/StudyPostsCard.styles.tsx
+++ b/src/components/study/card/StudyPostsCard.styles.tsx
@@ -1,0 +1,27 @@
+import { Post } from '@/services/posts'
+import { styled } from '@mui/material'
+
+export const StyledPostContainer = styled('div', { shouldForwardProp: (prop) => prop !== 'post' })<{ post: Post }>(
+  ({ theme, post }) => ({
+    borderRadius: '1rem',
+    color: 'white',
+    flex: '1',
+    maxWidth: 'var(--card-max-length)',
+    backgroundColor: theme.custom.postColors[post].light,
+  }),
+)
+
+export const StyledProgressLayer = styled('div', { shouldForwardProp: (prop) => prop !== 'post' })<{
+  post: Post
+  percent: number
+}>(({ theme, post, percent }) => ({
+  borderRadius: '1rem',
+
+  height: '100%',
+  position: 'absolute',
+  top: '0',
+  left: '0',
+  width: `${percent.toFixed(0)}%`,
+
+  backgroundColor: theme.custom.postColors[post].dark,
+}))

--- a/src/components/study/card/StudyPostsCard.tsx
+++ b/src/components/study/card/StudyPostsCard.tsx
@@ -2,17 +2,15 @@ import { FullStudy } from '@/db/study'
 import { hasAccessToEmissionSourceValidation } from '@/services/permissions/environment'
 import { Post, subPostsByPost } from '@/services/posts'
 import { withInfobulle } from '@/utils/post'
-import { defaultPostColor, postColors } from '@/utils/study'
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
 import { Environment } from '@prisma/client'
 import classNames from 'classnames'
 import { useTranslations } from 'next-intl'
-import { Dispatch, SetStateAction, useMemo } from 'react'
-import widthStyles from '../../base/ProgressBar.module.css'
-import progressStyles from '../infography/PostHeader.module.css'
+import { Dispatch, SetStateAction } from 'react'
 import PostIcon from '../infography/icons/PostIcon'
 import SelectStudySite from '../site/SelectStudySite'
 import styles from './StudyPostsCard.module.css'
+import { StyledPostContainer, StyledProgressLayer } from './StudyPostsCard.styles'
 
 interface Props {
   study: FullStudy
@@ -25,8 +23,6 @@ interface Props {
 const StudyPostsCard = ({ study, post, studySite, setSite, setGlossary, environment }: Props) => {
   const t = useTranslations('study')
   const tPost = useTranslations('emissionFactors.post')
-
-  const postColor = useMemo(() => (post ? postColors[post] : defaultPostColor), [post])
 
   const emissionSources = study.emissionSources.filter(
     (emissionSource) =>
@@ -48,18 +44,9 @@ const StudyPostsCard = ({ study, post, studySite, setSite, setGlossary, environm
       </div>
       <div className={classNames(styles.postContainer, 'grow flex-col gapped')}>
         <div className="grow justify-center">
-          <div className={classNames(styles.post, styles[`post-${postColor}`], 'grow')}>
+          <StyledPostContainer post={post}>
             <div className={classNames(styles.header, 'flex-col align-center grow')}>
-              {percent > 0 && (
-                <div
-                  className={classNames(
-                    styles.progress,
-                    progressStyles.progress,
-                    progressStyles[`progress-${postColor}`],
-                    widthStyles[`w${percent.toFixed(0)}`],
-                  )}
-                />
-              )}
+              {percent > 0 && <StyledProgressLayer post={post} percent={percent} />}
               <div className={classNames(styles.content, 'flex-cc text-center w100')}>
                 <PostIcon className={styles.icon} post={post} />
                 {tPost(post)}
@@ -73,7 +60,7 @@ const StudyPostsCard = ({ study, post, studySite, setSite, setGlossary, environm
                 )}
               </div>
             </div>
-          </div>
+          </StyledPostContainer>
         </div>
         {hasAccessToEmissionSourceValidation(environment) && (
           <div className={classNames({ [styles.allValidated]: percent === 100 }, 'grow flex-cc')}>


### PR DESCRIPTION
PR liée au(x) ticket(s) : https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/2073#issuecomment-3627267077

Suite aux discussions :
- On reste au maximum iso-BC
- On applique les couleurs du postes spécifique à l'environnement 

### Tests

- [x] J'ai bien testé ma PR sur tous les environnements concernés
- [ ] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
