### PR TITLE
fix: disconnect org for existing imported invited users + revert Loui's fix

### DIFF
--- a/src/services/email/email.ts
+++ b/src/services/email/email.ts
@@ -3,7 +3,7 @@ import { getEnvVar } from '@/lib/environment'
 import { Environment } from '@prisma/client'
 import { getTranslations } from 'next-intl/server'
 import { sendEmail } from './send'
-import { getActivationInvitationLink, getEnvResetLink } from './utils'
+import { getEnvResetLink } from './utils'
 
 const BASE_URL = process.env.NEXTAUTH_URL
 
@@ -74,26 +74,6 @@ export const sendActivationEmail = async (toEmail: string, token: string, fromRe
     },
   )
 }
-
-export const sendActivationInvitationEmail = async (
-  toEmail: string,
-  creatorName: string,
-  userName: string,
-  isUser: boolean,
-  studyName: string,
-  env: Environment,
-) =>
-  sendEmail(
-    env,
-    [toEmail],
-    await tSubject(isUser ? 'userOnStudyInvitation' : 'contributorInvitation', { studyName }),
-    'new-user',
-    {
-      creatorName,
-      userName,
-      link: getActivationInvitationLink(toEmail, env),
-    },
-  )
 
 export const sendActivationRequest = async (
   toEmailList: string[],

--- a/src/services/email/utils.ts
+++ b/src/services/email/utils.ts
@@ -24,8 +24,3 @@ export const getEnvResetLink = (path: string, token: string, env?: Environment) 
 
   return `${process.env.NEXTAUTH_URL}${route}/${token}`
 }
-
-export const getActivationInvitationLink = (email: string, env?: Environment) => {
-  const route = getEnvRoute('activation', env)
-  return `${process.env.NEXTAUTH_URL}${route}?email=${email}`
-}

--- a/src/services/serverFunctions/study.ts
+++ b/src/services/serverFunctions/study.ts
@@ -81,7 +81,14 @@ import {
   upsertStudyTemplate,
 } from '@/db/study'
 import { getTransitionPlanByStudyId } from '@/db/transitionPlan'
-import { addUser, getUserApplicationSettings, getUserByEmail, getUserSourceById, UserWithAccounts } from '@/db/user'
+import {
+  addUser,
+  getUserApplicationSettings,
+  getUserByEmail,
+  getUserSourceById,
+  updateAccount,
+  UserWithAccounts,
+} from '@/db/user'
 import { LocaleType } from '@/i18n/config'
 import { getLocale } from '@/i18n/locale'
 import { getNestedValue, groupBy } from '@/utils/array'
@@ -866,6 +873,13 @@ const getOrCreateUserAndSendStudyInvite = async (
         environment: organizationVersion.environment,
         status: UserStatus.VALIDATED,
       })) as AccountWithUser
+    } else if (account.status === UserStatus.IMPORTED) {
+      await updateAccount(account.id, {
+        organizationVersion: { disconnect: true },
+        status: UserStatus.VALIDATED,
+        role: Role.COLLABORATOR,
+      })
+      account = (await getAccountByEmailAndEnvironment(email, organizationVersion.environment)) as AccountWithUser
     }
 
     if (!skipInviteEmail) {

--- a/src/services/serverFunctions/user.ts
+++ b/src/services/serverFunctions/user.ts
@@ -72,7 +72,6 @@ import { auth, dbActualizedAuth } from '../auth'
 import { getUserCheckList } from '../checklist'
 import {
   sendActivationEmail,
-  sendActivationInvitationEmail,
   sendActivationRequest,
   sendAddedActiveUserEmail,
   sendAddedUsersByFile,
@@ -145,38 +144,27 @@ export const sendInvitation = async (
   existingAccount?: AccountWithUser,
 ) =>
   withServerResponse('sendInvitation', async () => {
-    if (existingAccount) {
-      if (existingAccount.status === UserStatus.ACTIVE) {
-        return roleOnStudy
-          ? sendUserOnStudyInvitationEmail(
-              email,
-              study.name,
-              study.id,
-              organization.name,
-              `${creator.firstName} ${creator.lastName}`,
-              existingAccount.user.firstName,
-              roleOnStudy,
-              env,
-            )
-          : sendContributorInvitationEmail(
-              email,
-              study.name,
-              study.id,
-              organization.name,
-              `${creator.firstName} ${creator.lastName}`,
-              existingAccount.user.firstName,
-              env,
-            )
-      } else if (existingAccount.status === UserStatus.IMPORTED) {
-        return sendActivationInvitationEmail(
-          email,
-          `${creator.firstName} ${creator.lastName}`,
-          existingAccount.user.firstName,
-          !!roleOnStudy,
-          study.name,
-          env,
-        )
-      }
+    if (existingAccount && existingAccount.status === UserStatus.ACTIVE) {
+      return roleOnStudy
+        ? sendUserOnStudyInvitationEmail(
+            email,
+            study.name,
+            study.id,
+            organization.name,
+            `${creator.firstName} ${creator.lastName}`,
+            existingAccount.user.firstName,
+            roleOnStudy,
+            env,
+          )
+        : sendContributorInvitationEmail(
+            email,
+            study.name,
+            study.id,
+            organization.name,
+            `${creator.firstName} ${creator.lastName}`,
+            existingAccount.user.firstName,
+            env,
+          )
     }
 
     const token = await updateUserResetToken(email, 1 * DAY)


### PR DESCRIPTION
Fait : 

- Déconnecter l'orga d'un user existant en IMPORTED, puis suivre le processus normal d'invitation
- J'ai revert [cette PR](https://github.com/ABC-TransitionBasCarbone/bilan-carbone/pull/1888/changes)

### Tests
Testé avec bc-new-1@yopmail.com et onboarding@yopmail.com pour invitation en contributeur ou membre.

- [X] J'ai bien testé ma PR sur tous les environnements concernés
- [ ] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
