### PR TITLE
fix: fixing bug simplified studies tilt

### DIFF
--- a/src/components/study/new/ExportCheckbox.tsx
+++ b/src/components/study/new/ExportCheckbox.tsx
@@ -93,7 +93,7 @@ const ExportCheckbox = ({
         className={styles.field}
         control={
           <Checkbox
-            checked={!!values.exports.includes(exportType)}
+            checked={!!values.exports?.includes(exportType)}
             className={styles.checkbox}
             disabled={!isExportAvailable || disabled}
             data-testid={`export-checkbox-${exportType}`}
@@ -116,10 +116,10 @@ const ExportCheckbox = ({
             )}
           </span>
         }
-        value={!!values.exports.includes(exportType)}
+        value={!!values.exports?.includes(exportType)}
         onChange={(_, checked) => onChange(exportType, checked)}
       />
-      {index === 0 && !!values.exports.length && (
+      {index === 0 && !!values.exports?.length && (
         <div className={styles.field}>
           <FormControl fullWidth>
             <Select

--- a/src/utils/study.ts
+++ b/src/utils/study.ts
@@ -210,11 +210,15 @@ export const exportSpecificFields: Record<Export, (keyof UpdateEmissionSourceCom
   [Export.ISO14069]: [],
 }
 
-export const getAllSpecificFieldsForExports = (exportTypes: Export[]) =>
-  exportTypes.reduce(
+export const getAllSpecificFieldsForExports = (exportTypes: Export[]) => {
+  if (!exportTypes) {
+    return []
+  }
+  return exportTypes.reduce(
     (res, exportType) => unique(exportType ? res.concat(exportSpecificFields[exportType as Export]) : res),
     [] as (keyof UpdateEmissionSourceCommand)[],
   )
+}
 
 export const formatEmission = (getValue: Getter<number>, resultsUnit: StudyResultUnit) =>
   formatNumber(getValue() / STUDY_UNIT_VALUES[resultsUnit])


### PR DESCRIPTION
PR liée au(x) ticket(s) : https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/2450

Je pouvais aussi régler en faisant ça mais j’ai l’impression que ça aurait pu casser d’autres choses déjà en place depuis longtemps j’ai préféré changer le code récent 

```
- -- a/src/components/study/perimeter/StudyPerimeter.tsx
+++ b/src/components/study/perimeter/StudyPerimeter.tsx
- `exports: study.exports?.types,`
+ `exports: study.exports?.types || [],`
```

### Tests

- [x] J'ai bien testé ma PR sur tous les environnements concernés
- [ ] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
