### PR TITLE
fix: fixing hydratation issues on login pages

### DIFF
--- a/src/app/(public)/(login)/layout.tsx
+++ b/src/app/(public)/(login)/layout.tsx
@@ -1,17 +1,23 @@
 import PublicPage from '@/components/pages/Public'
+import styles from '@/components/pages/Public.module.css'
 import DynamicTheme from '@/environments/core/providers/DynamicTheme'
+import { customRich } from '@/i18n/customRich'
 import { Environment } from '@prisma/client'
+import { getTranslations } from 'next-intl/server'
 import { ReactNode } from 'react'
 
 interface Props {
   children: ReactNode
 }
 
-const PublicLayout = ({ children }: Props) => {
+const PublicLayout = async ({ children }: Props) => {
+  const t = await getTranslations('login')
+  const question = customRich(t, 'question', {}, undefined, { faq: styles.link, support: styles.link })
+
   return (
     <DynamicTheme environment={Environment.BC}>
       <main className="h100">
-        <PublicPage>{children}</PublicPage>
+        <PublicPage question={question}>{children}</PublicPage>
       </main>
     </DynamicTheme>
   )

--- a/src/app/(public-clickson)/layout.tsx
+++ b/src/app/(public-clickson)/layout.tsx
@@ -1,7 +1,10 @@
+import styles from '@/components/pages/Public.module.css'
 import PublicClicksonPage from '@/components/pages/PublicClickson'
 import DynamicTheme from '@/environments/core/providers/DynamicTheme'
+import { customRich } from '@/i18n/customRich'
 import { Environment } from '@prisma/client'
 import { Metadata } from 'next'
+import { getTranslations } from 'next-intl/server'
 import { ReactNode } from 'react'
 
 interface Props {
@@ -13,11 +16,13 @@ export const metadata: Metadata = {
   description: 'Mesurons les émissions de gaz à effet de serre de votre établissement!',
 }
 
-const PublicLayout = ({ children }: Props) => {
+const PublicLayout = async ({ children }: Props) => {
+  const t = await getTranslations('login')
+  const question = customRich(t, 'question', {}, Environment.CLICKSON, { faq: styles.link, support: styles.link })
   return (
     <DynamicTheme environment={Environment.CLICKSON}>
       <main className="h100">
-        <PublicClicksonPage>{children}</PublicClicksonPage>
+        <PublicClicksonPage question={question}>{children}</PublicClicksonPage>
       </main>
     </DynamicTheme>
   )

--- a/src/app/(public-cut)/layout.tsx
+++ b/src/app/(public-cut)/layout.tsx
@@ -1,7 +1,10 @@
+import styles from '@/components/pages/Public.module.css'
 import PublicCutPage from '@/components/pages/PublicCut'
 import DynamicTheme from '@/environments/core/providers/DynamicTheme'
+import { customRich } from '@/i18n/customRich'
 import { Environment } from '@prisma/client'
 import { Metadata } from 'next'
+import { getTranslations } from 'next-intl/server'
 import { ReactNode } from 'react'
 
 interface Props {
@@ -13,11 +16,13 @@ export const metadata: Metadata = {
   description: "Count le premier calculateur d'impact écologique dédié aux salles de cinéma",
 }
 
-const PublicLayout = ({ children }: Props) => {
+const PublicLayout = async ({ children }: Props) => {
+  const t = await getTranslations('login')
+  const question = customRich(t, 'question', {}, Environment.CUT, { faq: styles.link, support: styles.link })
   return (
     <DynamicTheme environment={Environment.CUT}>
       <main className="h100">
-        <PublicCutPage>{children}</PublicCutPage>
+        <PublicCutPage question={question}>{children}</PublicCutPage>
       </main>
     </DynamicTheme>
   )

--- a/src/app/(public-tilt)/layout.tsx
+++ b/src/app/(public-tilt)/layout.tsx
@@ -1,7 +1,10 @@
+import styles from '@/components/pages/Public.module.css'
 import PublicTiltPage from '@/components/pages/PublicTilt'
 import DynamicTheme from '@/environments/core/providers/DynamicTheme'
+import { customRich } from '@/i18n/customRich'
 import { Environment } from '@prisma/client'
 import { Metadata } from 'next'
+import { getTranslations } from 'next-intl/server'
 import { ReactNode } from 'react'
 
 interface Props {
@@ -13,11 +16,13 @@ export const metadata: Metadata = {
   description: 'Découvrez le logiciel Bilan Carbone + pour les associations',
 }
 
-const PublicLayout = ({ children }: Props) => {
+const PublicLayout = async ({ children }: Props) => {
+  const t = await getTranslations('login')
+  const question = customRich(t, 'question', {}, Environment.TILT, { faq: styles.link, support: styles.link })
   return (
     <DynamicTheme environment={Environment.TILT}>
       <main className="h100">
-        <PublicTiltPage>{children}</PublicTiltPage>
+        <PublicTiltPage question={question}>{children}</PublicTiltPage>
       </main>
     </DynamicTheme>
   )

--- a/src/components/pages/Public.tsx
+++ b/src/components/pages/Public.tsx
@@ -12,10 +12,11 @@ import Image from '../document/Image'
 import styles from './Public.module.css'
 
 interface Props {
+  question: ReactNode
   children: ReactNode
 }
 
-const PublicPage = ({ children }: Props) => {
+const PublicPage = ({ question, children }: Props) => {
   const t = useTranslations('login')
   const tLocale = useTranslations('locale')
   const [locale, setLocale] = useState<LocaleType>(defaultLocale)
@@ -42,7 +43,7 @@ const PublicPage = ({ children }: Props) => {
           height={400}
           className={classNames(styles.image, 'w100')}
         />
-        <p>{customRich(t, 'question', {}, undefined, { faq: styles.link, support: styles.link })}</p>
+        <p>{question}</p>
       </div>
       <div className={classNames(styles.loginForm, 'grow flex-col')}>
         <div className={classNames(styles.header, 'justify-between')}>

--- a/src/components/pages/PublicClickson.tsx
+++ b/src/components/pages/PublicClickson.tsx
@@ -1,6 +1,5 @@
 'use client'
 import { defaultLocale, Locale, LocaleType } from '@/i18n/config'
-import { customRich } from '@/i18n/customRich'
 import { switchEnvironment } from '@/i18n/environment'
 import { getLocale, switchLocale } from '@/i18n/locale'
 import { Environment } from '@prisma/client'
@@ -13,8 +12,9 @@ import styles from './Public.module.css'
 
 interface Props {
   children: ReactNode
+  question: ReactNode
 }
-const PublicClicksonPage = ({ children }: Props) => {
+const PublicClicksonPage = ({ children, question }: Props) => {
   const t = useTranslations('login')
   const tLocale = useTranslations('locale')
   const [locale, setLocale] = useState<LocaleType>(defaultLocale)
@@ -52,7 +52,7 @@ const PublicClicksonPage = ({ children }: Props) => {
             className={classNames(styles.image, 'w50')}
           />
         </div>
-        <p>{customRich(t, 'question', {}, Environment.CLICKSON, { faq: styles.link, support: styles.link })}</p>
+        <p>{question}</p>
       </div>
       <div className={classNames(styles.loginForm, 'grow flex-col')}>
         <div className={classNames(styles.header, 'justify-between')}>

--- a/src/components/pages/PublicCut.tsx
+++ b/src/components/pages/PublicCut.tsx
@@ -30,8 +30,9 @@ const StyledLoginForm = styled(Container)(({ theme }) => ({
 
 interface Props {
   children: ReactNode
+  question: ReactNode
 }
-const PublicCutPage = ({ children }: Props) => {
+const PublicCutPage = ({ children, question }: Props) => {
   const t = useTranslations('login')
   const tLocale = useTranslations('locale')
   const [locale, setLocale] = useState<LocaleType>(defaultLocale)
@@ -63,7 +64,7 @@ const PublicCutPage = ({ children }: Props) => {
             <Typography className={styles.explanation}>{customRich(t, 'explanation')}</Typography>
           </Box>
         </Box>
-        <p>{customRich(t, 'question', {}, Environment.CUT, { faq: styles.link, support: styles.link })}</p>
+        <p>{question}</p>
         <Box className="justify-between" padding="1.2rem">
           <Image
             className={styles.france2030Logo}

--- a/src/components/pages/PublicTilt.tsx
+++ b/src/components/pages/PublicTilt.tsx
@@ -1,6 +1,5 @@
 'use client'
 import { defaultLocale, Locale, LocaleType } from '@/i18n/config'
-import { customRich } from '@/i18n/customRich'
 import { switchEnvironment } from '@/i18n/environment'
 import { getLocale, switchLocale } from '@/i18n/locale'
 import CloseIcon from '@mui/icons-material/Close'
@@ -14,8 +13,9 @@ import styles from './Public.module.css'
 
 interface Props {
   children: ReactNode
+  question: ReactNode
 }
-const PublicTiltPage = ({ children }: Props) => {
+const PublicTiltPage = ({ children, question }: Props) => {
   const t = useTranslations('login')
   const tLocale = useTranslations('locale')
   const [locale, setLocale] = useState<LocaleType>(defaultLocale)
@@ -43,7 +43,7 @@ const PublicTiltPage = ({ children }: Props) => {
           <CloseIcon />
           <Image src="/logos/tilt/logo_tilt.svg" alt="TILT logo" fill className="w50 hauto" />
         </div>
-        <p>{customRich(t, 'question', {}, Environment.TILT, { faq: styles.link, support: styles.link })}</p>
+        <p>{question}</p>
       </div>
       <div className={classNames(styles.loginForm, 'grow flex-col')}>
         <div className={classNames(styles.header, 'justify-between')}>


### PR DESCRIPTION
PR liée au(x) ticket(s) : https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/2484

J’ai pas refactoré l’appel dans <Error pour pas perdre trop de temps et je pense que c’est pas le plus urgent mais tous les login ont  été réglé il faudra faire attention à l’avenir d’appeler customRich/getEnvVar seulement dans des server component (customRich on peut l’appeler dans des clients à condition de pas utiliser support, abc ou faq qui utilisent getEnVar)

Pour info je crois que l'autre erreur d'hydration que tu vois partout vient du EnvironmentLoader ... j'ai retourné le problème dans tous les sens mais les seuls solutions qui existent l'empêchent d'apparaître donc je pense que je vais pas m'éterniser plus que ça car je pense pas que c'est un gros soucis 

La seule alternative que je vois c'est de ne pas mettre d'animation ? l'écran de chargement serait juste un icone/image fix ou texte maybe

### Tests

- [x] J'ai bien testé ma PR sur tous les environnements concernés
- [ ] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
