### PR TITLE
feat: add glossary for overshoot in legend and table + fix add subobjective only possible for custom type

### DIFF
--- a/apps/bilan-carbone/src/components/study/trajectory/ObjectivesExpandedRow.tsx
+++ b/apps/bilan-carbone/src/components/study/trajectory/ObjectivesExpandedRow.tsx
@@ -179,23 +179,21 @@ const ObjectivesExpandedRow = ({
           title={t('table.defaultObjectives')}
         />
       )}
-      {isCustom && (
-        <div className="flex flex-col gapped-2">
-          <div className="flex align-end justify-between">
-            <Typography variant="body1" color="text.secondary">
-              {t('table.subObjectives')}
-            </Typography>
-            {canEdit && subObjectives.length > 0 && <TableActionButton type="add" onClick={onAddObjective} />}
-          </div>
-          {subObjectives.length > 0 ? (
-            <ObjectivesInnerTable rows={subObjectiveRows} canEdit={canEdit} isDefaultSnbc={isDefaultSnbc} />
-          ) : (
-            <Button variant="outlined" onClick={onAddObjective}>
-              {t('table.addSubObjective')}
-            </Button>
-          )}
+      <div className="flex flex-col gapped-2">
+        <div className="flex align-end justify-between">
+          <Typography variant="body1" color="text.secondary">
+            {t('table.subObjectives')}
+          </Typography>
+          {canEdit && subObjectives.length > 0 && <TableActionButton type="add" onClick={onAddObjective} />}
         </div>
-      )}
+        {subObjectives.length > 0 ? (
+          <ObjectivesInnerTable rows={subObjectiveRows} canEdit={canEdit} isDefaultSnbc={isDefaultSnbc} />
+        ) : (
+          <Button variant="outlined" onClick={onAddObjective}>
+            {t('table.addSubObjective')}
+          </Button>
+        )}
+      </div>
     </div>
   )
 }

--- a/apps/bilan-carbone/src/components/study/trajectory/ObjectivesInnerTable.tsx
+++ b/apps/bilan-carbone/src/components/study/trajectory/ObjectivesInnerTable.tsx
@@ -2,6 +2,7 @@
 
 import BaseTable from '@/components/base/Table'
 import { TableActionButton } from '@/components/base/TableActionButton'
+import GlossaryIconModal from '@/components/modals/GlossaryIconModal'
 import { Typography } from '@mui/material'
 import { ColumnDef, getCoreRowModel, useReactTable } from '@tanstack/react-table'
 import classNames from 'classnames'
@@ -43,7 +44,18 @@ const ObjectivesInnerTable = ({ rows, canEdit, isDefaultSnbc, title }: Props) =>
       { header: tCommon('posts'), accessorKey: 'posts' },
       { header: tCommon('tags'), accessorKey: 'tags' },
       {
-        header: t('table.rates'),
+        header: () => (
+          <div className="flex align-center gapped025">
+            {t('table.rates')}
+            <GlossaryIconModal
+              title="table.ratesGlossary.title"
+              label="reduction-rates"
+              tModal="study.transitionPlan.objectives"
+            >
+              <p>{t('table.ratesGlossary.description')}</p>
+            </GlossaryIconModal>
+          </div>
+        ),
         accessorKey: 'reductionRate',
         cell: ({ row }) => getDisplayedRates(row.original.reductionRate, row.original.correctedRate),
       },

--- a/apps/bilan-carbone/src/components/study/trajectory/ObjectivesTable.tsx
+++ b/apps/bilan-carbone/src/components/study/trajectory/ObjectivesTable.tsx
@@ -3,6 +3,7 @@
 import BaseTable from '@/components/base/Table'
 import baseTableStyles from '@/components/base/Table.module.css'
 import { TableActionButton } from '@/components/base/TableActionButton'
+import GlossaryIconModal from '@/components/modals/GlossaryIconModal'
 import { useServerFunction } from '@/hooks/useServerFunction'
 import { customRich } from '@/i18n/customRich'
 import { deleteObjective } from '@/services/serverFunctions/objective.serverFunction'
