### PR TITLE
fix: test to fix crash in result page with lazy loading

### DIFF
--- a/src/environments/core/study/results/DynamicAllResults.tsx
+++ b/src/environments/core/study/results/DynamicAllResults.tsx
@@ -1,12 +1,14 @@
 'use client'
 
-import AllResults from '@/components/study/results/AllResults'
 import { EmissionFactorWithParts } from '@/db/emissionFactors'
 import { FullStudy } from '@/db/study'
 import DynamicComponent from '@/environments/core/utils/DynamicComponent'
-import AllResultsPublicodes from '@/environments/simplified/study/results/AllResultsPublicodes'
-import AllResultsTilt from '@/environments/tilt/study/results/AllResults'
 import { Environment, ExportRule, SiteCAUnit } from '@prisma/client'
+import dynamic from 'next/dynamic'
+
+const AllResults = dynamic(() => import('@/components/study/results/AllResults'))
+const AllResultsPublicodes = dynamic(() => import('@/environments/simplified/study/results/AllResultsPublicodes'))
+const AllResultsTilt = dynamic(() => import('@/environments/tilt/study/results/AllResults'))
 
 interface Props {
   study: FullStudy


### PR DESCRIPTION
Liée au DynamicComponent qui charge tous les composants de chaque environment au lieu de juste celui affiché. C'est d'ailleurs ce qu'on voulait régler avec Chloé mais à cause des tests end to end elle avait abandonné.

### Tests

- [X] J'ai bien testé ma PR sur tous les environnements concernés
- [X] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
