### PR TITLE
fix: fixing changing export bug for empty exports studies

### DIFF
--- a/src/components/study/perimeter/StudyPerimeter.tsx
+++ b/src/components/study/perimeter/StudyPerimeter.tsx
@@ -110,7 +110,7 @@ const StudyPerimeter = ({ study, organizationVersion, userRoleOnStudy, caUnit, u
     mode: 'onSubmit',
     reValidateMode: 'onChange',
     defaultValues: {
-      exports: study.exports?.types,
+      exports: study.exports?.types || [],
       controlMode: study.exports?.control,
     },
   })


### PR DESCRIPTION
PR liée au(x) ticket(s) : https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/2494

on faisait des concat sur des exports undefined dans exportCheckboxes
`        const newExports = values.exports.concat(type)
`
### Tests

- [x] J'ai bien testé ma PR sur tous les environnements concernés
- [ ] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
