### PR TITLE
feat: allowing invited users to duplicate sites on existing sites

### DIFF
--- a/src/components/study/perimeter/StudyPerimeter.tsx
+++ b/src/components/study/perimeter/StudyPerimeter.tsx
@@ -388,9 +388,7 @@ const StudyPerimeter = ({ study, organizationVersion, userRoleOnStudy, caUnit, u
               form={isEditing ? (siteForm as unknown as UseFormReturn<SitesCommand>) : undefined}
               caUnit={caUnit}
               withSelection
-              onDuplicate={
-                !isEditing && hasEditionRole && isFromStudyOrganizationOrParent ? setDuplicatingSiteId : undefined
-              }
+              onDuplicate={!isEditing && hasEditionRole ? setDuplicatingSiteId : undefined}
               organizationId={isFromStudyOrganizationOrParent ? study.organizationVersion.id : undefined}
             />
           ),
@@ -401,9 +399,7 @@ const StudyPerimeter = ({ study, organizationVersion, userRoleOnStudy, caUnit, u
             form={isEditing ? (siteForm as unknown as UseFormReturn<SitesCommand>) : undefined}
             caUnit={caUnit}
             withSelection
-            onDuplicate={
-              !isEditing && hasEditionRole && isFromStudyOrganizationOrParent ? setDuplicatingSiteId : undefined
-            }
+            onDuplicate={!isEditing && hasEditionRole ? setDuplicatingSiteId : undefined}
             organizationId={isFromStudyOrganizationOrParent ? study.organizationVersion.id : undefined}
           />
         }


### PR DESCRIPTION
PR liée au(x) ticket(s) : https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/2409

@cmolle @RomainCrevecoeur 
J'ai bien testé j'ai l'impression que cette seule modification suffit, l'utilisateur peut copier mais pas créer

- Est-ce que je lui empêche de copier les autres infos qu'emission source ?
- Est-ce que je laisse la feature pour clickson ou les utilisateurs n'auront pas cette possibilité ?

<img width="922" height="658" alt="image" src="https://github.com/user-attachments/assets/a1c1fd08-9df8-4dfa-8f35-cacc7b41d7a5" />


### Tests

- [x] J'ai bien testé ma PR sur tous les environnements concernés
- [ ] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
