### PR TITLE
fix: right post name for tilt déchets

### DIFF
--- a/src/environments/tilt/study/infography/AllPostsInfography.tsx
+++ b/src/environments/tilt/study/infography/AllPostsInfography.tsx
@@ -86,8 +86,8 @@ const AllPostsInfography = ({ study, data }: Props) => {
           />
           <PostInfography
             studyId={study.id}
-            data={data.find((d) => d.post === TiltPost.Déchets)}
-            post={TiltPost.Déchets}
+            data={data.find((d) => d.post === TiltPost.Dechets)}
+            post={TiltPost.Dechets}
             resultsUnit={study.resultsUnit}
           />
           <PostInfography

--- a/src/environments/tilt/theme/theme.ts
+++ b/src/environments/tilt/theme/theme.ts
@@ -14,7 +14,7 @@ const tiltTheme = createTheme(theme, {
       [TiltPost.TransportDeMarchandises]: { light: '#79C7AB', dark: '#469478' },
       [TiltPost.ConstructionDesLocaux]: { light: '#3F5488', dark: '#0C2155' },
       [TiltPost.Energies]: { light: '#3F5488', dark: '#0C2155' },
-      [TiltPost.Déchets]: { light: '#3F5488', dark: '#0C2155' },
+      [TiltPost.Dechets]: { light: '#3F5488', dark: '#0C2155' },
       [TiltPost.FroidEtClim]: { light: '#3F5488', dark: '#0C2155' },
       [TiltPost.AutresEmissions]: { light: '#3F5488', dark: '#0C2155' },
       [TiltPost.Utilisation]: { light: '#FBBC6B', dark: '#C88938' },

--- a/src/services/posts.ts
+++ b/src/services/posts.ts
@@ -26,7 +26,7 @@ export enum CutPost {
 export enum TiltPost {
   ConstructionDesLocaux = 'ConstructionDesLocaux',
   Energies = BCPost.Energies,
-  Déchets = BCPost.DechetsDirects,
+  Dechets = 'Dechets',
   FroidEtClim = 'FroidEtClim',
   AutresEmissions = 'AutresEmissions',
   DeplacementsDePersonne = 'DeplacementsDePersonne',
@@ -136,7 +136,7 @@ export const subPostsByPostCUT: Record<CutPost, SubPost[]> = {
 export const subPostsByPostTILT: Record<TiltPost, SubPost[]> = {
   [TiltPost.ConstructionDesLocaux]: [SubPost.Batiments, SubPost.AutresInfrastructures],
   [TiltPost.Energies]: subPostsByPostBC[BCPost.Energies],
-  [TiltPost.Déchets]: subPostsByPostBC[BCPost.DechetsDirects],
+  [TiltPost.Dechets]: subPostsByPostBC[BCPost.DechetsDirects],
   [TiltPost.FroidEtClim]: [SubPost.FroidEtClim],
   [TiltPost.AutresEmissions]: [
     SubPost.ActivitesAgricoles,


### PR DESCRIPTION
### Compréhension du bug
Le poste "Déchets" Tilt était mappé à la valeur `BCPost.DechetsDirects` alors que son nom est différent. Certes les sous postes sont identiques mais le nom de poste non. 
Les conséquences étaient qu'on ne trouvait pas les sous postes en cherchant avec "Déchets" et de plus, dans Saisie de données, le poste affichait "Déchets directes" et non "Déchets". 

### Tests

- [X] J'ai bien testé ma PR sur tous les environnements concernés
- [X] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
