### PR TITLE
[REFACTOR PUBLICODES] Use publicodes for Clickson PDF export

### DIFF
--- a/src/app/(public)/preview/etudes/[id]/pdf-summary.css
+++ b/src/app/(public)/preview/etudes/[id]/pdf-summary.css
@@ -97,12 +97,12 @@
   margin-bottom: 1.875rem;
 }
 
-.pdf-cinemas-list {
+.pdf-sites-list {
   text-align: left;
   margin-bottom: 1.875rem;
 }
 
-.pdf-cinemas-title {
+.pdf-sites-title {
   font-size: 1rem;
   font-weight: bold;
   margin-bottom: 0.625rem;
@@ -118,7 +118,7 @@
   padding-bottom: 0.625rem;
 }
 
-.pdf-cinema-header {
+.pdf-site-header {
   font-size: 1.25rem;
   font-weight: bold;
   color: var(--mui-palette-primary-main);

--- a/src/environments/clickson/study/PDF/PDFSummary.tsx
+++ b/src/environments/clickson/study/PDF/PDFSummary.tsx
@@ -122,7 +122,7 @@ const PDFSummary = ({ study }: Props) => {
             <h1 className="pdf-title">{tPdf('title', { year })}</h1>
           </div>
 
-          <div className="pdf-cinemas-list page-break-avoid">
+          <div className="pdf-sites-list page-break-avoid">
             <span>
               <ul>
                 {sitesData.map((site) => (

--- a/src/environments/cut/study/PDF/PDFSummary.tsx
+++ b/src/environments/cut/study/PDF/PDFSummary.tsx
@@ -148,9 +148,9 @@ const PDFSummary = ({ study }: Props) => {
             <h1 className="pdf-title">{tPdf('title', { year: study.startDate.getFullYear() })}</h1>
           </div>
 
-          <div className="pdf-cinemas-list page-break-avoid">
+          <div className="pdf-sites-list page-break-avoid">
             <span>
-              <h2 className="pdf-cinemas-title">{tPdf('cinemas.list')}:</h2>
+              <h2 className="pdf-sites-title">{tPdf('cinemas.list')}:</h2>
               <ul>
                 {sitesData.map((site) => (
                   <li key={site.id}>{site.fullName}</li>
@@ -223,7 +223,7 @@ const PDFSummary = ({ study }: Props) => {
             <React.Fragment key={site.id}>
               <div className="pdf-content page-break-before pdf-page-content">
                 <div className="pdf-section">
-                  <h2 className="pdf-cinema-header pdf-header-with-border">
+                  <h2 className="pdf-site-header pdf-header-with-border">
                     {tPdf('results.site', { site: site.fullName })}
                   </h2>
 


### PR DESCRIPTION
PR basée sur #2509.

J'ai gardé la duplication initiale entre les deux composants `PDFSummary` de Cut et Clickson. Je pense que ça pourra être fait si les composants deviennent plus complexes et qu'il y a possibilité de factoriser une plus large partie du code, mais pour l'instant ça ne parait pas justifié selon moi. 

---

PR liée au(x) ticket(s) :

### Tests

- [ ] J'ai bien testé ma PR sur tous les environnements concernés
- [ ] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
