### PR TITLE
fix: make duplication a transaction + fix ghgp and lastEditor issues during duplication

### DIFF
--- a/src/services/serverFunctions/study.test.ts
+++ b/src/services/serverFunctions/study.test.ts
@@ -436,6 +436,8 @@ describe('study', () => {
             },
           }),
           Environment.BC,
+          true,
+          mockTransaction,
         )
 
         expect(mockCreateEmissionSourcesWithReturn).toHaveBeenCalledWith(

--- a/src/services/serverFunctions/study.ts
+++ b/src/services/serverFunctions/study.ts
@@ -225,6 +225,7 @@ export const createStudyCommand = async (
   { organizationVersionId, validator, sites, ...command }: CreateStudyCommand,
   resultsUnit?: StudyResultUnit,
   sourceTagFamilies?: FullStudy['tagFamilies'],
+  tx?: Prisma.TransactionClient,
 ) =>
   withServerResponse('createStudyCommand', async () => {
     const session = await dbActualizedAuth()
@@ -356,8 +357,11 @@ export const createStudyCommand = async (
     }
 
     try {
-      const createdStudy = await createStudy(study, session.user.environment)
-      addUserChecklistItem(UserChecklist.CreateFirstStudy)
+      const createdStudy = await createStudy(study, session.user.environment, true, tx)
+      if (!tx) {
+        // This cannot be part of a transaction easily so it is done in the duplication flow after the transaction is committed
+        await addUserChecklistItem(UserChecklist.CreateFirstStudy)
+      }
       return { id: createdStudy.id }
     } catch (e) {
       console.error(e)
@@ -1470,7 +1474,7 @@ const duplicateEmissionSources = async (
           emissionFactorId: sourceEmissionSource.emissionFactor?.id ?? null,
           studySiteId: targetStudySiteId,
           validated: shouldClearValidations ? false : sourceEmissionSource.validated,
-          ...(lastEditorId ? { lastEditor: { connect: { id: lastEditorId } } } : {}),
+          lastEditorId,
         },
       }
     },
@@ -1544,20 +1548,35 @@ export const duplicateStudyCommand = async (
       throw new Error(NOT_AUTHORIZED)
     }
 
-    const createResult = await createStudyCommand(studyCommand, sourceStudy.resultsUnit, sourceStudy.tagFamilies)
-    if (!createResult.success) {
-      throw new Error(createResult.errorMessage || 'Failed to create study')
-    }
+    const { createdStudyId, createdStudy } = await prismaClient.$transaction(async (tx) => {
+      const createResult = await createStudyCommand(studyCommand, sourceStudy.resultsUnit, sourceStudy.tagFamilies, tx)
+      if (!createResult.success) {
+        throw new Error(createResult.errorMessage || 'Failed to create study')
+      }
 
-    const createdStudyId = createResult.data.id
-    const createdStudy = await getStudyById(createdStudyId, session.user.organizationVersionId)
-    if (!createdStudy) {
-      throw new Error('Failed to retrieve created study')
-    }
+      const id = createResult.data.id
+      const study = await getStudyById(id, session.user.organizationVersionId, tx)
+      if (!study) {
+        throw new Error('Failed to retrieve created study')
+      }
 
-    await prismaClient.$transaction(async (tx) => {
+      const allowedSourcesForNewStudy =
+        session.user.environment === Environment.BC
+          ? (() => {
+              const hasGHGP = studyCommand.exports?.includes(Export.GHGP)
+              return Object.values(Import).filter(
+                (source) => source !== Import.Manual && source !== Import.CUT && (source !== Import.AIB || hasGHGP),
+              )
+            })()
+          : undefined
+
       for (const sourceVersion of sourceStudy.emissionFactorVersions) {
-        await updateStudyEmissionFactorVersion(createdStudyId, sourceVersion.source, sourceVersion.importVersionId, tx)
+        if (
+          sourceVersion.importVersionId &&
+          (!allowedSourcesForNewStudy || allowedSourcesForNewStudy.includes(sourceVersion.source))
+        ) {
+          await updateStudyEmissionFactorVersion(id, sourceVersion.source, sourceVersion.importVersionId, tx)
+        }
       }
 
       const shouldClearCaracterisations = studyCommand.controlMode !== sourceStudy.exports?.control
@@ -1565,12 +1584,16 @@ export const duplicateStudyCommand = async (
       await duplicateEmissionSources(
         tx,
         sourceStudy.emissionSources,
-        createdStudy,
+        study,
         sourceStudy.id,
         shouldClearCaracterisations,
         true,
       )
+
+      return { createdStudyId: id, createdStudy: study }
     })
+
+    await addUserChecklistItem(UserChecklist.CreateFirstStudy)
 
     // This should not be part of the transaction because it contains third party requests which will get executed even if the transaction is rolled back
     if (inviteExistingTeam) {


### PR DESCRIPTION
Bugs résolus : 
- Si on duplique une étude avec export GHG-P et qu'on le désélectionne lors de la duplication, il y a un problème car les sources utilisant AIB ne pourront pas être créées puisque les FE AIB ne sont pas importés pour cette étude dupliquée sans GHG-P > Comme le mentionne la modale, on ne doit pas importer les sources utilisant AIB si le GHG-P n'est pas sélectionné.
- Problème de définition de `lastEditorId` durant la duplication.
- Ajout d'une transaction prisma pour la duplication

### Tests

- [X] J'ai bien testé ma PR sur tous les environnements concernés
- [X] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
