### PR TITLE
feat: autocomplete field for filter fe unit

### DIFF
--- a/src/components/emissionFactor/EmissionFactorsFilters.tsx
+++ b/src/components/emissionFactor/EmissionFactorsFilters.tsx
@@ -9,6 +9,7 @@ import {
   FormLabel,
   ListItemText,
   MenuItem,
+  Popper,
   Select,
   Switch,
   TextField,
@@ -16,7 +17,7 @@ import {
 import { EmissionFactorBase, EmissionFactorImportVersion, SubPost } from '@prisma/client'
 import classNames from 'classnames'
 import { useTranslations } from 'next-intl'
-import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react'
+import { Dispatch, SetStateAction, useEffect, useMemo, useRef, useState } from 'react'
 import Button from '../base/Button'
 import DebouncedInput from '../base/DebouncedInput'
 import MultiSelectAll from '../base/MultiSelectAll'
@@ -50,6 +51,13 @@ export const EmissionFactorsFilters = ({
   const [displayFilters, setDisplayFilters] = useState(true)
   const [displayHideButton, setDisplayHideButton] = useState(false)
 
+  const [unitsInputValue, setUnitsInputValue] = useState('')
+  const unitsOptions = ['all', ...initialSelectedUnits.filter((u) => u !== 'all')]
+  const unitsAllSelected = useMemo(
+    () =>
+      filters.units.filter((item) => item !== 'all').length === initialSelectedUnits.filter((u) => u !== 'all').length,
+    [filters.units, initialSelectedUnits],
+  )
   const filtersRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -141,12 +149,57 @@ export const EmissionFactorsFilters = ({
             <FormLabel id="emissions-unit-selector" component="legend">
               {t('units')}
             </FormLabel>
-            <MultiSelectAll
-              id="emissions-unit"
-              values={filters.units}
-              allValues={initialSelectedUnits.filter((unit) => unit != 'all')}
-              setValues={(values) => setFilters((prevFilters) => ({ ...prevFilters, units: values }))}
-              getLabel={(unit) => tUnit(unit)}
+
+            <Autocomplete
+              multiple
+              disableCloseOnSelect
+              value={filters.units}
+              options={unitsOptions}
+              inputValue={unitsInputValue}
+              clearOnBlur={false}
+              onInputChange={(_, newValue, reason) => {
+                if (reason === 'input') {
+                  setUnitsInputValue(newValue)
+                }
+              }}
+              getOptionLabel={(unit) => (unit === 'all' ? t('all') : tUnit(unit))}
+              getOptionKey={(unit) => unit}
+              filterSelectedOptions={false}
+              onChange={(_, newValue) => {
+                if (newValue.includes('all')) {
+                  setFilters((prev) => ({
+                    ...prev,
+                    units: unitsAllSelected ? [] : initialSelectedUnits.filter((unit) => unit !== 'all'),
+                  }))
+                  return
+                }
+                setFilters((prev) => ({
+                  ...prev,
+                  units: newValue.filter((value) => value !== 'all'),
+                }))
+              }}
+              renderValue={() => <></>}
+              renderOption={(props, option, { selected }) => {
+                const { key, ...restProps } = props
+                if (option === 'all') {
+                  return (
+                    <MenuItem key="all" {...restProps}>
+                      <Checkbox checked={unitsAllSelected} />
+                      <ListItemText primary={t('all')} />
+                    </MenuItem>
+                  )
+                }
+
+                return (
+                  <MenuItem key={option} {...restProps}>
+                    <Checkbox checked={selected} />
+                    <ListItemText primary={tUnit(option)} />
+                  </MenuItem>
+                )
+              }}
+              renderInput={(params) => <TextField {...params} placeholder={t('unitSearchPlaceholder')} />}
+              slots={{ popper: Popper }}
+              slotProps={{ popper: { style: { minWidth: 300 } } }}
             />
           </FormControl>
           {filters.base && (

--- a/src/i18n/translations/en/bc.json
+++ b/src/i18n/translations/en/bc.json
@@ -1666,6 +1666,7 @@
       "location": "Location",
       "locationSearch": "Search by location",
       "locationSearchPlaceholder": "e.g. Europe",
+      "unitSearchPlaceholder": "e.g. kg",
       "base": "Scope 2 approach",
       "Manual": "Manual",
       "edit": "Edit emission factor",

--- a/src/i18n/translations/fr/bc.json
+++ b/src/i18n/translations/fr/bc.json
@@ -1666,6 +1666,7 @@
       "location": "Localisation",
       "locationSearch": "Rechercher par localisation",
       "locationSearchPlaceholder": "ex : Europe",
+      "unitSearchPlaceholder": "ex: kg",
       "base": "Approche scope 2",
       "Manual": "Manuelle",
       "edit": "Éditer le facteur d'émissions",


### PR DESCRIPTION
PR liée au(x) ticket(s) : https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/2322

J’ai un peu réfléchis pour que ça soit pas trop embêtant à utiliser :
- le champs ne se reset pas à la selection
- on garde le menu ouvert 
- on affiche aucune selection dans l’input (ça ferait trop à afficher) 

je sais  pas si c’est encore l’idéal hésitez pas à faire vos retours

### Tests

- [x] J'ai bien testé ma PR sur tous les environnements concernés
- [ ] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
