### PR TITLE
fix: using the right form validation for date in clickson

### DIFF
--- a/src/environments/clickson/study/StudyRightsClickson.tsx
+++ b/src/environments/clickson/study/StudyRightsClickson.tsx
@@ -155,7 +155,7 @@ const StudyRightsClickson = ({ study, editionDisabled, emissionFactorSources }: 
   }
 
   const handleDateChange = useCallback(async () => {
-    const isValid = await form.trigger()
+    const isValid = await dateForm.trigger()
     if (isValid) {
       const values = dateForm.getValues()
       await callServerFunction(() => changeStudyDates(values), {


### PR DESCRIPTION
PR liée au(x) ticket(s) : https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/2092#issuecomment-3656398092

<img width="648" height="269" alt="image" src="https://github.com/user-attachments/assets/df9865f5-d735-4493-bc52-7760551bbefa" />

Mini fix j'avais juste utilisé le mauvais form pour tester la validation des dates