### PR TITLE
refactor: removing rule cell for exports

### DIFF
--- a/src/services/study.ts
+++ b/src/services/study.ts
@@ -517,6 +517,11 @@ const buildMerges = (rulesSpans: Record<number, number>, startRow: number, colum
   return merges
 }
 
+const buildRowMerge = (row: number, startCol: number, span: number): Merge => ({
+  s: { r: row, c: startCol },
+  e: { r: row, c: startCol + span - 1 },
+})
+
 export const formatStudyExportResultsForExport = (
   study: FullStudy,
   siteList: { name: string; id: string }[],
@@ -550,12 +555,19 @@ export const formatStudyExportResultsForExport = (
   for (let i = 0; i < siteList.length; i++) {
     const site = siteList[i]
     const resultList = getResults(site.id)
+    const gasFields = data.gasFields
 
     // Merge cells
     sheetOptions['!merges'].push(...buildMerges(rulesSpans, 3 + i * length))
 
     dataForExport.push([site.name])
-    dataForExport.push(['', '', tSpecificExport('ges', { unit: tUnits(study.resultsUnit) })])
+
+    const rowIndex = dataForExport.length
+    const totalCols = gasFields.length + 2
+    dataForExport.push(Array(totalCols).fill(''))
+    dataForExport[rowIndex][2] = tSpecificExport('ges', { unit: tUnits(study.resultsUnit) })
+    sheetOptions['!merges'].push(buildRowMerge(rowIndex, 2, totalCols))
+
     dataForExport.push([
       tSpecificExport('category.title'),
       tSpecificExport('post.title'),
@@ -565,8 +577,6 @@ export const formatStudyExportResultsForExport = (
       tSpecificExport('uncertainty'),
       tStudy('confidenceIntervalTitle'),
     ])
-
-    const gasFields = data.gasFields
 
     for (const result of resultList) {
       const category = result.rule.split('.')[0]


### PR DESCRIPTION
PR liée au(x) ticket(s) : https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/2257

<img width="1852" height="148" alt="image" src="https://github.com/user-attachments/assets/bd528dbc-9058-486b-afa0-365eaf1bd6d7" />


Je remets ce que j'ai dit dans le ticket :

J'ai retiré règle, mais bizarre en relisant la PR de Louis j'ai l'impression que ce "règle" était également déjà là sur BEGES (je l'ai retiré aussi du coup si ça vous va)

Pareil pour ta 2ème question "émissions de GES" s'affichait déjà comme ça sur les exports BEGES

SI jamais voici le code en question dans study.ts

<img width="853" height="94" alt="543675701-62d93490-e147-4060-a973-74b8c35f5274" src="https://github.com/user-attachments/assets/54939bf0-c200-418d-a5e8-1bcb9c461f61" />



### Tests

- [x] J'ai bien testé ma PR sur tous les environnements concernés
- [ ] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
