### PR TITLE
refactor: moving typeform button post

### DIFF
--- a/src/components/base/Block.module.css
+++ b/src/components/base/Block.module.css
@@ -26,3 +26,7 @@
 .actions {
   gap: 1rem;
 }
+
+.noPadding {
+  padding-top: 0 !important;
+}

--- a/src/components/base/Block.tsx
+++ b/src/components/base/Block.tsx
@@ -29,6 +29,7 @@ export interface Props {
   rightComponent?: ReactNode
   isMainContainer?: boolean
   grow?: boolean
+  withPadding?: boolean
 }
 
 const Block = ({
@@ -49,6 +50,7 @@ const Block = ({
   rightComponent,
   isMainContainer = true,
   grow = false,
+  withPadding = true,
   ...rest
 }: Props) => {
   const titleDiv = (
@@ -65,7 +67,15 @@ const Block = ({
   )
 
   return (
-    <div className={classNames(isMainContainer ? 'main-container' : '', styles.block, { grow: fullSize })} {...rest}>
+    <div
+      className={classNames(
+        isMainContainer ? 'main-container' : '',
+        styles.block,
+        { grow: fullSize },
+        withPadding ? '' : styles.noPadding,
+      )}
+      {...rest}
+    >
       <div className={classNames(styles.content, className)}>
         {actions || rightComponent ? (
           <div className={classNames(styles.header, 'align-center justify-between', bold && 'bold')}>

--- a/src/components/study/buttons/StudyPostsBlock.tsx
+++ b/src/components/study/buttons/StudyPostsBlock.tsx
@@ -1,16 +1,20 @@
 'use client'
 import Block from '@/components/base/Block'
 import DebouncedInput from '@/components/base/DebouncedInput'
+import LinkButton from '@/components/base/LinkButton'
+import GlossaryModal from '@/components/modals/GlossaryModal'
 import { FullStudy } from '@/db/study'
+import { hasAccessToPostTypeform } from '@/services/permissions/environment'
 import { Post } from '@/services/posts'
 import { downloadStudyPost } from '@/services/study'
 import { useAppEnvironmentStore } from '@/store/AppEnvironment'
 import { EmissionSourcesFilters, EmissionSourcesSort } from '@/types/filters'
 import DownloadIcon from '@mui/icons-material/Download'
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
 import { EmissionSourceCaracterisation } from '@prisma/client'
 import classNames from 'classnames'
 import { useTranslations } from 'next-intl'
-import { ReactNode, useState } from 'react'
+import { ReactNode, useMemo, useState } from 'react'
 import styles from '../SubPosts.module.css'
 import StudyPostFilters from './StudyPostFilters'
 import StudyPostSort from './StudyPostSort'
@@ -44,6 +48,7 @@ const StudyPostsBlock = ({
 }: Props) => {
   const { environment } = useAppEnvironmentStore()
   const [downloading, setDownloading] = useState(false)
+  const [glossaryTypeform, setGlossaryTypeform] = useState('')
   const tCaracterisations = useTranslations('categorisations')
   const tExport = useTranslations('study.export')
   const tPost = useTranslations('emissionFactors.post')
@@ -53,73 +58,114 @@ const StudyPostsBlock = ({
   const tResultUnits = useTranslations('study.results.units')
   const tBase = useTranslations('emissionFactors.base')
 
+  const showTypeformLink = useMemo(() => {
+    if (!environment) {
+      return false
+    }
+    const typeformPosts: Post[] = [Post.DeplacementsDePersonne]
+    return (
+      process.env.NEXT_PUBLIC_TYPEFORM_DEPLACEMENTS_LINK &&
+      hasAccessToPostTypeform(environment) &&
+      typeformPosts.includes(post as Post)
+    )
+  }, [post, environment])
+
   if (!environment) {
     return null
   }
 
   return (
-    <Block
-      grow
-      title={
-        <div className="flex grow gapped">
-          <DebouncedInput
-            className={classNames(styles.searchInput, 'grow')}
-            debounce={500}
-            value={filters.search}
-            onChange={(newValue) => setFilters({ search: newValue })}
-            placeholder={tStudyPost('search')}
-            data-testid="emission-source-search-field"
-          />
-          <StudyPostFilters
-            filters={filters}
-            setFilters={setFilters}
-            study={study}
-            post={post}
-            caracterisationOptions={caracterisationOptions}
-          />
-          <StudyPostSort sort={sort} setSort={setSort} />
-        </div>
-      }
-      actions={[
-        {
-          actionType: 'loadingButton',
-          onClick: async () => {
-            setDownloading(true)
-            await downloadStudyPost(
-              study,
-              emissionSources,
-              post,
-              tExport,
-              tCaracterisations,
-              tPost,
-              tQuality,
-              tUnit,
-              tBase,
-              tResultUnits,
-              environment,
-            )
-            setDownloading(false)
+    <>
+      {showTypeformLink && (
+        <Block>
+          <div className="justify-end align-center">
+            <LinkButton href={process.env.NEXT_PUBLIC_TYPEFORM_DEPLACEMENTS_LINK} rel="noreferrer noopener">
+              {tPost('seeTypeform')}
+            </LinkButton>
+            <HelpOutlineIcon
+              color="secondary"
+              className="pointer ml-2"
+              onClick={() => setGlossaryTypeform(tPost('seeTypeformDescription'))}
+              aria-label={tPost('seeTypeform')}
+              titleAccess={tPost('seeTypeform')}
+            />
+          </div>
+        </Block>
+      )}
+      <Block
+        withPadding={!showTypeformLink}
+        grow
+        title={
+          <div className="flex grow gapped">
+            <DebouncedInput
+              className={classNames(styles.searchInput, 'grow')}
+              debounce={500}
+              value={filters.search}
+              onChange={(newValue) => setFilters({ search: newValue })}
+              placeholder={tStudyPost('search')}
+              data-testid="emission-source-search-field"
+            />
+            <StudyPostFilters
+              filters={filters}
+              setFilters={setFilters}
+              study={study}
+              post={post}
+              caracterisationOptions={caracterisationOptions}
+            />
+            <StudyPostSort sort={sort} setSort={setSort} />
+          </div>
+        }
+        actions={[
+          {
+            actionType: 'loadingButton',
+            onClick: async () => {
+              setDownloading(true)
+              await downloadStudyPost(
+                study,
+                emissionSources,
+                post,
+                tExport,
+                tCaracterisations,
+                tPost,
+                tQuality,
+                tUnit,
+                tBase,
+                tResultUnits,
+                environment,
+              )
+              setDownloading(false)
+            },
+            disabled: emissionSources.length === 0,
+            loading: downloading,
+            children: (
+              <>
+                {tExport('download')}
+                {!downloading && <DownloadIcon />}
+              </>
+            ),
           },
-          disabled: emissionSources.length === 0,
-          loading: downloading,
-          children: (
-            <>
-              {tExport('download')}
-              {!downloading && <DownloadIcon />}
-            </>
-          ),
-        },
-        {
-          actionType: 'button',
-          onClick: () => setDisplay(!display),
-          'aria-expanded': display,
-          'aria-controls': 'study-post-infography',
-          children: tStudyPost(display ? 'hideInfography' : 'displayInfography'),
-        },
-      ]}
-    >
-      {children}
-    </Block>
+          {
+            actionType: 'button',
+            onClick: () => setDisplay(!display),
+            'aria-expanded': display,
+            'aria-controls': 'study-post-infography',
+            children: tStudyPost(display ? 'hideInfography' : 'displayInfography'),
+          },
+        ]}
+      >
+        {children}
+      </Block>
+      {glossaryTypeform && (
+        <GlossaryModal
+          glossary={'seeTypeform'}
+          label="typeform-glossary"
+          t={tPost}
+          onClose={() => setGlossaryTypeform('')}
+        >
+          {glossaryTypeform}
+        </GlossaryModal>
+      )}
+    </>
   )
 }
 

--- a/src/components/study/card/StudyPostsCard.tsx
+++ b/src/components/study/card/StudyPostsCard.tsx
@@ -1,14 +1,12 @@
-import LinkButton from '@/components/base/LinkButton'
-import GlossaryModal from '@/components/modals/GlossaryModal'
 import { FullStudy } from '@/db/study'
-import { hasAccessToEmissionSourceValidation, hasAccessToPostTypeform } from '@/services/permissions/environment'
+import { hasAccessToEmissionSourceValidation } from '@/services/permissions/environment'
 import { Post, subPostsByPost } from '@/services/posts'
 import { withInfobulle } from '@/utils/post'
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
 import { Environment } from '@prisma/client'
 import classNames from 'classnames'
 import { useTranslations } from 'next-intl'
-import { Dispatch, SetStateAction, useMemo, useState } from 'react'
+import { Dispatch, SetStateAction } from 'react'
 import PostIcon from '../infography/icons/PostIcon'
 import SelectStudySite from '../site/SelectStudySite'
 import styles from './StudyPostsCard.module.css'
@@ -26,8 +24,6 @@ const StudyPostsCard = ({ study, post, studySite, setSite, setGlossary, environm
   const t = useTranslations('study')
   const tPost = useTranslations('emissionFactors.post')
 
-  const [glossaryTypeform, setGlossaryTypeform] = useState('')
-
   const emissionSources = study.emissionSources.filter(
     (emissionSource) =>
       subPostsByPost[post].includes(emissionSource.subPost) && emissionSource.studySite.id === studySite,
@@ -35,31 +31,8 @@ const StudyPostsCard = ({ study, post, studySite, setSite, setGlossary, environm
   const validated = emissionSources.filter((emissionSource) => emissionSource.validated).length
   const percent = emissionSources.length ? Math.floor((validated / emissionSources.length) * 100) : 0
 
-  const showTypeformLink = useMemo(() => {
-    const typeformPosts: Post[] = [Post.DeplacementsDePersonne, Post.TransportDeMarchandises]
-    return (
-      process.env.NEXT_PUBLIC_TYPEFORM_DEPLACEMENTS_LINK &&
-      hasAccessToPostTypeform(environment) &&
-      typeformPosts.includes(post as Post)
-    )
-  }, [post, environment])
-
   return (
     <div className={classNames(styles.card, 'flex-col px1')}>
-      {showTypeformLink && (
-        <div className="justify-end align-center">
-          <LinkButton href={process.env.NEXT_PUBLIC_TYPEFORM_DEPLACEMENTS_LINK} rel="noreferrer noopener">
-            {tPost('seeTypeform')}
-          </LinkButton>
-          <HelpOutlineIcon
-            color="secondary"
-            className="pointer ml-2"
-            onClick={() => setGlossaryTypeform(tPost('seeTypeformDescription'))}
-            aria-label={tPost('seeTypeform')}
-            titleAccess={tPost('seeTypeform')}
-          />
-        </div>
-      )}
       <div className="justify-end align-center">
         <SelectStudySite
           sites={study.sites}
@@ -105,16 +78,6 @@ const StudyPostsCard = ({ study, post, studySite, setSite, setGlossary, environm
           </div>
         )}
       </div>
-      {glossaryTypeform && (
-        <GlossaryModal
-          glossary={'seeTypeform'}
-          label="typeform-glossary"
-          t={tPost}
-          onClose={() => setGlossaryTypeform('')}
-        >
-          {glossaryTypeform}
-        </GlossaryModal>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
PR liée au(x) ticket(s) : https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/1984#issuecomment-3786563896

<img width="1385" height="698" alt="image" src="https://github.com/user-attachments/assets/d79d8a55-9fb0-4c47-aeaf-0611e4420198" />

@GChabahABC Tu me diras si ça te semble bon, si je bouge l'icone ou bien que je mets le bouton encore plus proche

### Tests

- [x] J'ai bien testé ma PR sur tous les environnements concernés
- [x] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
