### PR TITLE
fix 0 when no emissionValue

### DIFF
--- a/src/components/study/EmissionSource.tsx
+++ b/src/components/study/EmissionSource.tsx
@@ -269,7 +269,7 @@ const EmissionSource = ({
               <p className={styles.resultText} data-testid="emission-source-value">
                 {`${formatNumber(emissionResults.emissionValue / STUDY_UNIT_VALUES[study.resultsUnit])} ${tResultstUnits(study.resultsUnit)}`}
               </p>
-              {emissionResults.emissionValue && (
+              {!!emissionResults.emissionValue && (
                 <p
                   className={classNames(styles.resultQuality, styles.resultText)}
                   data-testid="emission-source-quality"


### PR DESCRIPTION
PR liée au(x) ticket(s) :

Mini fix, il y a un 0 qui s'affiche sur les sources d'émissions à la place de l'incertitude tant qu'il n'y a pas de donnée d'activité. Il faudrait faire le même chngement sur master avant la mep 

### Tests

- [ ] J'ai bien testé ma PR sur tous les environnements concernés
- [ ] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
