### PR TITLE
display warning if negative difference

### DIFF
--- a/src/components/study/results/ConsolatedBEGESDifference.tsx
+++ b/src/components/study/results/ConsolatedBEGESDifference.tsx
@@ -4,7 +4,6 @@ import { wasteEmissionFactors } from '@/constants/wasteEmissionFactors'
 import { EmissionFactorWithParts } from '@/db/emissionFactors'
 import { FullStudy } from '@/db/study'
 import { customRich } from '@/i18n/customRich'
-import { getEnvVar } from '@/lib/environment'
 import { getEmissionResults } from '@/services/emissionSource'
 import { Post } from '@/services/posts'
 import { BegesPostInfos, getBegesEmissionTotal } from '@/services/results/beges'
@@ -88,8 +87,6 @@ const ConsolatedBEGESDifference = ({
   const unitValue = STUDY_UNIT_VALUES[study.resultsUnit]
   const [open, setOpen] = useState(false)
   const router = useRouter()
-
-  const contactMail = getEnvVar('SUPPORT_EMAIL', study.organizationVersion.environment)
 
   const environment = useMemo(() => study.organizationVersion.environment, [study])
 
@@ -220,12 +217,13 @@ const ConsolatedBEGESDifference = ({
 
   const unexplainedDifference = useMemo(() => {
     return (
-      Math.floor(begesTotalNumber) +
-        1 -
-        Math.floor(
-          computedTotalNumber + utilisationEnDependanceValue + wasteTotalDifference + missingCaractDifference,
-        ) >
-      1
+      Math.abs(
+        Math.floor(begesTotalNumber) +
+          1 -
+          Math.floor(
+            computedTotalNumber + utilisationEnDependanceValue + wasteTotalDifference + missingCaractDifference,
+          ),
+      ) > 1
     )
   }, [
     begesTotalNumber,


### PR DESCRIPTION
Le warning de différence entre beges et bc non expliquées ne s'affichait pas si la différence est négative


PR liée au(x) ticket(s) :

### Tests

- [ ] J'ai bien testé ma PR sur tous les environnements concernés
- [ ] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
