### PR TITLE
fix: removing manual import for fe clickson

### DIFF
--- a/src/components/emissionFactor/EmissionFactors.tsx
+++ b/src/components/emissionFactor/EmissionFactors.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { hasAccessToManualImport } from '@/services/permissions/environment'
 import { getEmissionFactorImportVersions, getFELocations } from '@/services/serverFunctions/emissionFactor'
 import { EmissionFactorImportVersion, Environment, Import } from '@prisma/client'
 import { useTranslations } from 'next-intl'
@@ -43,25 +44,29 @@ const EmissionFactors = ({ userOrganizationId, environment, hasActiveLicence }: 
       const selectedImportVersionsArray = Object.values(selectedImportVersions)
 
       setLocationOptions(locationFromBdd.filter((loc) => !!loc).map((loc) => loc.location) ?? [])
-      const manualImport = { id: Import.Manual, source: Import.Manual, name: '' }
-      setImportVersions([
-        manualImport as EmissionFactorImportVersion,
-        ...importVersionsFromBdd.sort((a, b) => {
-          if (a.source === b.source) {
-            return b.createdAt.getTime() - a.createdAt.getTime()
-          } else {
-            return `${a.source} ${a.name}`.localeCompare(`${b.source} ${b.name}`)
-          }
-        }),
-      ])
-      setInitialImportVersions(
-        importVersionsFromBdd.length > 0
-          ? [
-              Import.Manual,
-              ...importVersionsFromBdd.map((iv) => iv.id).filter((id) => selectedImportVersionsArray.includes(id)),
-            ]
-          : [Import.Manual],
-      )
+
+      const importVersions = importVersionsFromBdd.sort((a, b) => {
+        if (a.source === b.source) {
+          return b.createdAt.getTime() - a.createdAt.getTime()
+        } else {
+          return `${a.source} ${a.name}`.localeCompare(`${b.source} ${b.name}`)
+        }
+      })
+
+      const initialImportVersions = importVersionsFromBdd
+        .map((iv) => iv.id)
+        .filter((id) => selectedImportVersionsArray.includes(id))
+
+      if (hasAccessToManualImport(environment)) {
+        setInitialImportVersions(
+          importVersionsFromBdd.length > 0 ? [Import.Manual, ...initialImportVersions] : [Import.Manual],
+        )
+        const manualImport = { id: Import.Manual, source: Import.Manual, name: '' }
+        setImportVersions([manualImport as EmissionFactorImportVersion, ...importVersions])
+      } else {
+        setImportVersions(importVersions)
+        setInitialImportVersions(initialImportVersions || [])
+      }
     }
 
     fetchFiltersInfos()

--- a/src/services/permissions/environment.ts
+++ b/src/services/permissions/environment.ts
@@ -76,3 +76,6 @@ export const hasAccessToSimplifiedStudies = (env: Environment) => {
 export const hasReaderRoleOnStudyAsContributor = isClickson
 
 export const hasAccessToStudyComments = isClickson
+
+export const hasAccessToManualImport = (environment: Environment) =>
+  ([BC, TILT, CUT] as Environment[]).includes(environment)


### PR DESCRIPTION
PR liée au(x) ticket(s) : https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/2298

### Tests

- [x] J'ai bien testé ma PR sur tous les environnements concernés
- [x] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
