### PR TITLE
refactor: moving getMessage logic so it can be forced in pdf generation

### DIFF
--- a/src/app/(public)/preview/etudes/[id]/PDFSummaryContainer.tsx
+++ b/src/app/(public)/preview/etudes/[id]/PDFSummaryContainer.tsx
@@ -4,9 +4,9 @@ import PDFSummaryClickson from '@/environments/clickson/study/PDF/PDFSummary'
 import DynamicComponent from '@/environments/core/utils/DynamicComponent'
 import PDFSummaryCut from '@/environments/cut/study/PDF/PDFSummary'
 import { LocaleType } from '@/i18n/config'
-import { switchEnvironment } from '@/i18n/environment'
-import { switchLocale } from '@/i18n/locale'
+import { getMessages } from '@/i18n/utils'
 import { Environment } from '@prisma/client'
+import { NextIntlClientProvider } from 'next-intl'
 import { useEffect, useState } from 'react'
 
 interface Props {
@@ -16,26 +16,28 @@ interface Props {
 }
 
 const PDFSummaryContainer = ({ study, environment, locale }: Props) => {
-  const [canRender, setCanRender] = useState(false)
+  const [messages, setMessages] = useState<{ locale: LocaleType; messages: object } | null>(null)
 
   useEffect(() => {
-    const setTranslationCookies = async () => {
-      await switchLocale(locale)
-      await switchEnvironment(environment)
-      setCanRender(true)
+    const setMessagesLocaleEnvironment = async () => {
+      const messages = await getMessages(locale, environment)
+      setMessages(messages)
     }
-    setTranslationCookies()
+    setMessagesLocaleEnvironment()
   }, [environment, locale])
 
-  if (!canRender) {
+  if (!messages) {
     return null
   }
+
   return (
-    <DynamicComponent
-      forceEnvironment={environment}
-      environmentComponents={{ [Environment.CLICKSON]: <PDFSummaryClickson study={study} /> }}
-      defaultComponent={<PDFSummaryCut study={study} />}
-    />
+    <NextIntlClientProvider locale={messages.locale} messages={messages.messages}>
+      <DynamicComponent
+        forceEnvironment={environment}
+        environmentComponents={{ [Environment.CLICKSON]: <PDFSummaryClickson study={study} /> }}
+        defaultComponent={<PDFSummaryCut study={study} />}
+      />
+    </NextIntlClientProvider>
   )
 }
 

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,11 +1,9 @@
-import { mergeObjects } from '@/utils/object'
 import { Environment } from '@prisma/client'
-import fs from 'fs'
 import { getRequestConfig } from 'next-intl/server'
-import path from 'path'
 import { Locale } from './config'
 import { getEnvironment } from './environment'
 import { getLocale } from './locale'
+import { getMessages } from './utils'
 
 export default getRequestConfig(async () => {
   // Provide a static locale, fetch a user setting,
@@ -14,57 +12,5 @@ export default getRequestConfig(async () => {
 
   const locale = environment === Environment.CUT ? Locale.FR : await getLocale()
 
-  let commonMessages = {}
-  let bcMessages = {}
-
-  try {
-    commonMessages = (await import(`./translations/${locale}/common.json`)).default
-  } catch {
-    console.log(`No common translation file for locale: ${locale}, falling back to default`)
-    commonMessages = (await import(`./translations/${Locale.EN}/common.json`)).default
-  }
-
-  try {
-    bcMessages = (await import(`./translations/${locale}/bc.json`)).default
-  } catch {
-    console.log(`No bc translation file for locale: ${locale}, falling back to default`)
-    bcMessages = (await import(`./translations/${Locale.EN}/bc.json`)).default
-  }
-  const baseMessages = mergeObjects({}, commonMessages, bcMessages)
-
-  if (!environment || environment === Environment.BC) {
-    return {
-      locale,
-      messages: baseMessages,
-    }
-  }
-
-  const envLower = environment.toLocaleLowerCase()
-  const overrideFilePath = path.join(process.cwd(), 'src/i18n/translations', `${locale}/${envLower}.json`)
-
-  let overrideMessages = {}
-  if (fs.existsSync(overrideFilePath)) {
-    overrideMessages = JSON.parse(fs.readFileSync(overrideFilePath, 'utf-8'))
-  } else {
-    console.log(`No translation files at: ${overrideFilePath}`)
-  }
-
-  let publicodesRules = {}
-  try {
-    publicodesRules = (await import(`./translations/${locale}/publicodes/${envLower}-rules.json`)).default
-  } catch {
-    console.log(`No publicodes rules translation file for locale: ${locale} and environment: ${environment}`)
-  }
-
-  let publicodesLayout = {}
-  try {
-    publicodesLayout = (await import(`./translations/${locale}/publicodes/${envLower}-layout.json`)).default
-  } catch {
-    console.log(`No publicodes layout translation file for locale: ${locale} and environment: ${environment}`)
-  }
-
-  return {
-    locale,
-    messages: mergeObjects({}, baseMessages, overrideMessages, publicodesRules, publicodesLayout),
-  }
+  return getMessages(locale, environment)
 })

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -1,0 +1,62 @@
+'use server'
+import { mergeObjects } from '@/utils/object'
+import { Environment } from '@prisma/client'
+import fs from 'fs'
+import path from 'path'
+import { Locale, LocaleType } from './config'
+
+export const getMessages = async (locale: LocaleType, environment?: Environment) => {
+  let commonMessages = {}
+  let bcMessages = {}
+
+  try {
+    commonMessages = (await import(`./translations/${locale}/common.json`)).default
+  } catch {
+    console.log(`No common translation file for locale: ${locale}, falling back to default`)
+    commonMessages = (await import(`./translations/${Locale.EN}/common.json`)).default
+  }
+
+  try {
+    bcMessages = (await import(`./translations/${locale}/bc.json`)).default
+  } catch {
+    console.log(`No bc translation file for locale: ${locale}, falling back to default`)
+    bcMessages = (await import(`./translations/${Locale.EN}/bc.json`)).default
+  }
+  const baseMessages = mergeObjects({}, commonMessages, bcMessages)
+
+  if (!environment || environment === Environment.BC) {
+    return {
+      locale,
+      messages: baseMessages,
+    }
+  }
+
+  const envLower = environment.toLocaleLowerCase()
+  const overrideFilePath = path.join(process.cwd(), 'src/i18n/translations', `${locale}/${envLower}.json`)
+
+  let overrideMessages = {}
+  if (fs.existsSync(overrideFilePath)) {
+    overrideMessages = JSON.parse(fs.readFileSync(overrideFilePath, 'utf-8'))
+  } else {
+    console.log(`No translation files at: ${overrideFilePath}`)
+  }
+
+  let publicodesRules = {}
+  try {
+    publicodesRules = (await import(`./translations/${locale}/publicodes/${envLower}-rules.json`)).default
+  } catch {
+    console.log(`No publicodes rules translation file for locale: ${locale} and environment: ${environment}`)
+  }
+
+  let publicodesLayout = {}
+  try {
+    publicodesLayout = (await import(`./translations/${locale}/publicodes/${envLower}-layout.json`)).default
+  } catch {
+    console.log(`No publicodes layout translation file for locale: ${locale} and environment: ${environment}`)
+  }
+
+  return {
+    locale,
+    messages: mergeObjects({}, baseMessages, overrideMessages, publicodesRules, publicodesLayout),
+  }
+}


### PR DESCRIPTION
PR liée au(x) ticket(s) : https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/2236

Pour info je n'avais pas le soucis en local donc je tente juste une alternative qui me semble + solide que de récupérer les cookies à la génération du PDF

j'ai dû bouger toute la logique des traductions n'hésitez pas à me suggérer un meilleur nommage de fichier/fonction pour ce refactor ! En esperant que cette fois ça fonctionne mieux sur staging/prod

### Tests

- [x] J'ai bien testé ma PR sur tous les environnements concernés
- [x] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