@@ -307,7 +308,19 @@ const ObjectivesTable = ({
         },
       },
       {
-        header: t('table.rates'),
+        id: 'rates',
+        header: () => (
+          <div className="flex align-center gapped025">
+            {t('table.rates')}
+            <GlossaryIconModal
+              title="table.ratesGlossary.title"
+              label="reduction-rates"
+              tModal="study.transitionPlan.objectives"
+            >
+              <p>{customRich(t, 'table.ratesGlossary.description')}</p>
+            </GlossaryIconModal>
+          </div>
+        ),
         accessorFn: (row) => row,
         cell: ({ row }) => {
           const isExpanded = row.getIsExpanded()

--- a/apps/bilan-carbone/src/components/study/transitionPlan/TrajectoryGraph.tsx
+++ b/apps/bilan-carbone/src/components/study/transitionPlan/TrajectoryGraph.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import GlossaryIconModal from '@/components/modals/GlossaryIconModal'
 import GlossaryModal from '@/components/modals/GlossaryModal'
 import { TRAJECTORY_15_ID, TRAJECTORY_SNBC_GENERAL_ID, TRAJECTORY_WB2C_ID } from '@/constants/trajectory.constants'
 import type { FullStudy } from '@/db/study'
@@ -505,6 +506,15 @@ const TrajectoryGraph = ({
                     <circle cx="12" cy="12" r="6" fill={s.color as string} />
                   </SvgIcon>
                   <Typography variant="body2">{s.label as string}</Typography>
+                  {s.dataType === 'current' && !s.withinThreshold && (
+                    <GlossaryIconModal
+                      title="overshootTrajectoryGlossary.title"
+                      label="current-trajectory"
+                      tModal="study.transitionPlan.trajectories.graph"
+                    >
+                      <p>{customRich(t, 'overshootTrajectoryGlossary.description')}</p>
+                    </GlossaryIconModal>
+                  )}
                 </div>
               ))}
           </div>

--- a/apps/bilan-carbone/src/i18n/translations/en/bc.json
+++ b/apps/bilan-carbone/src/i18n/translations/en/bc.json
@@ -1103,6 +1103,10 @@
             "title": "Reconstruction of past emissions on BC+",
             "description": "Description Gabriel",
             "close": "Close"
+          },
+          "overshootTrajectoryGlossary": {
+            "title": "Pour Gabriel - titre",
+            "description": "Pour Gabriel - description"
           }
         },
         "linkedStudies": {
@@ -1299,6 +1303,10 @@
           "startYear": "Start year",
           "targetYear": "Target year",
           "rates": "Annual reduction: reference / corrected",
+          "ratesGlossary": {
+            "title": "Pour Gabriel - titre",
+            "description": "Pour Gabriel - description"
+          },
           "referenceYear": "Reference year",
           "actions": "Actions",
           "period": "Period",

--- a/apps/bilan-carbone/src/i18n/translations/fr/bc.json
+++ b/apps/bilan-carbone/src/i18n/translations/fr/bc.json
@@ -1103,6 +1103,10 @@
             "title": "Reconstruction des émissions passées sur le BC+",
             "description": "Les émissions historiques affichées sont : - Soit issues de vos études passées, que vous avez renseignées dans la page « Initialisation » - Soit reconstituées à partir des inventaires nationaux français pour les années qui précèdent votre premier bilan. L'outil suppose donc que votre organisation s'est décarbonée au même rythme que la France.",
             "close": "Close"
+          },
+          "overshootTrajectoryGlossary": {
+            "title": "Pour Gabriel - titre",
+            "description": "Pour Gabriel - description"
           }
         },
         "linkedStudies": {
@@ -1299,6 +1303,10 @@
           "startYear": "Année de départ",
           "targetYear": "Année cible",
           "rates": "Réduction annuelle: référence / compensée",
+          "ratesGlossary": {
+            "title": "Pour Gabriel - titre",
+            "description": "Pour Gabriel - description"
+          },
           "referenceYear": "Année de référence",
           "actions": "Actions",
           "period": "Période",


### PR DESCRIPTION
J'ai aussi résolu dans ce ticket un bug où seules les trajectoires custom pouvaient ajouter des sous-objectifs, alors qu'il faut que tous les types de trajectoires puisse le faire (avec un warning en modale si ce n'est pas une personnalisée).

### Tests

- [X] J'ai bien testé ma PR sur tous les environnements concernés
- [X] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
