### PR TITLE
feat: manage multiple FE versions and overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,16 @@ cd apps/bilan-carbone && docker-compose up -d && cd ../..
 ### 4. Set up the database with Prisma
 
 ```bash
-yarn workspace @abc-transitionbascarbone/db-common db:migrate
+yarn prisma migrate dev
 ```
 
 Or in production :
 
 ```bash
-yarn workspace @abc-transitionbascarbone/db-common prisma migrate deploy
+yarn prisma migrate deploy
 ```
 
-### 5. Seed the database
+### 5. Seed the database (cannot use the yarn prisma shortcut)
 
 ```bash
 yarn workspace bilan-carbone prisma db seed
@@ -59,7 +59,7 @@ yarn workspace bilan-carbone prisma db seed
 ### 6. Generated prisma client
 
 ```bash
-yarn workspace @abc-transitionbascarbone/db-common db:generate
+yarn prisma generate
 ```
 
 ### 7. Run the development serve
@@ -70,13 +70,11 @@ yarn dev
 
 The application will be available at [http://localhost:3000](http://localhost:3000)
 
----
-
 ## Commands by workspace
 
 ### bilan-carbone application
 
-````bash
+```bash
 # Development
 yarn workspace bilan-carbone dev
 
@@ -91,24 +89,28 @@ yarn workspace bilan-carbone cypress
 
 # Reset test database
 yarn workspace bilan-carbone db:test:reset
+```
 
 ### Database (db-common)
 
-```bash
+````bash
 # Create a new migration
-yarn workspace @abc-transitionbascarbone/db-common db:migrate
+yarn prisma migrate dev
+
+# Reset the database
+yarn prisma migrate reset
 
 # Apply migrations
-yarn workspace @abc-transitionbascarbone/db-common prisma migrate deploy
+yarn prisma migrate deploy
 
 # Check migration status
-yarn workspace @abc-transitionbascarbone/db-common db:status
+yarn prisma migrate status
 
 # Generate Prisma client
-yarn workspace @abc-transitionbascarbone/db-common db:generate
+yarn prisma generate
 
 # Prisma Studio
-yarn workspace @abc-transitionbascarbone/db-common prisma studio
+yarn prisma studio
 
 ---
 
@@ -157,35 +159,9 @@ yarn workspace bilan-carbone test
 yarn workspace bilan-carbone test:watch
 ```
 
-### Run Publicodes test
-
-```bash
-yarn workspace bilan-carbone publicodes-count:test
-```
-
-### Run Cypress tests
-
-```bash
-# Start the app in test environment connected to the test database
-yarn workspace bilan-carbone dev:test
-
-# Run Cypress tests
-yarn workspace bilan-carbone cypress
-
-# Run a specific test file
-cd apps/bilan-carbone && yarn cypress --spec "src/tests/end-to-end/app/auth.cy.ts"
-
-# Open Cypress GUI
-yarn workspace bilan-carbone cypress:gui
-```
-
----
-
 ## Deploy on Scalingo
 
 Migrations are automatically applied via the Procfile on each deployment
-
----
 
 ## Dependency Upgrades
 

--- a/apps/bilan-carbone/README.md
+++ b/apps/bilan-carbone/README.md
@@ -56,48 +56,93 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
    The application will be available at [http://localhost:3000](http://localhost:3000)
 
-## Import Scripts
+## Import scripts
 
-Run these import scripts in the production environment (change the value of the version):
+These scripts must be run from apps/bilan-carbone:
 
-Importer les facteurs d'emissions de negaoctet :
-`npx tsx src/scripts/negaOctet/getEmissionFactors.ts -n ${versionNumber} -f ${pathToCSVFileNegaOctet}`
+### Import emission factors from NegaOctet
 
-Importer les facteurs d'emissions de legifrance :
-`npx tsx src/scripts/legifrance/getEmissionFactors.ts -n ${versionNumber} -f ${pathToCSVFileLegifrance}`
+```bash
+yarn tsx src/scripts/negaOctet/getEmissionFactors.ts -n ${versionNumber} -f ${pathToCSVFile}
+```
 
-Importer les facteurs d'emissions de la base empreinte :
-`npx tsx src/scripts/baseEmpreinte/getEmissionFactors.ts -n ${versionNumberBaseEmpreinte}"`
+### Import emission factors from Legifrance
 
-Créer les règles de gestion du BEGES :
-`npx tsx src/scripts/exportRules/beges.ts`
+```bash
+yarn tsx src/scripts/legifrance/getEmissionFactors.ts -n ${versionNumber} -f ${pathToCSVFile}
+```
 
-Importer les actualités depuis un CSV :
-`npx tsx src/scripts/actuality/add.ts -f ${pathToCSVFileActuality}`
+### Import emission factors from Base Empreinte
 
-Importer les Donnée cartographie depuis un [CSV du CNC](https://www.cnc.fr/cinema/etudes-et-rapports/statistiques/geolocalisation-des-cinemas-actifs-en-france) :
-`npx tsx src/scripts/cnc/add.ts -f ${pathToCSVFileCNC}`
+```bash
+# Prévisualiser un import sans écrire en base
+yarn tsx src/scripts/baseEmpreinte/getEmissionFactors.ts -n ${versionNumberBaseEmpreinte} -f ${pathToCSVFile} --dry-run
 
-Supprimer les réponses d'une question :
-`npx tsx src/scripts/questions/deleteAnswersWithCleanup.ts -q "question-intern-id-here"`
+# Importer la base empreinte
+yarn tsx src/scripts/baseEmpreinte/getEmissionFactors.ts -n ${versionNumberBaseEmpreinte} -f ${pathToCSVFile}
+
+# Importer la base empreinte en conservant les correctifs manuels existants en cas de conflit
+yarn tsx src/scripts/baseEmpreinte/getEmissionFactors.ts -n ${versionNumberBaseEmpreinte} -f ${pathToCSVFile} --keep-overrides
+
+# Importer la base empreinte en supprimant les correctifs manuels existants en cas de conflit
+yarn tsx src/scripts/baseEmpreinte/getEmissionFactors.ts -n ${versionNumberBaseEmpreinte} -f ${pathToCSVFile} --discard-overrides
+
+# Preview overrides to emission factors (overrides)
+yarn tsx src/scripts/baseEmpreinte/applyOverrides.ts -f ${pathToCSVFile} --dry-run
+
+# Apply overrides to emission factors on an existing version
+yarn tsx src/scripts/baseEmpreinte/applyOverrides.ts -f ${pathToCSVFile}
+
+# Export existing overrides to Excel to modify or add new ones
+yarn tsx src/scripts/baseEmpreinte/exportOverrides.ts
+```
+
+### Create BEGES rules
+
+```bash
+yarn tsx src/scripts/exportRules/beges.ts
+```
+
+### Import actualities
+
+```bash
+yarn tsx src/scripts/actuality/add.ts -f ${pathToCSVFile}
+```
+
+### Import CNC data
+
+Import CNC data from a [CSV file](https://www.cnc.fr/cinema/etudes-et-rapports/statistiques/geolocalisation-des-cinemas-actifs-en-france) :
+
+```bash
+yarn tsx src/scripts/cnc/add.ts -f ${pathToCSVFile}
+```
+
+### Delete answers of a question
+
+```bash
+yarn tsx src/scripts/questions/deleteAnswersWithCleanup.ts -q "question-intern-id-here"
+```
 
 ### Scripts lancés par CRON
 
-Importer les utilisateurs depuis le FTP : `curl -X POST $NEXT_API_URL/cron/import-users -H "Authorization: Bearer $CRON_SECRET"`
+Import users from the FTP server : `curl -X POST $NEXT_API_URL/cron/import-users -H "Authorization: Bearer $CRON_SECRET"`
 
-Créer les études de formation pour les utilisateurs qui ont commencé ou terminé une formation : `curl -X POST $NEXT_API_URL/cron/assign-training-studies -H "Authorization: Bearer $CRON_SECRET"`
+Create training studies for users who have started or ended a formation : `curl -X POST $NEXT_API_URL/cron/assign-training-studies -H "Authorization: Bearer $CRON_SECRET"`
 
-### Importer les données de Secten
+### Import Secten data
 
-Importer les données de Secten en créant une nouvelle version ou en mettant à jour une version existante si le nom de la version est déjà utilisé :
-`npx tsx src/scripts/secten/importSectenData.ts -y ${versionYear} -f ${pathToCSVFileSecten}`
+Import Secten data by creating a new version or updating an existing version if the version name is already used :
 
-Le CSV est créé manuellement depuis l'excel disponible sur le site de Secten.
+```bash
+yarn tsx src/scripts/secten/importSectenData.ts -y ${versionYear} -f ${pathToCSVFileSecten}
+```
 
-- Trouver le fichier <https://www.citepa.org/donnees-air-climat/donnees-gaz-a-effet-de-serre/secten/> > "Données de GES ed X"
-- Télécharger le fichier 01 > Onglet CO2e-UE
-- Copier les valeurs des lignes 7 à 14, sauf la ligne 13, dans le fichier excel template.
-- Puis exporter le fichier excel en CSV avec le delimiter ";" et le format "UTF-8".
+The CSV file is created manually from the Excel file available on the Secten website.
+
+- Find the file <https://www.citepa.org/donnees-air-climat/donnees-gaz-a-effet-de-serre/secten/> > "Données de GES ed X"
+- Download the file 01 > Tab CO2e-UE
+- Copy the values of lines 7 to 14, except line 13, into the excel template file.
+- Then export the excel file to CSV with the delimiter ";" and the format "UTF-8".
 
 ## Prisma Commands
 
@@ -122,6 +167,14 @@ yarn test
 
 # Run tests in watch mode
 yarn test:watch
+```
+
+### Run Publicodes test
+
+```bash
+yarn publicodes-count:test
+yarn publicodes-clickson:test
+yarn publicodes-tilt:test
 ```
 
 ### Run Cypress tests

--- a/apps/bilan-carbone/README.md
+++ b/apps/bilan-carbone/README.md
@@ -74,27 +74,33 @@ yarn tsx src/scripts/legifrance/getEmissionFactors.ts -n ${versionNumber} -f ${p
 
 ### Import emission factors from Base Empreinte
 
+Unchanged EFs between two imports are reused (same DB row). Changed EFs create a new row. Comparison is done via the raw CSV line stored in `importedRawCsv` at import time.
+
+If EFs have been manually corrected via `applyOverrides` and their CSV row has changed, the import fails and requires an explicit choice between `--keep-overrides` and `--discard-overrides`.
+
 ```bash
-# Prévisualiser un import sans écrire en base
+# Preview an import without writing to the database
 yarn tsx src/scripts/baseEmpreinte/getEmissionFactors.ts -n ${versionNumberBaseEmpreinte} -f ${pathToCSVFile} --dry-run
 
-# Importer la base empreinte
+# Import Base Empreinte
 yarn tsx src/scripts/baseEmpreinte/getEmissionFactors.ts -n ${versionNumberBaseEmpreinte} -f ${pathToCSVFile}
 
-# Importer la base empreinte en conservant les correctifs manuels existants en cas de conflit
+# Import while keeping existing manual overrides on changed EFs
 yarn tsx src/scripts/baseEmpreinte/getEmissionFactors.ts -n ${versionNumberBaseEmpreinte} -f ${pathToCSVFile} --keep-overrides
 
-# Importer la base empreinte en supprimant les correctifs manuels existants en cas de conflit
+# Import while discarding existing manual overrides in favor of new CSV values
 yarn tsx src/scripts/baseEmpreinte/getEmissionFactors.ts -n ${versionNumberBaseEmpreinte} -f ${pathToCSVFile} --discard-overrides
 
-# Preview overrides to emission factors (overrides)
-yarn tsx src/scripts/baseEmpreinte/applyOverrides.ts -f ${pathToCSVFile} --dry-run
+# Backfill importedRawCsv on EFs imported before the field was introduced (one-timeon the last version before the field was introduced)
+yarn tsx src/scripts/baseEmpreinte/backfillImportedRawCsv.ts -n ${versionNumberBaseEmpreinte} -f ${pathToCSVFile} --dry-run
+yarn tsx src/scripts/baseEmpreinte/backfillImportedRawCsv.ts -n ${versionNumberBaseEmpreinte} -f ${pathToCSVFile}
 
-# Apply overrides to emission factors on an existing version
-yarn tsx src/scripts/baseEmpreinte/applyOverrides.ts -f ${pathToCSVFile}
+# Preview manual corrections without writing to the database
+yarn tsx src/scripts/baseEmpreinte/applyOverrides.ts -f ${pathToXlsxFile} --dry-run
 
-# Export existing overrides to Excel to modify or add new ones
-yarn tsx src/scripts/baseEmpreinte/exportOverrides.ts
+# Apply manual corrections to existing EFs (writes values directly onto the EF)
+# The Excel file must contain the same columns as the standard import CSV
+yarn tsx src/scripts/baseEmpreinte/applyOverrides.ts -f ${pathToXlsxFile}
 ```
 
 ### Create BEGES rules

--- a/apps/bilan-carbone/package.json
+++ b/apps/bilan-carbone/package.json
@@ -134,7 +134,7 @@
     "@typescript-eslint/eslint-plugin": "^8.59.1",
     "@typescript-eslint/parser": "^8.59.1",
     "csv-parse": "^6.2.1",
-    "cypress": "^15.14.1",
+    "cypress": "^15.14.0",
     "dotenv-cli": "^11.0.0",
     "eslint": "^9.39.2",
     "eslint-config-next": "16.2.4",

--- a/apps/bilan-carbone/prisma/seed/index.ts
+++ b/apps/bilan-carbone/prisma/seed/index.ts
@@ -55,9 +55,15 @@ const users = async () => {
   await prisma.answer.deleteMany()
   await prisma.question.deleteMany()
 
+  await prisma.emissionFactorOverridePartMetaData.deleteMany()
+  await prisma.emissionFactorOverridePart.deleteMany()
+  await prisma.emissionFactorOverrideMetaData.deleteMany()
+  await prisma.emissionFactorOverride.deleteMany()
+
   await prisma.emissionFactorPartMetaData.deleteMany()
   await prisma.emissionFactorPart.deleteMany()
   await prisma.emissionFactorMetaData.deleteMany()
+  await prisma.emissionFactorVersion.deleteMany()
   await prisma.emissionFactor.deleteMany()
 
   await prisma.emissionSourceTag.deleteMany()

--- a/apps/bilan-carbone/prisma/seed/index.ts
+++ b/apps/bilan-carbone/prisma/seed/index.ts
@@ -55,11 +55,6 @@ const users = async () => {
   await prisma.answer.deleteMany()
   await prisma.question.deleteMany()
 
-  await prisma.emissionFactorOverridePartMetaData.deleteMany()
-  await prisma.emissionFactorOverridePart.deleteMany()
-  await prisma.emissionFactorOverrideMetaData.deleteMany()
-  await prisma.emissionFactorOverride.deleteMany()
-
   await prisma.emissionFactorPartMetaData.deleteMany()
   await prisma.emissionFactorPart.deleteMany()
   await prisma.emissionFactorMetaData.deleteMany()

--- a/apps/bilan-carbone/prisma/seed/study.ts
+++ b/apps/bilan-carbone/prisma/seed/study.ts
@@ -1,4 +1,5 @@
-import { getEmissionFactorsFromCSV } from '@/services/importEmissionFactor/baseEmpreinte/getEmissionFactorsFromCSV'
+import { mapBaseEmpreinteEmissionFactors } from '@/services/importEmissionFactor/baseEmpreinte/import'
+import { getEmissionFactorsFromCSV } from '@/services/importEmissionFactor/getEmissionFactorsFromCSV'
 import { addSourceToStudies } from '@/services/importEmissionFactor/import'
 import {
   ControlMode,
@@ -26,12 +27,18 @@ export const createRealStudy = async (prisma: PrismaClient, creator: Account) =>
     return null
   }
 
-  await getEmissionFactorsFromCSV('test', './prisma/seed/Base_Carbone_Test.csv')
+  await getEmissionFactorsFromCSV(
+    'test',
+    './prisma/seed/Base_Carbone_Test.csv',
+    Import.BaseEmpreinte,
+    mapBaseEmpreinteEmissionFactors,
+  )
+
   await prisma.emissionFactorImportVersion.createMany({
     data: [
-      { internId: 'Legifrance_Test.csv', name: 'test', source: Import.Legifrance },
-      { internId: 'Negaoctet_Test.csv', name: 'test', source: Import.NegaOctet },
-      { internId: 'AIB_Test.csv', name: 'test', source: Import.AIB },
+      { name: 'Legifrance_Test.csv', source: Import.Legifrance },
+      { name: 'Negaoctet_Test.csv', source: Import.NegaOctet },
+      { name: 'AIB_Test.csv', source: Import.AIB },
     ],
   })
 
@@ -55,13 +62,15 @@ export const createRealStudy = async (prisma: PrismaClient, creator: Account) =>
   })
 
   const version = await prisma.emissionFactorImportVersion.findFirst({
-    where: { internId: 'Base_Carbone_Test.csv', source: Import.BaseEmpreinte },
+    where: { name: 'test', source: Import.BaseEmpreinte },
   })
   if (!version) {
     return null
   }
 
-  const emissionFactors = await prisma.emissionFactor.findMany({ where: { versionId: version.id } })
+  const emissionFactors = await prisma.emissionFactor.findMany({
+    where: { versions: { some: { importVersionId: version.id } } },
+  })
 
   const papier = await prisma.emissionFactor.create({
     data: {

--- a/apps/bilan-carbone/src/components/emissionFactor/EmissionFactorDetails.tsx
+++ b/apps/bilan-carbone/src/components/emissionFactor/EmissionFactorDetails.tsx
@@ -68,9 +68,9 @@ const EmissionFactorDetails = ({ emissionFactor }: Props) => {
       <div className="flex-col grow">
         <div className={styles.info}>
           <span className={classNames(styles.infoTitle, 'bold')}>{t('source')} : </span>
-          {emissionFactor.importedFrom !== Import.Manual && emissionFactor.version && (
+          {emissionFactor.importedFrom !== Import.Manual && emissionFactor.versions.length > 0 && (
             <>
-              {t(emissionFactor.importedFrom)} {emissionFactor.version.name}
+              {t(emissionFactor.importedFrom)} {emissionFactor.versions.map((v) => v.importVersion.name).join(', ')}
             </>
           )}
           {emissionFactor.source && <> - {emissionFactor.source}</>}

--- a/apps/bilan-carbone/src/components/emissionFactor/EmissionFactors.tsx
+++ b/apps/bilan-carbone/src/components/emissionFactor/EmissionFactors.tsx
@@ -44,7 +44,7 @@ const EmissionFactors = ({ userOrganizationId, environment, hasActiveLicence }: 
       }
       const selectedImportVersionsArray = Object.values(selectedImportVersions)
 
-      setLocationOptions(locationFromBdd.filter((loc) => !!loc).map((loc) => loc.location) ?? [])
+      setLocationOptions(locationFromBdd.flatMap((loc) => (loc.location ? [loc.location] : [])))
 
       const importVersions = importVersionsFromBdd.sort((a, b) => {
         if (a.source === b.source) {

--- a/apps/bilan-carbone/src/components/study/EmissionSource.tsx
+++ b/apps/bilan-carbone/src/components/study/EmissionSource.tsx
@@ -190,10 +190,11 @@ const EmissionSource = ({
 
   const isFromOldImport = useMemo(
     () =>
-      !!selectedFactor?.version?.id &&
-      !study.emissionFactorVersions
-        .map((studyImportVersion) => studyImportVersion.importVersionId)
-        .includes(selectedFactor.version.id),
+      !!selectedFactor &&
+      selectedFactor.versions.length > 0 &&
+      !selectedFactor.versions.some((v) =>
+        study.emissionFactorVersions.map((sv) => sv.importVersionId).includes(v.importVersionId),
+      ),
     [selectedFactor, study.emissionFactorVersions],
   )
 

--- a/apps/bilan-carbone/src/components/study/EmissionSourceFactorModal.tsx
+++ b/apps/bilan-carbone/src/components/study/EmissionSourceFactorModal.tsx
@@ -35,7 +35,7 @@ const EmissionSourceFactorModal = ({
   useEffect(() => {
     async function fetchFiltersInfos() {
       const locationFromBdd = await getFELocations()
-      setLocationOptions(locationFromBdd.filter((loc) => !!loc).map((loc) => loc.location) ?? [])
+      setLocationOptions(locationFromBdd.flatMap((loc) => (loc.location ? [loc.location] : [])))
     }
 
     fetchFiltersInfos()

--- a/apps/bilan-carbone/src/db/emissionFactors.ts
+++ b/apps/bilan-carbone/src/db/emissionFactors.ts
@@ -32,37 +32,6 @@ const versionsSelect = {
   },
 }
 
-const overrideSelect = {
-  select: {
-    totalCo2: true,
-    co2f: true,
-    ch4f: true,
-    ch4b: true,
-    n2o: true,
-    co2b: true,
-    sf6: true,
-    hfc: true,
-    pfc: true,
-    otherGES: true,
-    unit: true,
-    status: true,
-    source: true,
-    location: true,
-    parts: { select: { type: true, totalCo2: true } },
-    metaData: {
-      select: {
-        language: true,
-        title: true,
-        attribute: true,
-        comment: true,
-        frontiere: true,
-        tag: true,
-        location: true,
-      },
-    },
-  },
-}
-
 const otherSelectEmissionFactor = {
   id: true,
   status: true,
@@ -92,7 +61,6 @@ const otherSelectEmissionFactor = {
   pfc: true,
   otherGES: true,
   versions: versionsSelect,
-  override: overrideSelect,
   emissionFactorParts: { select: { type: true, totalCo2: true } },
 }
 
@@ -136,7 +104,6 @@ const selectEmissionFactor = {
     },
   },
   versions: versionsSelect,
-  override: overrideSelect,
   emissionFactorParts: { select: { type: true, totalCo2: true } },
 } as Prisma.EmissionFactorSelect
 
@@ -148,33 +115,6 @@ type EmissionFactorVersion = {
     source: Import
     archived: boolean
   }
-}
-
-export type EmissionFactorOverrideData = {
-  totalCo2: number
-  co2f: number | null
-  ch4f: number | null
-  ch4b: number | null
-  n2o: number | null
-  co2b: number | null
-  sf6: number | null
-  hfc: number | null
-  pfc: number | null
-  otherGES: number | null
-  unit: Unit | null
-  status: EmissionFactorStatus | null
-  source: string | null
-  location: string | null
-  parts: { type: string; totalCo2: number }[]
-  metaData: {
-    language: string
-    title: string | null
-    attribute: string | null
-    comment: string | null
-    frontiere: string | null
-    tag: string | null
-    location: string | null
-  }[]
 }
 
 export type EmissionFactorList = {
@@ -215,48 +155,10 @@ export type EmissionFactorList = {
     tag: string | null
   }
   versions: EmissionFactorVersion[]
-  override: EmissionFactorOverrideData | null
   emissionFactorParts: {
     type: string
     totalCo2: number
   }[]
-}
-
-/**
- * Apply the override to the emission factor's fields including the metaData.
- */
-export const applyEmissionFactorOverride = <T extends EmissionFactorList>(ef: T, locale: string): T => {
-  if (!ef.override) {
-    return ef
-  }
-  const efOverride = ef.override
-  const efMetadataOverride = efOverride.metaData.find((m) => m.language === locale)
-  return {
-    ...ef,
-    totalCo2: efOverride.totalCo2,
-    co2f: efOverride.co2f ?? ef.co2f,
-    ch4f: efOverride.ch4f ?? ef.ch4f,
-    ch4b: efOverride.ch4b ?? ef.ch4b,
-    n2o: efOverride.n2o ?? ef.n2o,
-    co2b: efOverride.co2b ?? ef.co2b,
-    sf6: efOverride.sf6 ?? ef.sf6,
-    hfc: efOverride.hfc ?? ef.hfc,
-    pfc: efOverride.pfc ?? ef.pfc,
-    otherGES: efOverride.otherGES ?? ef.otherGES,
-    unit: efOverride.unit ?? ef.unit,
-    status: efOverride.status ?? ef.status,
-    source: efOverride.source ?? ef.source,
-    location: efOverride.location ?? ef.location,
-    metaData: {
-      ...ef.metaData,
-      title: efMetadataOverride?.title ?? ef.metaData.title,
-      attribute: efMetadataOverride?.attribute ?? ef.metaData.attribute,
-      comment: efMetadataOverride?.comment ?? ef.metaData.comment,
-      frontiere: efMetadataOverride?.frontiere ?? ef.metaData.frontiere,
-      location: efMetadataOverride?.location ?? ef.metaData.location,
-      tag: efMetadataOverride?.tag ?? ef.metaData.tag,
-    },
-  }
 }
 
 const getDefaultEmissionFactorsCount = async (
@@ -307,22 +209,6 @@ const getBaseFilterForEmissionFactors = (
           { title: { contains: filters.search, mode: Prisma.QueryMode.insensitive } },
           { attribute: { contains: filters.search, mode: Prisma.QueryMode.insensitive } },
           { frontiere: { contains: filters.search, mode: Prisma.QueryMode.insensitive } },
-          {
-            emissionFactor: {
-              override: {
-                metaData: {
-                  some: {
-                    language: locale,
-                    OR: [
-                      { title: { contains: filters.search, mode: Prisma.QueryMode.insensitive } },
-                      { attribute: { contains: filters.search, mode: Prisma.QueryMode.insensitive } },
-                      { frontiere: { contains: filters.search, mode: Prisma.QueryMode.insensitive } },
-                    ],
-                  },
-                },
-              },
-            },
-          },
         ],
       }),
       ...(filters.locations.length > 0
@@ -376,23 +262,18 @@ const getDefaultEmissionFactors = async (
     orderBy: { title: 'asc' },
   })
 
-  return emissionFactorsMetadata.map((metadata) =>
-    applyEmissionFactorOverride(
-      {
-        ...metadata.emissionFactor,
-        metaData: {
-          language: metadata.language,
-          title: metadata.title,
-          attribute: metadata.attribute,
-          comment: metadata.comment,
-          location: metadata.location,
-          frontiere: metadata.frontiere,
-          tag: metadata.tag,
-        },
-      },
-      locale,
-    ),
-  )
+  return emissionFactorsMetadata.map((metadata) => ({
+    ...metadata.emissionFactor,
+    metaData: {
+      language: metadata.language,
+      title: metadata.title,
+      attribute: metadata.attribute,
+      comment: metadata.comment,
+      location: metadata.location,
+      frontiere: metadata.frontiere,
+      tag: metadata.tag,
+    },
+  }))
 }
 
 export const getAllEmissionFactorsLocations = async () => {

--- a/apps/bilan-carbone/src/db/emissionFactors.ts
+++ b/apps/bilan-carbone/src/db/emissionFactors.ts
@@ -18,6 +18,51 @@ import { Session } from 'next-auth'
 import { prismaClient } from './client.server'
 import { getOrgVersionWithOrgId } from './organization'
 
+const versionsSelect = {
+  select: {
+    importVersionId: true,
+    importVersion: {
+      select: {
+        id: true,
+        name: true,
+        source: true,
+        archived: true,
+      },
+    },
+  },
+}
+
+const overrideSelect = {
+  select: {
+    totalCo2: true,
+    co2f: true,
+    ch4f: true,
+    ch4b: true,
+    n2o: true,
+    co2b: true,
+    sf6: true,
+    hfc: true,
+    pfc: true,
+    otherGES: true,
+    unit: true,
+    status: true,
+    source: true,
+    location: true,
+    parts: { select: { type: true, totalCo2: true } },
+    metaData: {
+      select: {
+        language: true,
+        title: true,
+        attribute: true,
+        comment: true,
+        frontiere: true,
+        tag: true,
+        location: true,
+      },
+    },
+  },
+}
+
 const otherSelectEmissionFactor = {
   id: true,
   status: true,
@@ -46,13 +91,8 @@ const otherSelectEmissionFactor = {
   hfc: true,
   pfc: true,
   otherGES: true,
-  version: {
-    select: {
-      id: true,
-      name: true,
-      archived: true,
-    },
-  },
+  versions: versionsSelect,
+  override: overrideSelect,
   emissionFactorParts: { select: { type: true, totalCo2: true } },
 }
 
@@ -92,17 +132,50 @@ const selectEmissionFactor = {
       comment: true,
       location: true,
       frontiere: true,
+      tag: true,
     },
   },
-  version: {
-    select: {
-      id: true,
-      name: true,
-      archived: true,
-    },
-  },
+  versions: versionsSelect,
+  override: overrideSelect,
   emissionFactorParts: { select: { type: true, totalCo2: true } },
 } as Prisma.EmissionFactorSelect
+
+type EmissionFactorVersion = {
+  importVersionId: string
+  importVersion: {
+    id: string
+    name: string
+    source: Import
+    archived: boolean
+  }
+}
+
+export type EmissionFactorOverrideData = {
+  totalCo2: number
+  co2f: number | null
+  ch4f: number | null
+  ch4b: number | null
+  n2o: number | null
+  co2b: number | null
+  sf6: number | null
+  hfc: number | null
+  pfc: number | null
+  otherGES: number | null
+  unit: Unit | null
+  status: EmissionFactorStatus | null
+  source: string | null
+  location: string | null
+  parts: { type: string; totalCo2: number }[]
+  metaData: {
+    language: string
+    title: string | null
+    attribute: string | null
+    comment: string | null
+    frontiere: string | null
+    tag: string | null
+    location: string | null
+  }[]
+}
 
 export type EmissionFactorList = {
   id: string
@@ -139,16 +212,51 @@ export type EmissionFactorList = {
     comment: string | null
     location: string | null
     frontiere: string | null
+    tag: string | null
   }
-  version: {
-    id: string
-    name: string
-    archived: boolean
-  } | null
+  versions: EmissionFactorVersion[]
+  override: EmissionFactorOverrideData | null
   emissionFactorParts: {
     type: string
     totalCo2: number
   }[]
+}
+
+/**
+ * Apply the override to the emission factor's fields including the metaData.
+ */
+export const applyEmissionFactorOverride = <T extends EmissionFactorList>(ef: T, locale: string): T => {
+  if (!ef.override) {
+    return ef
+  }
+  const efOverride = ef.override
+  const efMetadataOverride = efOverride.metaData.find((m) => m.language === locale)
+  return {
+    ...ef,
+    totalCo2: efOverride.totalCo2,
+    co2f: efOverride.co2f ?? ef.co2f,
+    ch4f: efOverride.ch4f ?? ef.ch4f,
+    ch4b: efOverride.ch4b ?? ef.ch4b,
+    n2o: efOverride.n2o ?? ef.n2o,
+    co2b: efOverride.co2b ?? ef.co2b,
+    sf6: efOverride.sf6 ?? ef.sf6,
+    hfc: efOverride.hfc ?? ef.hfc,
+    pfc: efOverride.pfc ?? ef.pfc,
+    otherGES: efOverride.otherGES ?? ef.otherGES,
+    unit: efOverride.unit ?? ef.unit,
+    status: efOverride.status ?? ef.status,
+    source: efOverride.source ?? ef.source,
+    location: efOverride.location ?? ef.location,
+    metaData: {
+      ...ef.metaData,
+      title: efMetadataOverride?.title ?? ef.metaData.title,
+      attribute: efMetadataOverride?.attribute ?? ef.metaData.attribute,
+      comment: efMetadataOverride?.comment ?? ef.metaData.comment,
+      frontiere: efMetadataOverride?.frontiere ?? ef.metaData.frontiere,
+      location: efMetadataOverride?.location ?? ef.metaData.location,
+      tag: efMetadataOverride?.tag ?? ef.metaData.tag,
+    },
+  }
 }
 
 const getDefaultEmissionFactorsCount = async (
@@ -180,13 +288,13 @@ const getBaseFilterForEmissionFactors = (
     } else if (filters.sources.includes(Import.Manual) && organizationId) {
       importedFromCondition = {
         OR: [
-          { versionId: { in: filters.sources.filter((s) => s !== Import.Manual) } },
+          { versions: { some: { importVersionId: { in: filters.sources.filter((s) => s !== Import.Manual) } } } },
           { importedFrom: Import.Manual, organizationId },
         ],
       }
     } else {
       importedFromCondition = {
-        OR: [{ versionId: { in: filters.sources.filter((s) => s !== Import.Manual) } }],
+        OR: [{ versions: { some: { importVersionId: { in: filters.sources.filter((s) => s !== Import.Manual) } } } }],
       }
     }
   }
@@ -199,6 +307,22 @@ const getBaseFilterForEmissionFactors = (
           { title: { contains: filters.search, mode: Prisma.QueryMode.insensitive } },
           { attribute: { contains: filters.search, mode: Prisma.QueryMode.insensitive } },
           { frontiere: { contains: filters.search, mode: Prisma.QueryMode.insensitive } },
+          {
+            emissionFactor: {
+              override: {
+                metaData: {
+                  some: {
+                    language: locale,
+                    OR: [
+                      { title: { contains: filters.search, mode: Prisma.QueryMode.insensitive } },
+                      { attribute: { contains: filters.search, mode: Prisma.QueryMode.insensitive } },
+                      { frontiere: { contains: filters.search, mode: Prisma.QueryMode.insensitive } },
+                    ],
+                  },
+                },
+              },
+            },
+          },
         ],
       }),
       ...(filters.locations.length > 0
@@ -246,22 +370,29 @@ const getDefaultEmissionFactors = async (
       comment: true,
       location: true,
       frontiere: true,
+      tag: true,
       emissionFactor: { select: otherSelectEmissionFactor },
     },
     orderBy: { title: 'asc' },
   })
 
-  return emissionFactorsMetadata.map((metadata) => ({
-    ...metadata.emissionFactor,
-    metaData: {
-      language: metadata.language,
-      title: metadata.title,
-      attribute: metadata.attribute,
-      comment: metadata.comment,
-      location: metadata.location,
-      frontiere: metadata.frontiere,
-    },
-  }))
+  return emissionFactorsMetadata.map((metadata) =>
+    applyEmissionFactorOverride(
+      {
+        ...metadata.emissionFactor,
+        metaData: {
+          language: metadata.language,
+          title: metadata.title,
+          attribute: metadata.attribute,
+          comment: metadata.comment,
+          location: metadata.location,
+          frontiere: metadata.frontiere,
+          tag: metadata.tag,
+        },
+      },
+      locale,
+    ),
+  )
 }
 
 export const getAllEmissionFactorsLocations = async () => {
@@ -306,7 +437,7 @@ export const getEmissionFactorByImportedIdAndStudiesEmissionSource = (importedId
   prismaClient.emissionFactor.findFirst({
     where: {
       importedId,
-      versionId: { in: versionIds },
+      versions: { some: { importVersionId: { in: versionIds } } },
     },
     select: selectEmissionFactor,
   })
@@ -330,11 +461,11 @@ export const getEmissionFactorsByIdsAndSource = (ids: string[], source: Import) 
     select: selectEmissionFactor,
   })
 
-export const getEmissionFactorsByImportedIdsAndVersion = (ids: string[], versionId: string) =>
+export const getEmissionFactorsByImportedIdsAndVersion = (ids: string[], importVersionId: string) =>
   prismaClient.emissionFactor.findMany({
     where: {
       importedId: { in: ids },
-      versionId,
+      versions: { some: { importVersionId } },
     },
     select: selectEmissionFactor,
   })
@@ -556,11 +687,10 @@ export const findEmissionFactorByImportedId = (id: string) =>
     where: { importedId: id },
     select: {
       id: true,
-      versionId: true,
       importedId: true,
       unit: true,
       customUnit: true,
-      version: { select: { id: true } },
+      versions: { select: { importVersionId: true } },
       metaData: true,
     },
   })

--- a/apps/bilan-carbone/src/db/emissionFactors.utils.ts
+++ b/apps/bilan-carbone/src/db/emissionFactors.utils.ts
@@ -14,6 +14,7 @@ export const keepOnlyOneMetadata = <T extends { metaData: EmissionFactorList['me
       comment: null,
       location: null,
       frontiere: null,
+      tag: null,
     },
   }))
 }

--- a/apps/bilan-carbone/src/db/study.ts
+++ b/apps/bilan-carbone/src/db/study.ts
@@ -152,9 +152,10 @@ const fullStudyInclude = {
               comment: true,
             },
           },
-          version: {
+          versions: {
             select: {
-              id: true,
+              importVersionId: true,
+              importVersion: { select: { id: true, name: true, source: true, archived: true } },
             },
           },
         },

--- a/apps/bilan-carbone/src/db/study.ts
+++ b/apps/bilan-carbone/src/db/study.ts
@@ -150,6 +150,7 @@ const fullStudyInclude = {
               frontiere: true,
               location: true,
               comment: true,
+              tag: true,
             },
           },
           versions: {

--- a/apps/bilan-carbone/src/scripts/baseEmpreinte/applyOverrides.ts
+++ b/apps/bilan-carbone/src/scripts/baseEmpreinte/applyOverrides.ts
@@ -1,0 +1,22 @@
+import { Import } from '@repo/db-common/enums'
+import { Command } from 'commander'
+import * as XLSX from 'xlsx'
+import { applyOverridesFromRows } from '../../services/importEmissionFactor/applyOverrides'
+import { mapBaseEmpreinteEmissionFactors } from '../../services/importEmissionFactor/baseEmpreinte/import'
+import { parseSheetRows } from '../../services/importEmissionFactor/parseXlsx'
+
+const program = new Command()
+
+program
+  .name('base-empreinte-apply-overrides')
+  .description("Script pour appliquer des overrides manuels sur les facteurs d'émission de la base empreinte")
+  .version('1.0.0')
+  .requiredOption('-f, --file <value>', 'Fichier Excel (.xlsx) contenant les lignes à overrider')
+  .option('--dry-run', 'Affiche un rapport sans écrire en base')
+  .parse(process.argv)
+
+const params = program.opts()
+
+const workbook = XLSX.readFile(params.file)
+const rows = parseSheetRows(workbook.Sheets[workbook.SheetNames[0]])
+applyOverridesFromRows(Import.BaseEmpreinte, rows, mapBaseEmpreinteEmissionFactors, params.dryRun)

--- a/apps/bilan-carbone/src/scripts/baseEmpreinte/applyOverrides.ts
+++ b/apps/bilan-carbone/src/scripts/baseEmpreinte/applyOverrides.ts
@@ -1,4 +1,4 @@
-import { Import } from '@repo/db-common/enums'
+import { Import } from '@abc-transitionbascarbone/db-common/enums'
 import { Command } from 'commander'
 import * as XLSX from 'xlsx'
 import { applyOverridesFromRows } from '../../services/importEmissionFactor/applyOverrides'

--- a/apps/bilan-carbone/src/scripts/baseEmpreinte/backfillImportedRawCsv.ts
+++ b/apps/bilan-carbone/src/scripts/baseEmpreinte/backfillImportedRawCsv.ts
@@ -1,4 +1,4 @@
-import { Import } from '@repo/db-common/enums'
+import { Import } from '@abc-transitionbascarbone/db-common/enums'
 import { Command } from 'commander'
 import { prismaClient } from '../../db/client.server'
 import { parseCSVRows } from '../../services/importEmissionFactor/getEmissionFactorsFromCSV'

--- a/apps/bilan-carbone/src/scripts/baseEmpreinte/backfillImportedRawCsv.ts
+++ b/apps/bilan-carbone/src/scripts/baseEmpreinte/backfillImportedRawCsv.ts
@@ -1,0 +1,110 @@
+import { Import } from '@repo/db-common/enums'
+import { Command } from 'commander'
+import { prismaClient } from '../../db/client.server'
+import { parseCSVRows } from '../../services/importEmissionFactor/getEmissionFactorsFromCSV'
+import { getType, serializeRowAsCsv } from '../../services/importEmissionFactor/import'
+
+const program = new Command()
+
+program
+  .name('base-empreinte-backfill-imported-raw-csv')
+  .description(
+    "Backfill importedRawCsv on existing EFs and parts that were imported before the field was introduced. Reads the original CSV and writes the raw CSV line on matching rows that don't have it yet.",
+  )
+  .version('1.0.0')
+  .requiredOption('-n, --name <value>', 'Nom de la version à remplir (ex: 23.4)')
+  .requiredOption('-f, --file <value>', 'Fichier CSV original utilisé pour cet import')
+  .option('--dry-run', 'Affiche un rapport sans écrire en base')
+  .parse(process.argv)
+
+const params = program.opts()
+
+const run = async () => {
+  const importVersion = await prismaClient.emissionFactorImportVersion.findFirst({
+    where: { name: params.name, source: Import.BaseEmpreinte },
+  })
+  if (!importVersion) {
+    console.error(`No import version found with name "${params.name}" for BaseEmpreinte`)
+    process.exit(1)
+  }
+
+  console.log(`Parsing CSV...`)
+  const { emissionFactors, parts } = await parseCSVRows(params.file)
+  console.log(`${emissionFactors.length} EF rows + ${parts.length} part rows parsed`)
+
+  const importedIds = emissionFactors.map((ef) => ef["Identifiant_de_l'élément"])
+
+  const existingEFs = await prismaClient.emissionFactor.findMany({
+    where: {
+      importedId: { in: importedIds },
+      importedFrom: Import.BaseEmpreinte,
+      versions: { some: { importVersionId: importVersion.id } },
+      importedRawCsv: null,
+    },
+    select: {
+      id: true,
+      importedId: true,
+      emissionFactorParts: { select: { id: true, type: true, importedRawCsv: true } },
+    },
+  })
+
+  const existingByImportedId = new Map(existingEFs.map((ef) => [ef.importedId!, ef]))
+
+  const efsToBackfill = existingEFs.length
+  const partsToBackfill = existingEFs.flatMap((ef) =>
+    ef.emissionFactorParts.filter((p) => p.importedRawCsv === null),
+  ).length
+
+  if (efsToBackfill === 0 && partsToBackfill === 0) {
+    console.log(`All EFs and parts for version "${params.name}" already have importedRawCsv — nothing to backfill`)
+    return
+  }
+
+  console.log(`${efsToBackfill} EFs to backfill, ${partsToBackfill} parts to backfill`)
+
+  if (params.dryRun) {
+    console.log('Dry run — no writes')
+    return
+  }
+
+  let updatedEFs = 0
+  for (const row of emissionFactors) {
+    const ef = existingByImportedId.get(row["Identifiant_de_l'élément"])
+    if (!ef) {
+      continue
+    }
+    await prismaClient.emissionFactor.update({
+      where: { id: ef.id },
+      data: { importedRawCsv: serializeRowAsCsv(row) },
+    })
+    updatedEFs++
+    if (updatedEFs % 500 === 0) {
+      console.log(`EFs: ${updatedEFs}/${efsToBackfill}...`)
+    }
+  }
+
+  let updatedParts = 0
+  for (const partRow of parts) {
+    const ef = existingByImportedId.get(partRow["Identifiant_de_l'élément"])
+    if (!ef) {
+      continue
+    }
+    const partType = getType(partRow.Type_poste)
+    const existingPart = ef.emissionFactorParts.find((p) => p.type === partType && p.importedRawCsv === null)
+    if (!existingPart) {
+      continue
+    }
+    await prismaClient.emissionFactorPart.update({
+      where: { id: existingPart.id },
+      data: { importedRawCsv: serializeRowAsCsv(partRow) },
+    })
+    updatedParts++
+    if (updatedParts % 500 === 0) {
+      console.log(`Parts: ${updatedParts}/${partsToBackfill}...`)
+    }
+  }
+
+  console.log(`Done — backfilled ${updatedEFs} EFs and ${updatedParts} parts`)
+}
+
+run()

--- a/apps/bilan-carbone/src/scripts/baseEmpreinte/getEmissionFactors.ts
+++ b/apps/bilan-carbone/src/scripts/baseEmpreinte/getEmissionFactors.ts
@@ -1,4 +1,4 @@
-import { Import } from '@repo/db-common/enums'
+import { Import } from '@abc-transitionbascarbone/db-common/enums'
 import { Command } from 'commander'
 import { mapBaseEmpreinteEmissionFactors } from '../../services/importEmissionFactor/baseEmpreinte/import'
 import { getEmissionFactorsFromCSV, OverrideMode } from '../../services/importEmissionFactor/getEmissionFactorsFromCSV'

--- a/apps/bilan-carbone/src/scripts/baseEmpreinte/getEmissionFactors.ts
+++ b/apps/bilan-carbone/src/scripts/baseEmpreinte/getEmissionFactors.ts
@@ -12,21 +12,22 @@ program
   .requiredOption('-n, --name <value>', 'Nom de la version')
   .requiredOption('-f, --file <value>', 'Import depuis un fichier CSV complet')
   .option('--dry-run', 'Affiche un rapport sans écrire en base')
-  .option('--keep-overrides', 'En cas de conflits, duplique les overrides existants vers les nouveaux EFs')
-  .option(
-    '--discard-overrides',
-    "En cas de conflits, ignore les overrides existants (les nouveaux EFs n'ont pas d'override)",
-  )
+  .option('--keep-overrides', 'Progagates existing manual overrides onto the new EF values')
+  .option('--discard-overrides', 'Discards existing manual overrides and imports the new CSV values')
   .parse(process.argv)
 
 const params = program.opts()
 
 if (params.keepOverrides && params.discardOverrides) {
-  console.error('Cannot use --keep-overrides and --discard-overrides together')
+  console.error('Cannot use --keep-overrides and --discard-overrides at the same time')
   process.exit(1)
 }
 
-const overrideMode: OverrideMode = params.keepOverrides ? 'keep' : params.discardOverrides ? 'discard' : 'none'
+const overrideMode: OverrideMode | undefined = params.keepOverrides
+  ? 'keep'
+  : params.discardOverrides
+    ? 'discard'
+    : undefined
 
 getEmissionFactorsFromCSV(params.name, params.file, Import.BaseEmpreinte, mapBaseEmpreinteEmissionFactors, {
   dryRun: params.dryRun,

--- a/apps/bilan-carbone/src/scripts/baseEmpreinte/getEmissionFactors.ts
+++ b/apps/bilan-carbone/src/scripts/baseEmpreinte/getEmissionFactors.ts
@@ -1,7 +1,7 @@
-import { prismaClient } from '@/db/client.node'
+import { Import } from '@repo/db-common/enums'
 import { Command } from 'commander'
-import { getEmissionFactorsFromAPI } from '../../services/importEmissionFactor/baseEmpreinte/getEmissionFactorsFromAPI'
-import { getEmissionFactorsFromCSV } from '../../services/importEmissionFactor/baseEmpreinte/getEmissionFactorsFromCSV'
+import { mapBaseEmpreinteEmissionFactors } from '../../services/importEmissionFactor/baseEmpreinte/import'
+import { getEmissionFactorsFromCSV, OverrideMode } from '../../services/importEmissionFactor/getEmissionFactorsFromCSV'
 
 const program = new Command()
 
@@ -10,13 +10,25 @@ program
   .description("Script pour importer les facteurs d'émission depuis la base empreinte")
   .version('1.0.0')
   .requiredOption('-n, --name <value>', 'Nom de la version')
-  .option('-f, --file <value>', 'Import from CSV file')
+  .requiredOption('-f, --file <value>', 'Import depuis un fichier CSV complet')
+  .option('--dry-run', 'Affiche un rapport sans écrire en base')
+  .option('--keep-overrides', 'En cas de conflits, duplique les overrides existants vers les nouveaux EFs')
+  .option(
+    '--discard-overrides',
+    "En cas de conflits, ignore les overrides existants (les nouveaux EFs n'ont pas d'override)",
+  )
   .parse(process.argv)
 
 const params = program.opts()
 
-if (params.file) {
-  getEmissionFactorsFromCSV(params.name, params.file)
-} else {
-  getEmissionFactorsFromAPI(prismaClient, params.name)
+if (params.keepOverrides && params.discardOverrides) {
+  console.error('Cannot use --keep-overrides and --discard-overrides together')
+  process.exit(1)
 }
+
+const overrideMode: OverrideMode = params.keepOverrides ? 'keep' : params.discardOverrides ? 'discard' : 'none'
+
+getEmissionFactorsFromCSV(params.name, params.file, Import.BaseEmpreinte, mapBaseEmpreinteEmissionFactors, {
+  dryRun: params.dryRun,
+  overrideMode,
+})

--- a/apps/bilan-carbone/src/scripts/oldBC/transition/repositories.ts
+++ b/apps/bilan-carbone/src/scripts/oldBC/transition/repositories.ts
@@ -79,7 +79,7 @@ export const getExistingEmissionFactors = async (
   const emissionFactors = await transaction.emissionFactor.findMany({
     where: { OR: [{ importedId: { in: importedIds } }, { oldBCId: { in: oldBCIds } }] },
     include: {
-      version: true,
+      versions: { include: { importVersion: true } },
     },
   })
   return emissionFactors

--- a/apps/bilan-carbone/src/scripts/oldBC/transition/studies.ts
+++ b/apps/bilan-carbone/src/scripts/oldBC/transition/studies.ts
@@ -555,7 +555,7 @@ const getExistingStudySites = async (transaction: Prisma.TransactionClient, stud
 }
 
 interface EmissionFactorWithVersion extends EmissionFactorPrismaModel {
-  version: EmissionFactorImportVersion | null
+  versions: { importVersionId: string; importVersion: EmissionFactorImportVersion }[]
 }
 
 class EmissionFactorsByImportedIdMap {
@@ -566,14 +566,15 @@ class EmissionFactorsByImportedIdMap {
     this.emissionFactorsMap = emissionFactors.reduce((emissionFactorsMap, emissionFactor) => {
       if (emissionFactor.importedId) {
         const emissionFactors = emissionFactorsMap.get(emissionFactor.importedId)
+        const firstVersion = emissionFactor.versions[0]?.importVersion ?? null
         const emissionFactorItem = {
           id: emissionFactor.id,
           unit: emissionFactor.unit,
-          version: emissionFactor.version
+          version: firstVersion
             ? {
-                id: emissionFactor.version.id,
-                source: emissionFactor.version.source,
-                createdAt: emissionFactor.version.createdAt,
+                id: firstVersion.id,
+                source: firstVersion.source,
+                createdAt: firstVersion.createdAt,
               }
             : null,
           importedId: emissionFactor.importedId,
@@ -623,13 +624,14 @@ class StudiesEmissionFactorVersionsMap {
   addEmissionFactor(studyId: string, emissionFactor: EmissionFactor) {
     const emissionFactorVersionsMap =
       this.studiesEmissionFactorVersionsMap.get(studyId) ?? new Map<string, { id: string; createdAt: Date }[]>()
-    if (emissionFactor.version) {
+    const firstVersion = emissionFactor.version
+    if (firstVersion) {
       const emissionFactorItem = {
-        id: emissionFactor.version.id,
-        createdAt: emissionFactor.version.createdAt,
+        id: firstVersion.id,
+        createdAt: firstVersion.createdAt,
       }
-      const emissionFactorVersions = emissionFactorVersionsMap.get(emissionFactor.version.source) ?? []
-      emissionFactorVersionsMap.set(emissionFactor.version.source, emissionFactorVersions.concat(emissionFactorItem))
+      const emissionFactorVersions = emissionFactorVersionsMap.get(firstVersion.source) ?? []
+      emissionFactorVersionsMap.set(firstVersion.source, emissionFactorVersions.concat(emissionFactorItem))
       this.studiesEmissionFactorVersionsMap.set(studyId, emissionFactorVersionsMap)
     }
   }

--- a/apps/bilan-carbone/src/services/emissionSource.test.ts
+++ b/apps/bilan-carbone/src/services/emissionSource.test.ts
@@ -42,6 +42,7 @@ const defaultEmissionSource = {
         title: 'Mocked Emission Factor',
         attribute: 'Mocked Attribute',
         comment: 'Mocked Comment',
+        tag: null,
       },
     ],
     emissionFactorParts: [],

--- a/apps/bilan-carbone/src/services/emissionSource.test.ts
+++ b/apps/bilan-carbone/src/services/emissionSource.test.ts
@@ -1,5 +1,5 @@
 import type { FullStudy } from '@/db/study'
-import { EmissionFactorBase, Environment, SubPost, Unit } from '@abc-transitionbascarbone/db-common/enums'
+import { EmissionFactorBase, Environment, Import, SubPost, Unit } from '@abc-transitionbascarbone/db-common/enums'
 import { expect } from '@jest/globals'
 import { getEmissionResults } from './emissionSource'
 
@@ -28,9 +28,12 @@ const defaultEmissionSource = {
     isMonetary: false,
     location: '',
     customUnit: null,
-    version: {
-      id: 'version-id',
-    },
+    versions: [
+      {
+        importVersionId: 'versionId',
+        importVersion: { id: 'versionId', name: 'versionName', source: Import.BaseEmpreinte, archived: false },
+      },
+    ],
     metaData: [
       {
         language: 'fr',

--- a/apps/bilan-carbone/src/services/emissionSource.ts
+++ b/apps/bilan-carbone/src/services/emissionSource.ts
@@ -29,10 +29,10 @@ type EmissionSourceFormType = Pick<
   | 'duration'
 >
 
-export const getEmissionSourceCompletion = (
+const getEmissionSourceCompletion = (
   emissionSource: EmissionSourceFormType,
   study: FullStudy,
-  emissionFactor: FullStudy['emissionSources'][number]['emissionFactor'],
+  unit: string | null | undefined,
   environment: Environment | undefined,
 ) => {
   const mandatoryFields = ['name', 'type', 'emissionFactorId'] as (keyof typeof emissionSource)[]
@@ -58,11 +58,7 @@ export const getEmissionSourceCompletion = (
     }
   }
 
-  if (
-    emissionSource.subPost === SubPost.EmissionsLieesAuChangementDAffectationDesSolsCas &&
-    emissionFactor &&
-    emissionFactor.unit === 'HA_YEAR'
-  ) {
+  if (emissionSource.subPost === SubPost.EmissionsLieesAuChangementDAffectationDesSolsCas && unit === 'HA_YEAR') {
     mandatoryFields.push('hectare')
     mandatoryFields.push('duration')
   }
@@ -77,10 +73,10 @@ export const getEmissionSourceCompletion = (
 export const canBeValidated = (
   emissionSource: EmissionSourceFormType,
   study: FullStudy,
-  emissionFactor: FullStudy['emissionSources'][number]['emissionFactor'],
+  emissionFactor: { unit?: string | null } | null | undefined,
   environment: Environment | undefined,
 ) => {
-  return getEmissionSourceCompletion(emissionSource, study, emissionFactor, environment) === 1
+  return getEmissionSourceCompletion(emissionSource, study, emissionFactor?.unit, environment) === 1
 }
 
 export const getAlpha = (emission: number, confidenceInterval: number[]) => {

--- a/apps/bilan-carbone/src/services/importEmissionFactor/aib/getEmissionFactors.ts
+++ b/apps/bilan-carbone/src/services/importEmissionFactor/aib/getEmissionFactors.ts
@@ -6,8 +6,8 @@ const source = Import.AIB
 
 const getSubPostsFunc = () => [SubPost.Electricite]
 
-const mapAIBEmissionFactors = (emissionFactor: ImportEmissionFactor, versionId: string) => ({
-  ...mapEmissionFactors(emissionFactor, source, versionId, getSubPostsFunc),
+const mapAIBEmissionFactors = (emissionFactor: ImportEmissionFactor) => ({
+  ...mapEmissionFactors(emissionFactor, source, getSubPostsFunc),
   base: EmissionFactorBase.MarketBased,
 })
 

--- a/apps/bilan-carbone/src/services/importEmissionFactor/applyOverrides.ts
+++ b/apps/bilan-carbone/src/services/importEmissionFactor/applyOverrides.ts
@@ -6,7 +6,7 @@ import { ImportEmissionFactor, mapEmissionFactors } from './import'
 
 type MapFunction = (row: ImportEmissionFactor) => ReturnType<typeof mapEmissionFactors>
 
-const buildOverrideData = (mapped: ReturnType<typeof mapEmissionFactors>) => ({
+const pickGasFields = (mapped: ReturnType<typeof mapEmissionFactors>) => ({
   totalCo2: mapped.totalCo2,
   co2f: mapped.co2f,
   ch4f: mapped.ch4f,
@@ -17,6 +17,10 @@ const buildOverrideData = (mapped: ReturnType<typeof mapEmissionFactors>) => ({
   hfc: mapped.hfc,
   pfc: mapped.pfc,
   otherGES: mapped.otherGES,
+})
+
+const buildOverrideData = (mapped: ReturnType<typeof mapEmissionFactors>) => ({
+  ...pickGasFields(mapped),
   unit: mapped.unit,
   status: mapped.status,
   source: mapped.source,
@@ -102,16 +106,7 @@ export const applyOverridesFromRows = async (
                 }
                 return {
                   type: part.Type_poste as Prisma.EmissionFactorOverridePartCreateManyInput['type'],
-                  totalCo2: mappedPart.totalCo2,
-                  co2f: mappedPart.co2f,
-                  ch4f: mappedPart.ch4f,
-                  ch4b: mappedPart.ch4b,
-                  n2o: mappedPart.n2o,
-                  co2b: mappedPart.co2b,
-                  sf6: mappedPart.sf6,
-                  hfc: mappedPart.hfc,
-                  pfc: mappedPart.pfc,
-                  otherGES: mappedPart.otherGES,
+                  ...pickGasFields(mappedPart),
                   metaData: metaData.length > 0 ? { createMany: { data: metaData } } : undefined,
                 }
               }),

--- a/apps/bilan-carbone/src/services/importEmissionFactor/applyOverrides.ts
+++ b/apps/bilan-carbone/src/services/importEmissionFactor/applyOverrides.ts
@@ -1,6 +1,6 @@
-import { Import } from '@repo/db-common/enums'
+import { Import } from '@abc-transitionbascarbone/db-common/enums'
+import { MIN, TIME_IN_MS } from '@abc-transitionbascarbone/utils'
 import { prismaClient } from '../../db/client.server'
-import { MIN, TIME_IN_MS } from '../../utils/time'
 import { getGases, getType, ImportEmissionFactor, mapEmissionFactors, serializeRowAsCsv } from './import'
 
 type MapFunction = (row: ImportEmissionFactor) => ReturnType<typeof mapEmissionFactors>

--- a/apps/bilan-carbone/src/services/importEmissionFactor/applyOverrides.ts
+++ b/apps/bilan-carbone/src/services/importEmissionFactor/applyOverrides.ts
@@ -4,33 +4,29 @@ import { prismaClient } from '../../db/client.server'
 import { MIN, TIME_IN_MS } from '../../utils/time'
 import { ImportEmissionFactor, mapEmissionFactors } from './import'
 
-type MapFunction = (row: ImportEmissionFactor) => Prisma.EmissionFactorCreateInput
+type MapFunction = (row: ImportEmissionFactor) => ReturnType<typeof mapEmissionFactors>
 
-const buildOverrideData = (
-  mapped: Prisma.EmissionFactorCreateInput,
-): Omit<Prisma.EmissionFactorOverrideCreateInput, 'emissionFactor'> => {
-  return {
-    totalCo2: mapped.totalCo2 as number,
-    co2f: mapped.co2f as number | undefined,
-    ch4f: mapped.ch4f as number | undefined,
-    ch4b: mapped.ch4b as number | undefined,
-    n2o: mapped.n2o as number | undefined,
-    co2b: mapped.co2b as number | undefined,
-    sf6: mapped.sf6 as number | undefined,
-    hfc: mapped.hfc as number | undefined,
-    pfc: mapped.pfc as number | undefined,
-    otherGES: mapped.otherGES as number | undefined,
-    unit: mapped.unit as Prisma.EmissionFactorOverrideCreateInput['unit'],
-    status: mapped.status as Prisma.EmissionFactorOverrideCreateInput['status'],
-    source: mapped.source as string | undefined,
-    location: mapped.location as string | undefined,
-    metaData: {
-      createMany: {
-        data: mapped.metaData?.createMany?.data ?? [],
-      },
+const buildOverrideData = (mapped: ReturnType<typeof mapEmissionFactors>) => ({
+  totalCo2: mapped.totalCo2,
+  co2f: mapped.co2f,
+  ch4f: mapped.ch4f,
+  ch4b: mapped.ch4b,
+  n2o: mapped.n2o,
+  co2b: mapped.co2b,
+  sf6: mapped.sf6,
+  hfc: mapped.hfc,
+  pfc: mapped.pfc,
+  otherGES: mapped.otherGES,
+  unit: mapped.unit,
+  status: mapped.status,
+  source: mapped.source,
+  location: mapped.location,
+  metaData: {
+    createMany: {
+      data: mapped.metaData.createMany.data,
     },
-  }
-}
+  },
+})
 
 export const applyOverridesFromRows = async (
   source: Import,
@@ -95,32 +91,30 @@ export const applyOverridesFromRows = async (
             emissionFactor: { connect: { id: efId } },
             ...overrideData,
             parts: {
-              create: await Promise.all(
-                partRowsForEf.map(async (part) => {
-                  const mappedPart = mapEmissionFactors(part, source, () => [])
-                  const metaData = []
-                  if (part.Nom_poste_français) {
-                    metaData.push({ language: 'fr', title: part.Nom_poste_français })
-                  }
-                  if (part.Nom_poste_anglais) {
-                    metaData.push({ language: 'en', title: part.Nom_poste_anglais })
-                  }
-                  return {
-                    type: part.Type_poste as Prisma.EmissionFactorOverridePartCreateManyInput['type'],
-                    totalCo2: mappedPart.totalCo2,
-                    co2f: mappedPart.co2f,
-                    ch4f: mappedPart.ch4f,
-                    ch4b: mappedPart.ch4b,
-                    n2o: mappedPart.n2o,
-                    co2b: mappedPart.co2b,
-                    sf6: mappedPart.sf6,
-                    hfc: mappedPart.hfc,
-                    pfc: mappedPart.pfc,
-                    otherGES: mappedPart.otherGES,
-                    metaData: metaData.length > 0 ? { createMany: { data: metaData } } : undefined,
-                  }
-                }),
-              ),
+              create: partRowsForEf.map((part) => {
+                const mappedPart = mapEmissionFactors(part, source, () => [])
+                const metaData = []
+                if (part.Nom_poste_français) {
+                  metaData.push({ language: 'fr', title: part.Nom_poste_français })
+                }
+                if (part.Nom_poste_anglais) {
+                  metaData.push({ language: 'en', title: part.Nom_poste_anglais })
+                }
+                return {
+                  type: part.Type_poste as Prisma.EmissionFactorOverridePartCreateManyInput['type'],
+                  totalCo2: mappedPart.totalCo2,
+                  co2f: mappedPart.co2f,
+                  ch4f: mappedPart.ch4f,
+                  ch4b: mappedPart.ch4b,
+                  n2o: mappedPart.n2o,
+                  co2b: mappedPart.co2b,
+                  sf6: mappedPart.sf6,
+                  hfc: mappedPart.hfc,
+                  pfc: mappedPart.pfc,
+                  otherGES: mappedPart.otherGES,
+                  metaData: metaData.length > 0 ? { createMany: { data: metaData } } : undefined,
+                }
+              }),
             },
           },
         })

--- a/apps/bilan-carbone/src/services/importEmissionFactor/applyOverrides.ts
+++ b/apps/bilan-carbone/src/services/importEmissionFactor/applyOverrides.ts
@@ -1,0 +1,135 @@
+import type { Prisma } from '@repo/db-common'
+import { Import } from '@repo/db-common/enums'
+import { prismaClient } from '../../db/client.server'
+import { MIN, TIME_IN_MS } from '../../utils/time'
+import { ImportEmissionFactor, mapEmissionFactors } from './import'
+
+type MapFunction = (row: ImportEmissionFactor) => Prisma.EmissionFactorCreateInput
+
+const buildOverrideData = (
+  mapped: Prisma.EmissionFactorCreateInput,
+): Omit<Prisma.EmissionFactorOverrideCreateInput, 'emissionFactor'> => {
+  return {
+    totalCo2: mapped.totalCo2 as number,
+    co2f: mapped.co2f as number | undefined,
+    ch4f: mapped.ch4f as number | undefined,
+    ch4b: mapped.ch4b as number | undefined,
+    n2o: mapped.n2o as number | undefined,
+    co2b: mapped.co2b as number | undefined,
+    sf6: mapped.sf6 as number | undefined,
+    hfc: mapped.hfc as number | undefined,
+    pfc: mapped.pfc as number | undefined,
+    otherGES: mapped.otherGES as number | undefined,
+    unit: mapped.unit as Prisma.EmissionFactorOverrideCreateInput['unit'],
+    status: mapped.status as Prisma.EmissionFactorOverrideCreateInput['status'],
+    source: mapped.source as string | undefined,
+    location: mapped.location as string | undefined,
+    metaData: {
+      createMany: {
+        data: mapped.metaData?.createMany?.data ?? [],
+      },
+    },
+  }
+}
+
+export const applyOverridesFromRows = async (
+  source: Import,
+  rows: ImportEmissionFactor[],
+  mapFunction: MapFunction,
+  dryRun = false,
+) => {
+  const efRows = rows.filter((r) => r.Type_Ligne !== 'Poste')
+  const partRows = rows.filter((r) => r.Type_Ligne === 'Poste')
+  const allImportedIds = [...new Set(rows.map((r) => r["Identifiant_de_l'élément"]))]
+
+  const existingEFs = await prismaClient.emissionFactor.findMany({
+    where: { importedId: { in: allImportedIds }, importedFrom: source },
+    select: { id: true, importedId: true },
+  })
+  const efByImportedId = new Map(existingEFs.map((ef) => [ef.importedId!, ef.id]))
+
+  const notFound = efRows.filter((r) => !efByImportedId.has(r["Identifiant_de_l'élément"])).length
+  const foundIds = [...efByImportedId.values()]
+
+  const existingOverrides = await prismaClient.emissionFactorOverride.findMany({
+    where: { emissionFactorId: { in: foundIds } },
+    select: { emissionFactorId: true },
+  })
+  const wouldCreate = foundIds.filter((id) => !existingOverrides.some((o) => o.emissionFactorId === id)).length
+  const wouldUpdate = existingOverrides.length
+
+  if (dryRun) {
+    console.log(`\n--- Dry Run Report ---`)
+    console.log(`Overrides to create: ${wouldCreate}`)
+    console.log(`Overrides to update: ${wouldUpdate}`)
+    console.log(`EFs not found: ${notFound}`)
+    console.log(`---------------------\n`)
+    return
+  }
+
+  await prismaClient.$transaction(
+    async (transaction) => {
+      // Delete in cascade all existing overrides for the EFs in the file, then recreate from scratch
+      await transaction.emissionFactorOverride.deleteMany({
+        where: { emissionFactorId: { in: foundIds } },
+      })
+
+      let applied = 0
+
+      for (const row of efRows) {
+        const importedId = row["Identifiant_de_l'élément"]
+        const efId = efByImportedId.get(importedId)
+
+        if (!efId) {
+          console.warn(`  EF not found for importedId "${importedId}" — skipping`)
+          continue
+        }
+
+        const mapped = mapFunction(row)
+        const overrideData = buildOverrideData(mapped)
+
+        const partRowsForEf = partRows.filter((p) => p["Identifiant_de_l'élément"] === importedId)
+
+        await transaction.emissionFactorOverride.create({
+          data: {
+            emissionFactor: { connect: { id: efId } },
+            ...overrideData,
+            parts: {
+              create: await Promise.all(
+                partRowsForEf.map(async (part) => {
+                  const mappedPart = mapEmissionFactors(part, source, () => [])
+                  const metaData = []
+                  if (part.Nom_poste_français) {
+                    metaData.push({ language: 'fr', title: part.Nom_poste_français })
+                  }
+                  if (part.Nom_poste_anglais) {
+                    metaData.push({ language: 'en', title: part.Nom_poste_anglais })
+                  }
+                  return {
+                    type: part.Type_poste as Prisma.EmissionFactorOverridePartCreateManyInput['type'],
+                    totalCo2: mappedPart.totalCo2,
+                    co2f: mappedPart.co2f,
+                    ch4f: mappedPart.ch4f,
+                    ch4b: mappedPart.ch4b,
+                    n2o: mappedPart.n2o,
+                    co2b: mappedPart.co2b,
+                    sf6: mappedPart.sf6,
+                    hfc: mappedPart.hfc,
+                    pfc: mappedPart.pfc,
+                    otherGES: mappedPart.otherGES,
+                    metaData: metaData.length > 0 ? { createMany: { data: metaData } } : undefined,
+                  }
+                }),
+              ),
+            },
+          },
+        })
+
+        applied++
+      }
+
+      console.log(`Applied ${applied} overrides, ${notFound} EFs not found`)
+    },
+    { timeout: 20 * MIN * TIME_IN_MS },
+  )
+}

--- a/apps/bilan-carbone/src/services/importEmissionFactor/applyOverrides.ts
+++ b/apps/bilan-carbone/src/services/importEmissionFactor/applyOverrides.ts
@@ -1,36 +1,9 @@
-import type { Prisma } from '@repo/db-common'
 import { Import } from '@repo/db-common/enums'
 import { prismaClient } from '../../db/client.server'
 import { MIN, TIME_IN_MS } from '../../utils/time'
-import { ImportEmissionFactor, mapEmissionFactors } from './import'
+import { getGases, getType, ImportEmissionFactor, mapEmissionFactors, serializeRowAsCsv } from './import'
 
 type MapFunction = (row: ImportEmissionFactor) => ReturnType<typeof mapEmissionFactors>
-
-const pickGasFields = (mapped: ReturnType<typeof mapEmissionFactors>) => ({
-  totalCo2: mapped.totalCo2,
-  co2f: mapped.co2f,
-  ch4f: mapped.ch4f,
-  ch4b: mapped.ch4b,
-  n2o: mapped.n2o,
-  co2b: mapped.co2b,
-  sf6: mapped.sf6,
-  hfc: mapped.hfc,
-  pfc: mapped.pfc,
-  otherGES: mapped.otherGES,
-})
-
-const buildOverrideData = (mapped: ReturnType<typeof mapEmissionFactors>) => ({
-  ...pickGasFields(mapped),
-  unit: mapped.unit,
-  status: mapped.status,
-  source: mapped.source,
-  location: mapped.location,
-  metaData: {
-    createMany: {
-      data: mapped.metaData.createMany.data,
-    },
-  },
-})
 
 export const applyOverridesFromRows = async (
   source: Import,
@@ -40,76 +13,78 @@ export const applyOverridesFromRows = async (
 ) => {
   const efRows = rows.filter((r) => r.Type_Ligne !== 'Poste')
   const partRows = rows.filter((r) => r.Type_Ligne === 'Poste')
-  const allImportedIds = [...new Set(rows.map((r) => r["Identifiant_de_l'élément"]))]
+  const allImportedIds = [...new Set(efRows.map((r) => r["Identifiant_de_l'élément"]))]
 
   const existingEFs = await prismaClient.emissionFactor.findMany({
     where: { importedId: { in: allImportedIds }, importedFrom: source },
-    select: { id: true, importedId: true },
+    select: { id: true, importedId: true, emissionFactorParts: { select: { id: true, type: true } } },
   })
-  const efByImportedId = new Map(existingEFs.map((ef) => [ef.importedId!, ef.id]))
-
+  const efByImportedId = new Map(existingEFs.map((ef) => [ef.importedId!, ef]))
   const notFound = efRows.filter((r) => !efByImportedId.has(r["Identifiant_de_l'élément"])).length
-  const foundIds = [...efByImportedId.values()]
 
-  const existingOverrides = await prismaClient.emissionFactorOverride.findMany({
-    where: { emissionFactorId: { in: foundIds } },
-    select: { emissionFactorId: true },
-  })
-  const wouldCreate = foundIds.filter((id) => !existingOverrides.some((o) => o.emissionFactorId === id)).length
-  const wouldUpdate = existingOverrides.length
+  const wouldUpdate = efRows.filter((r) => efByImportedId.has(r["Identifiant_de_l'élément"])).length
+  const total = efRows.length
+  const pct = total > 0 ? Math.round((wouldUpdate / total) * 100) : 0
+  const partOverrides = partRows.filter((r) => efByImportedId.has(r["Identifiant_de_l'élément"])).length
+  console.log(`\n--- Apply Overrides Report ---`)
+  console.log(`Found ${total} overrides`)
+  console.log(`EFs found in DB: ${pct}% (${wouldUpdate}/${total})`)
+  console.log(`Part overrides: ${partOverrides}`)
+  if (notFound > 0) {
+    console.log(`EFs not found: ${notFound}`)
+  }
+  console.log(`---------------------\n`)
 
   if (dryRun) {
-    console.log(`\n--- Dry Run Report ---`)
-    console.log(`Overrides to create: ${wouldCreate}`)
-    console.log(`Overrides to update: ${wouldUpdate}`)
-    console.log(`EFs not found: ${notFound}`)
-    console.log(`---------------------\n`)
     return
   }
 
   await prismaClient.$transaction(
     async (transaction) => {
-      // Delete in cascade all existing overrides for the EFs in the file, then recreate from scratch
-      await transaction.emissionFactorOverride.deleteMany({
-        where: { emissionFactorId: { in: foundIds } },
-      })
-
       let applied = 0
 
       for (const row of efRows) {
         const importedId = row["Identifiant_de_l'élément"]
-        const efId = efByImportedId.get(importedId)
+        const ef = efByImportedId.get(importedId)
 
-        if (!efId) {
+        if (!ef) {
           console.warn(`  EF not found for importedId "${importedId}" — skipping`)
           continue
         }
 
         const mapped = mapFunction(row)
-        const overrideData = buildOverrideData(mapped)
 
-        const partRowsForEf = partRows.filter((p) => p["Identifiant_de_l'élément"] === importedId)
-
-        await transaction.emissionFactorOverride.create({
+        await transaction.emissionFactor.update({
+          where: { id: ef.id },
           data: {
-            emissionFactor: { connect: { id: efId } },
-            ...overrideData,
-            parts: {
-              create: partRowsForEf.map((part) => {
-                const mappedPart = mapEmissionFactors(part, source, () => [])
-                const metaData = []
-                if (part.Nom_poste_français) {
-                  metaData.push({ language: 'fr', title: part.Nom_poste_français })
-                }
-                if (part.Nom_poste_anglais) {
-                  metaData.push({ language: 'en', title: part.Nom_poste_anglais })
-                }
-                return {
-                  type: part.Type_poste as Prisma.EmissionFactorOverridePartCreateManyInput['type'],
-                  ...pickGasFields(mappedPart),
-                  metaData: metaData.length > 0 ? { createMany: { data: metaData } } : undefined,
-                }
-              }),
+            totalCo2: mapped.totalCo2,
+            co2f: mapped.co2f,
+            ch4f: mapped.ch4f,
+            ch4b: mapped.ch4b,
+            n2o: mapped.n2o,
+            co2b: mapped.co2b,
+            sf6: mapped.sf6,
+            hfc: mapped.hfc,
+            pfc: mapped.pfc,
+            otherGES: mapped.otherGES,
+            unit: mapped.unit,
+            isMonetary: mapped.isMonetary,
+            status: mapped.status,
+            source: mapped.source,
+            location: mapped.location,
+            overrideRawCsv: serializeRowAsCsv(row),
+            metaData: {
+              updateMany: mapped.metaData.createMany.data.map((meta) => ({
+                where: { emissionFactorId: ef.id, language: meta.language },
+                data: {
+                  title: meta.title,
+                  attribute: meta.attribute,
+                  frontiere: meta.frontiere,
+                  tag: meta.tag,
+                  location: meta.location,
+                  comment: meta.comment,
+                },
+              })),
             },
           },
         })
@@ -117,7 +92,53 @@ export const applyOverridesFromRows = async (
         applied++
       }
 
-      console.log(`Applied ${applied} overrides, ${notFound} EFs not found`)
+      for (const partRow of partRows) {
+        const importedId = partRow["Identifiant_de_l'élément"]
+        const ef = efByImportedId.get(importedId)
+        if (!ef) {
+          continue
+        }
+
+        const partType = getType(partRow.Type_poste)
+        const existingPart = ef.emissionFactorParts.find((p) => p.type === partType)
+        if (!existingPart) {
+          console.warn(`  Part type "${partRow.Type_poste}" not found for EF "${importedId}" — skipping`)
+          continue
+        }
+
+        const gases = getGases(partRow)
+        const metaData: { title: string; language: string }[] = []
+        if (partRow.Nom_poste_français) {
+          metaData.push({ title: partRow.Nom_poste_français, language: 'fr' })
+        }
+        if (partRow.Nom_poste_anglais) {
+          metaData.push({ title: partRow.Nom_poste_anglais, language: 'en' })
+        }
+
+        await transaction.emissionFactorPart.update({
+          where: { id: existingPart.id },
+          data: {
+            ...gases,
+            overrideRawCsv: serializeRowAsCsv(partRow),
+            metaData:
+              metaData.length > 0
+                ? {
+                    updateMany: metaData.map((m) => ({
+                      where: { emissionFactorPartId: existingPart.id, language: m.language },
+                      data: { title: m.title },
+                    })),
+                  }
+                : undefined,
+          },
+        })
+      }
+
+      const total = efRows.length
+      const pct = total > 0 ? Math.round((applied / total) * 100) : 0
+      console.log(`Applied ${applied} overrides, ${pct}% EFs found in DB`)
+      if (notFound > 0) {
+        console.log(`EFs not found: ${notFound}`)
+      }
     },
     { timeout: 20 * MIN * TIME_IN_MS },
   )

--- a/apps/bilan-carbone/src/services/importEmissionFactor/baseEmpreinte/getEmissionFactorsFromAPI.ts
+++ b/apps/bilan-carbone/src/services/importEmissionFactor/baseEmpreinte/getEmissionFactorsFromAPI.ts
@@ -9,6 +9,7 @@ import {
   ImportEmissionFactor,
   requiredColumns,
   saveEmissionFactorsParts,
+  serializeRowAsCsv,
   validStatuses,
 } from '../import'
 import { mapBaseEmpreinteEmissionFactors } from './import'
@@ -47,6 +48,7 @@ export const getEmissionFactorsFromAPI = async (prismaClient: PrismaClient, name
           const created = await transaction.emissionFactor.create({
             data: {
               ...data,
+              importedRawCsv: serializeRowAsCsv(row),
               versions: { create: { importVersionId: emissionFactorImportVersion.id } },
             },
           })

--- a/apps/bilan-carbone/src/services/importEmissionFactor/baseEmpreinte/getEmissionFactorsFromAPI.ts
+++ b/apps/bilan-carbone/src/services/importEmissionFactor/baseEmpreinte/getEmissionFactorsFromAPI.ts
@@ -20,22 +20,18 @@ type EmissionFactorResponse = {
 }
 
 export const getEmissionFactorsFromAPI = async (prismaClient: PrismaClient, name: string) => {
-  const results = await axios.get('https://data.ademe.fr/data-fair/api/v1/datasets/base-carboner')
-  const fileName = results.data.file.name
+  await axios.get('https://data.ademe.fr/data-fair/api/v1/datasets/base-carboner')
 
   await prismaClient.$transaction(
     async (transaction) => {
-      const emissionFactorImportVersion = await getEmissionFactorImportVersion(
-        transaction,
-        name,
-        Import.BaseEmpreinte,
-        fileName,
-      )
-      if (!emissionFactorImportVersion.success) {
+      const emissionFactorImportVersion = await getEmissionFactorImportVersion(transaction, name, Import.BaseEmpreinte)
+      if (emissionFactorImportVersion.alreadyExists) {
         return console.error('Emission factors already imported with id : ', emissionFactorImportVersion.id)
       }
 
       let parts: ImportEmissionFactor[] = []
+      const importedIdToEfId = new Map<string, string>()
+      const newEmissionFactorIds: string[] = []
       let url: string | undefined =
         `https://data.ademe.fr/data-fair/api/v1/datasets/base-carboner/lines?select=${requiredColumns.join(',')}&q_fields=Statut_de_l'élément&q=${validStatuses.map((status) => encodeURI(status)).join(',')}`
 
@@ -45,16 +41,23 @@ export const getEmissionFactorsFromAPI = async (prismaClient: PrismaClient, name
         parts = parts.concat(
           emissionFactors.data.results.filter((emissionFactor) => emissionFactor.Type_Ligne === 'Poste'),
         )
-        const data = emissionFactors.data.results
-          .filter((emissionFactor) => emissionFactor.Type_Ligne !== 'Poste')
-          .map((emissionFactor) => mapBaseEmpreinteEmissionFactors(emissionFactor, emissionFactorImportVersion.id))
-
-        await Promise.all(data.map((data) => transaction.emissionFactor.create({ data })))
+        const efRows = emissionFactors.data.results.filter((emissionFactor) => emissionFactor.Type_Ligne !== 'Poste')
+        for (const row of efRows) {
+          const data = mapBaseEmpreinteEmissionFactors(row)
+          const created = await transaction.emissionFactor.create({
+            data: {
+              ...data,
+              versions: { create: { importVersionId: emissionFactorImportVersion.id } },
+            },
+          })
+          importedIdToEfId.set(row["Identifiant_de_l'élément"], created.id)
+          newEmissionFactorIds.push(created.id)
+        }
         url = emissionFactors.data.next
       }
 
-      await saveEmissionFactorsParts(transaction, emissionFactorImportVersion.id, parts)
-      await cleanImport(transaction, emissionFactorImportVersion.id)
+      await saveEmissionFactorsParts(transaction, importedIdToEfId, parts)
+      await cleanImport(transaction, newEmissionFactorIds)
       await addSourceToStudies(Import.BaseEmpreinte, transaction)
     },
     { timeout: HOUR * TIME_IN_MS },

--- a/apps/bilan-carbone/src/services/importEmissionFactor/baseEmpreinte/getEmissionFactorsFromCSV.ts
+++ b/apps/bilan-carbone/src/services/importEmissionFactor/baseEmpreinte/getEmissionFactorsFromCSV.ts
@@ -1,6 +1,0 @@
-import { Import } from '@abc-transitionbascarbone/db-common/enums'
-import { getEmissionFactorsFromCSV as getEmissionFactors } from '../getEmissionFactorsFromCSV'
-import { mapBaseEmpreinteEmissionFactors } from './import'
-
-export const getEmissionFactorsFromCSV = async (name: string, file: string) =>
-  getEmissionFactors(name, file, Import.BaseEmpreinte, mapBaseEmpreinteEmissionFactors)

--- a/apps/bilan-carbone/src/services/importEmissionFactor/baseEmpreinte/import.ts
+++ b/apps/bilan-carbone/src/services/importEmissionFactor/baseEmpreinte/import.ts
@@ -7,7 +7,7 @@ const getSubPostsFunc = (emissionFactor: ImportEmissionFactor) =>
     .filter(([, elements]) => elements.some((element) => element === emissionFactor["Identifiant_de_l'élément"]))
     .map(([subPost]) => subPost as SubPost)
 
-export const mapBaseEmpreinteEmissionFactors = (emissionFactor: ImportEmissionFactor, versionId: string) => ({
-  ...mapEmissionFactors(emissionFactor, Import.BaseEmpreinte, versionId, getSubPostsFunc),
+export const mapBaseEmpreinteEmissionFactors = (emissionFactor: ImportEmissionFactor) => ({
+  ...mapEmissionFactors(emissionFactor, Import.BaseEmpreinte, getSubPostsFunc),
   base: getSubPostsFunc(emissionFactor).includes(SubPost.Electricite) ? EmissionFactorBase.LocationBased : null,
 })

--- a/apps/bilan-carbone/src/services/importEmissionFactor/cut/getEmissionFactors.ts
+++ b/apps/bilan-carbone/src/services/importEmissionFactor/cut/getEmissionFactors.ts
@@ -4,8 +4,8 @@ import { ImportEmissionFactor, mapEmissionFactors } from '../import'
 
 const getSubPostsFunc = () => [SubPost.UsagesNumeriques]
 
-const mapCUTEmissionFactors = (emissionFactor: ImportEmissionFactor, versionId: string) =>
-  mapEmissionFactors(emissionFactor, Import.CUT, versionId, getSubPostsFunc)
+const mapCUTEmissionFactors = (emissionFactor: ImportEmissionFactor) =>
+  mapEmissionFactors(emissionFactor, Import.CUT, getSubPostsFunc)
 
 export const getEmissionFactorsFromCSV = async (name: string, file: string) =>
   getEmissionFactors(name, file, Import.CUT, mapCUTEmissionFactors)

--- a/apps/bilan-carbone/src/services/importEmissionFactor/getEmissionFactorsFromCSV.ts
+++ b/apps/bilan-carbone/src/services/importEmissionFactor/getEmissionFactorsFromCSV.ts
@@ -1,20 +1,28 @@
-import type { Prisma } from '@abc-transitionbascarbone/db-common'
+import type { Prisma, PrismaClient } from '@abc-transitionbascarbone/db-common'
 import { Import } from '@abc-transitionbascarbone/db-common/enums'
 import { MIN, TIME_IN_MS } from '@abc-transitionbascarbone/utils'
 import { parse } from 'csv-parse'
 import fs from 'fs'
-import path from 'path'
 import { prismaClient } from '../../db/client.server'
 import { getEncoding } from '../../utils/csv'
 import {
   addSourceToStudies,
+  checkOverrideConflicts,
   cleanImport,
+  ConflictReport,
+  connectEmissionFactorToVersion,
+  DryRunReport,
   getEmissionFactorImportVersion,
   ImportEmissionFactor,
+  isEmissionFactorUnchanged,
+  numberColumns,
+  propagateOverrides,
   requiredColumns,
   saveEmissionFactorsParts,
   validStatuses,
 } from './import'
+
+export type OverrideMode = 'keep' | 'discard' | 'none'
 
 const checkHeaders = (headers: string[]) => {
   if (requiredColumns.length > headers.length) {
@@ -27,100 +35,254 @@ const checkHeaders = (headers: string[]) => {
   }
 }
 
-const numberColumns: (keyof ImportEmissionFactor)[] = [
-  'Total_poste_non_décomposé',
-  'CO2b',
-  'CH4f',
-  'CH4b',
-  'Autres_GES',
-  'N2O',
-  'CO2f',
-  'Qualité',
-  'Qualité_TeR',
-  'Qualité_GR',
-  'Qualité_TiR',
-  'Qualité_C',
-  'Valeur_gaz_supplémentaire_1',
-  'Valeur_gaz_supplémentaire_2',
-]
+export const parseCSVRows = (
+  file: string,
+): Promise<{ emissionFactors: ImportEmissionFactor[]; parts: ImportEmissionFactor[] }> =>
+  new Promise((resolve, reject) => {
+    const emissionFactors: ImportEmissionFactor[] = []
+    const parts: ImportEmissionFactor[] = []
+    fs.createReadStream(file)
+      .pipe(
+        parse({
+          columns: (headers: string[]) => {
+            const formattedHeader = headers.map((header) => header.trim().replaceAll(' ', '_'))
+            checkHeaders(formattedHeader)
+            return formattedHeader
+          },
+          delimiter: ';',
+          encoding: getEncoding(file),
+          cast: (value, context) => {
+            if (value === '') {
+              return undefined
+            }
+            if (numberColumns.includes(context.column as keyof ImportEmissionFactor)) {
+              return Number(value.replace(',', '.'))
+            }
+            return value
+          },
+        }),
+      )
+      .on('data', (row: ImportEmissionFactor) => {
+        if (validStatuses.includes(row["Statut_de_l'élément"])) {
+          if (row.Type_Ligne === 'Poste') {
+            parts.push(row)
+          } else {
+            emissionFactors.push(row)
+          }
+        }
+      })
+      .on('end', () => resolve({ emissionFactors, parts }))
+      .on('error', reject)
+  })
+
+type ExistingEF = Prisma.EmissionFactorGetPayload<{ include: { metaData: true } }>
+
+type AnalysisResult = {
+  importedIds: string[]
+  existingByImportedId: Map<string, ExistingEF>
+  partsByImportedId: Map<string, ImportEmissionFactor[]>
+  changedEfs: { importedId: string; efId: string }[]
+  newCount: number
+  reusedCount: number
+  removedCount: number
+  conflicts: ConflictReport[]
+}
+
+const analyzeImport = async (
+  client: PrismaClient | Prisma.TransactionClient,
+  emissionFactors: ImportEmissionFactor[],
+  parts: ImportEmissionFactor[],
+  importFrom: Import,
+  previousVersionId: string | undefined,
+): Promise<AnalysisResult> => {
+  const importedIds = emissionFactors.map((ef) => ef["Identifiant_de_l'élément"])
+
+  const existingEFs = await client.emissionFactor.findMany({
+    where: {
+      importedId: { in: importedIds },
+      importedFrom: importFrom,
+      ...(previousVersionId ? { versions: { some: { importVersionId: previousVersionId } } } : {}),
+    },
+    include: { metaData: true },
+  })
+  const existingByImportedId = new Map(existingEFs.map((ef) => [ef.importedId!, ef]))
+
+  const partsByImportedId = new Map<string, ImportEmissionFactor[]>()
+  for (const part of parts) {
+    const id = part["Identifiant_de_l'élément"]
+    const existing = partsByImportedId.get(id) ?? []
+    existing.push(part)
+    partsByImportedId.set(id, existing)
+  }
+
+  const changedEfs: { importedId: string; efId: string }[] = []
+  let reusedCount = 0
+  let newCount = 0
+
+  for (const emissionFactor of emissionFactors) {
+    const importedId = emissionFactor["Identifiant_de_l'élément"]
+    const existing = existingByImportedId.get(importedId)
+    const efParts = partsByImportedId.get(importedId) ?? []
+    if (existing && isEmissionFactorUnchanged(existing, emissionFactor, efParts)) {
+      reusedCount++
+    } else if (existing) {
+      changedEfs.push({ importedId, efId: existing.id })
+    } else {
+      newCount++
+    }
+  }
+
+  const conflicts = await checkOverrideConflicts(client, changedEfs)
+
+  let removedCount = 0
+  if (previousVersionId) {
+    const previousImportedIds = await client.emissionFactor.findMany({
+      where: { importedFrom: importFrom, versions: { some: { importVersionId: previousVersionId } } },
+      select: { importedId: true },
+    })
+    const incomingIdSet = new Set(importedIds)
+    removedCount = previousImportedIds.filter((ef) => ef.importedId && !incomingIdSet.has(ef.importedId)).length
+  }
+
+  return {
+    importedIds,
+    existingByImportedId,
+    partsByImportedId,
+    changedEfs,
+    newCount,
+    reusedCount,
+    removedCount,
+    conflicts,
+  }
+}
+
+const logReport = (label: string, { newCount, updatedCount, reusedCount, removedCount, conflicts }: DryRunReport) => {
+  console.log(`\n--- ${label} ---`)
+  console.log(`New EFs (not in any previous version): ${newCount}`)
+  console.log(`Updated EFs (values changed, new row will be created): ${updatedCount}`)
+  console.log(`Reused EFs (unchanged, existing row reused): ${reusedCount}`)
+  console.log(`Removed EFs (in previous version but absent from this import): ${removedCount}`)
+  console.log(`Conflicts with existing overrides: ${conflicts.length}`)
+  for (const c of conflicts) {
+    console.log(`  importedId: ${c.importedId}`)
+  }
+  console.log(`---------------------\n`)
+}
 
 export const getEmissionFactorsFromCSV = async (
   name: string,
   file: string,
   importFrom: Import,
-  mapFunction: (emissionFactor: ImportEmissionFactor, importVersionId: string) => Prisma.EmissionFactorCreateInput,
-) => {
-  await prismaClient.$transaction(
+  mapFunction: (emissionFactor: ImportEmissionFactor) => Prisma.EmissionFactorCreateInput,
+  options: { dryRun?: boolean; overrideMode?: OverrideMode } = {},
+): Promise<DryRunReport | void> => {
+  const { dryRun = false, overrideMode = 'none' } = options
+
+  const existingVersion = await prismaClient.emissionFactorImportVersion.findFirst({
+    where: { name, source: importFrom },
+  })
+  if (existingVersion) {
+    console.error(
+      `Version "${name}" already exists for source "${importFrom}". Use a different name or use the override script.`,
+    )
+    process.exit(1)
+  }
+
+  console.log('Parse file...')
+  const { emissionFactors, parts } = await parseCSVRows(file)
+  console.log(`Processing ${emissionFactors.length} emission factors...`)
+
+  const previousVersion = await prismaClient.emissionFactorImportVersion.findFirst({
+    where: { source: importFrom, emissionFactorVersions: { some: {} } },
+    orderBy: { createdAt: 'desc' },
+  })
+
+  if (dryRun) {
+    const { changedEfs, newCount, reusedCount, removedCount, conflicts } = await analyzeImport(
+      prismaClient,
+      emissionFactors,
+      parts,
+      importFrom,
+      previousVersion?.id,
+    )
+    const report: DryRunReport = {
+      newCount,
+      updatedCount: changedEfs.length,
+      reusedCount,
+      removedCount,
+      conflicts,
+    }
+    logReport('Dry Run Report', report)
+    return report
+  }
+
+  return prismaClient.$transaction(
     async (transaction) => {
-      const emissionFactorImportVersion = await getEmissionFactorImportVersion(
-        transaction,
-        name,
-        importFrom,
-        path.basename(file),
-      )
-      if (!emissionFactorImportVersion.success) {
-        return console.error('Emission factors already imported with id : ', emissionFactorImportVersion.id)
+      const emissionFactorImportVersion = await getEmissionFactorImportVersion(transaction, name, importFrom)
+      const importVersionId = emissionFactorImportVersion.id
+
+      const { existingByImportedId, partsByImportedId, newCount, reusedCount, removedCount, conflicts } =
+        await analyzeImport(transaction, emissionFactors, parts, importFrom, previousVersion?.id)
+
+      if (conflicts.length > 0 && overrideMode === 'none') {
+        console.error(`\n⚠️  ${conflicts.length} conflict(s) detected with existing overrides:`)
+        for (const c of conflicts) {
+          console.error(`  importedId: ${c.importedId}`)
+        }
+        console.error(`\nRe-run with --keep-overrides or --discard-overrides to proceed.\n`)
+        process.exit(1)
       }
 
-      console.log('Parse file...')
-      const emissionFactors: ImportEmissionFactor[] = []
-      const parts: ImportEmissionFactor[] = []
+      const importedIdToEfId = new Map<string, string>()
+      const newEmissionFactorIds: string[] = []
+      const oldToNewEfId: { oldId: string; newId: string }[] = []
 
-      await new Promise<void>((resolve, reject) => {
-        fs.createReadStream(file)
-          .pipe(
-            parse({
-              columns: (headers: string[]) => {
-                const formattedHeader = headers.map((header) => header.trim().replaceAll(' ', '_'))
-                checkHeaders(formattedHeader)
-                return formattedHeader
-              },
-              delimiter: ';',
-              encoding: getEncoding(file),
-              cast: (value, context) => {
-                if (value === '') {
-                  return undefined
-                }
+      let i = 0
+      for (const emissionFactor of emissionFactors) {
+        i++
+        if (i % 500 === 0) {
+          console.log(`${i}/${emissionFactors.length}...`)
+        }
 
-                if (numberColumns.includes(context.column as keyof ImportEmissionFactor)) {
-                  return Number(value.replace(',', '.'))
-                }
+        const importedId = emissionFactor["Identifiant_de_l'élément"]
+        const existing = existingByImportedId.get(importedId)
 
-                return value
-              },
-            }),
-          )
-          .on('data', (row: ImportEmissionFactor) => {
-            if (validStatuses.includes(row["Statut_de_l'élément"])) {
-              if (row.Type_Ligne === 'Poste') {
-                parts.push(row)
-              } else {
-                emissionFactors.push(row)
-              }
-            }
+        const efParts = partsByImportedId.get(importedId) ?? []
+        if (existing && isEmissionFactorUnchanged(existing, emissionFactor, efParts)) {
+          await connectEmissionFactorToVersion(transaction, existing.id, importVersionId)
+          importedIdToEfId.set(importedId, existing.id)
+        } else {
+          const data = mapFunction(emissionFactor)
+          const created = await transaction.emissionFactor.create({
+            data: { ...data, versions: { create: { importVersionId } } },
           })
-          .on('end', async () => {
-            console.log(`Save ${emissionFactors.length} emission factors...`)
-            let i = 0
-            for (const emissionFactor of emissionFactors) {
-              i++
-              if (i % 500 === 0) {
-                console.log(`${i}/${emissionFactors.length}...`)
-              }
-              const data = mapFunction(emissionFactor, emissionFactorImportVersion.id)
-              await transaction.emissionFactor.create({ data })
-            }
-            console.log(`Save ${parts.length} emission factors parts...`)
-            await saveEmissionFactorsParts(transaction, emissionFactorImportVersion.id, parts)
-            await cleanImport(transaction, emissionFactorImportVersion.id)
-            await addSourceToStudies(importFrom, transaction)
-            console.log('Done')
-            resolve()
-          })
-          .on('error', (error) => {
-            reject(error)
-          })
+          importedIdToEfId.set(importedId, created.id)
+          newEmissionFactorIds.push(created.id)
+          if (existing) {
+            oldToNewEfId.push({ oldId: existing.id, newId: created.id })
+          }
+        }
+      }
+
+      if (overrideMode === 'keep' && oldToNewEfId.length > 0) {
+        await propagateOverrides(transaction, oldToNewEfId)
+      }
+
+      logReport(`Import Report (overrideMode: ${overrideMode})`, {
+        newCount,
+        updatedCount: oldToNewEfId.length,
+        reusedCount,
+        removedCount,
+        conflicts,
       })
+
+      console.log(`Save ${parts.length} emission factors parts...`)
+      await saveEmissionFactorsParts(transaction, importedIdToEfId, parts)
+      await cleanImport(transaction, newEmissionFactorIds)
+
+      await addSourceToStudies(importFrom, transaction)
+
+      console.log('Done')
     },
     { timeout: 20 * MIN * TIME_IN_MS },
   )

--- a/apps/bilan-carbone/src/services/importEmissionFactor/getEmissionFactorsFromCSV.ts
+++ b/apps/bilan-carbone/src/services/importEmissionFactor/getEmissionFactorsFromCSV.ts
@@ -7,22 +7,27 @@ import { prismaClient } from '../../db/client.server'
 import { getEncoding } from '../../utils/csv'
 import {
   addSourceToStudies,
-  checkOverrideConflicts,
   cleanImport,
-  ConflictReport,
   connectEmissionFactorToVersion,
-  DryRunReport,
   getEmissionFactorImportVersion,
   ImportEmissionFactor,
-  isEmissionFactorUnchanged,
+  isRowUnchanged,
+  mergeRowWithOverride,
   numberColumns,
-  propagateOverrides,
+  propagatePartOverrides,
   requiredColumns,
   saveEmissionFactorsParts,
+  serializeRowAsCsv,
   validStatuses,
 } from './import'
 
-export type OverrideMode = 'keep' | 'discard' | 'none'
+export type DryRunReport = {
+  newCount: number
+  updatedCount: number
+  reusedCount: number
+  removedCount: number
+  overriddenAndUpdatedCount: number
+}
 
 const checkHeaders = (headers: string[]) => {
   if (requiredColumns.length > headers.length) {
@@ -75,23 +80,23 @@ export const parseCSVRows = (
       .on('error', reject)
   })
 
-type ExistingEF = Prisma.EmissionFactorGetPayload<{ include: { metaData: true } }>
+type ExistingEF = Prisma.EmissionFactorGetPayload<{
+  select: { id: true; importedId: true; importedRawCsv: true; overrideRawCsv: true }
+}>
 
 type AnalysisResult = {
   importedIds: string[]
   existingByImportedId: Map<string, ExistingEF>
-  partsByImportedId: Map<string, ImportEmissionFactor[]>
   changedEfs: { importedId: string; efId: string }[]
+  overriddenAndUpdatedCount: number
   newCount: number
   reusedCount: number
   removedCount: number
-  conflicts: ConflictReport[]
 }
 
 const analyzeImport = async (
   client: PrismaClient | Prisma.TransactionClient,
   emissionFactors: ImportEmissionFactor[],
-  parts: ImportEmissionFactor[],
   importFrom: Import,
   previousVersionId: string | undefined,
 ): Promise<AnalysisResult> => {
@@ -103,36 +108,29 @@ const analyzeImport = async (
       importedFrom: importFrom,
       ...(previousVersionId ? { versions: { some: { importVersionId: previousVersionId } } } : {}),
     },
-    include: { metaData: true },
+    select: { id: true, importedId: true, importedRawCsv: true, overrideRawCsv: true },
   })
   const existingByImportedId = new Map(existingEFs.map((ef) => [ef.importedId!, ef]))
-
-  const partsByImportedId = new Map<string, ImportEmissionFactor[]>()
-  for (const part of parts) {
-    const id = part["Identifiant_de_l'élément"]
-    const existing = partsByImportedId.get(id) ?? []
-    existing.push(part)
-    partsByImportedId.set(id, existing)
-  }
 
   const changedEfs: { importedId: string; efId: string }[] = []
   let reusedCount = 0
   let newCount = 0
+  let overriddenAndUpdatedCount = 0
 
   for (const emissionFactor of emissionFactors) {
     const importedId = emissionFactor["Identifiant_de_l'élément"]
     const existing = existingByImportedId.get(importedId)
-    const efParts = partsByImportedId.get(importedId) ?? []
-    if (existing && isEmissionFactorUnchanged(existing, emissionFactor, efParts)) {
+    if (existing?.importedRawCsv && isRowUnchanged(existing.importedRawCsv, emissionFactor)) {
       reusedCount++
     } else if (existing) {
+      if (existing.overrideRawCsv) {
+        overriddenAndUpdatedCount++
+      }
       changedEfs.push({ importedId, efId: existing.id })
     } else {
       newCount++
     }
   }
-
-  const conflicts = await checkOverrideConflicts(client, changedEfs)
 
   let removedCount = 0
   if (previousVersionId) {
@@ -147,27 +145,30 @@ const analyzeImport = async (
   return {
     importedIds,
     existingByImportedId,
-    partsByImportedId,
     changedEfs,
+    overriddenAndUpdatedCount,
     newCount,
     reusedCount,
     removedCount,
-    conflicts,
   }
 }
 
-const logReport = (label: string, { newCount, updatedCount, reusedCount, removedCount, conflicts }: DryRunReport) => {
+const logReport = (
+  label: string,
+  { newCount, updatedCount, reusedCount, removedCount, overriddenAndUpdatedCount }: DryRunReport,
+) => {
   console.log(`\n--- ${label} ---`)
   console.log(`New EFs (not in any previous version): ${newCount}`)
   console.log(`Updated EFs (values changed, new row will be created): ${updatedCount}`)
+  console.log(
+    `Conflicts (updated EFs with manual overrides — require --keep-overrides or --discard-overrides): ${overriddenAndUpdatedCount}`,
+  )
   console.log(`Reused EFs (unchanged, existing row reused): ${reusedCount}`)
   console.log(`Removed EFs (in previous version but absent from this import): ${removedCount}`)
-  console.log(`Conflicts with existing overrides: ${conflicts.length}`)
-  for (const c of conflicts) {
-    console.log(`  importedId: ${c.importedId}`)
-  }
   console.log(`---------------------\n`)
 }
+
+export type OverrideMode = 'keep' | 'discard'
 
 export const getEmissionFactorsFromCSV = async (
   name: string,
@@ -176,7 +177,7 @@ export const getEmissionFactorsFromCSV = async (
   mapFunction: (emissionFactor: ImportEmissionFactor) => Prisma.EmissionFactorCreateInput,
   options: { dryRun?: boolean; overrideMode?: OverrideMode } = {},
 ): Promise<DryRunReport | void> => {
-  const { dryRun = false, overrideMode = 'none' } = options
+  const { dryRun = false, overrideMode } = options
 
   const existingVersion = await prismaClient.emissionFactorImportVersion.findFirst({
     where: { name, source: importFrom },
@@ -198,10 +199,9 @@ export const getEmissionFactorsFromCSV = async (
   })
 
   if (dryRun) {
-    const { changedEfs, newCount, reusedCount, removedCount, conflicts } = await analyzeImport(
+    const { changedEfs, overriddenAndUpdatedCount, newCount, reusedCount, removedCount } = await analyzeImport(
       prismaClient,
       emissionFactors,
-      parts,
       importFrom,
       previousVersion?.id,
     )
@@ -210,10 +210,20 @@ export const getEmissionFactorsFromCSV = async (
       updatedCount: changedEfs.length,
       reusedCount,
       removedCount,
-      conflicts,
+      overriddenAndUpdatedCount,
     }
     logReport('Dry Run Report', report)
     return report
+  }
+
+  const { existingByImportedId, changedEfs, overriddenAndUpdatedCount, newCount, reusedCount, removedCount } =
+    await analyzeImport(prismaClient, emissionFactors, importFrom, previousVersion?.id)
+
+  if (overriddenAndUpdatedCount > 0 && !overrideMode) {
+    console.error(`\n⚠️  ${overriddenAndUpdatedCount} EF(s) have manual overrides and their CSV row has changed.`)
+    console.error(`   Use --keep-overrides to propagate existing overrides onto the new EF values.`)
+    console.error(`   Use --discard-overrides to import the new CSV values and discard manual overrides.`)
+    process.exit(1)
   }
 
   return prismaClient.$transaction(
@@ -221,21 +231,11 @@ export const getEmissionFactorsFromCSV = async (
       const emissionFactorImportVersion = await getEmissionFactorImportVersion(transaction, name, importFrom)
       const importVersionId = emissionFactorImportVersion.id
 
-      const { existingByImportedId, partsByImportedId, newCount, reusedCount, removedCount, conflicts } =
-        await analyzeImport(transaction, emissionFactors, parts, importFrom, previousVersion?.id)
-
-      if (conflicts.length > 0 && overrideMode === 'none') {
-        console.error(`\n⚠️  ${conflicts.length} conflict(s) detected with existing overrides:`)
-        for (const c of conflicts) {
-          console.error(`  importedId: ${c.importedId}`)
-        }
-        console.error(`\nRe-run with --keep-overrides or --discard-overrides to proceed.\n`)
-        process.exit(1)
-      }
-
       const importedIdToEfId = new Map<string, string>()
       const newEmissionFactorIds: string[] = []
-      const oldToNewEfId: { oldId: string; newId: string }[] = []
+      const reusedEfIds = new Set<string>()
+      // Maps new EF id → old EF id, for EFs where override was merged (to propagate to parts)
+      const mergedOverrideEfIds = new Map<string, string>()
 
       let i = 0
       for (const emissionFactor of emissionFactors) {
@@ -247,37 +247,43 @@ export const getEmissionFactorsFromCSV = async (
         const importedId = emissionFactor["Identifiant_de_l'élément"]
         const existing = existingByImportedId.get(importedId)
 
-        const efParts = partsByImportedId.get(importedId) ?? []
-        if (existing && isEmissionFactorUnchanged(existing, emissionFactor, efParts)) {
+        if (existing?.importedRawCsv && isRowUnchanged(existing.importedRawCsv, emissionFactor)) {
           await connectEmissionFactorToVersion(transaction, existing.id, importVersionId)
           importedIdToEfId.set(importedId, existing.id)
+          reusedEfIds.add(existing.id)
         } else {
-          const data = mapFunction(emissionFactor)
+          const shouldMergeOverride = overrideMode === 'keep' && existing?.overrideRawCsv && existing?.importedRawCsv
+          const rowToMap = shouldMergeOverride
+            ? mergeRowWithOverride(emissionFactor, existing.importedRawCsv!, existing.overrideRawCsv!)
+            : emissionFactor
+          const data = mapFunction(rowToMap)
           const created = await transaction.emissionFactor.create({
-            data: { ...data, versions: { create: { importVersionId } } },
+            data: {
+              ...data,
+              importedRawCsv: serializeRowAsCsv(emissionFactor),
+              ...(shouldMergeOverride ? { overrideRawCsv: serializeRowAsCsv(rowToMap) } : {}),
+              versions: { create: { importVersionId } },
+            },
           })
           importedIdToEfId.set(importedId, created.id)
           newEmissionFactorIds.push(created.id)
-          if (existing) {
-            oldToNewEfId.push({ oldId: existing.id, newId: created.id })
+          if (shouldMergeOverride && existing) {
+            mergedOverrideEfIds.set(created.id, existing.id)
           }
         }
       }
 
-      if (overrideMode === 'keep' && oldToNewEfId.length > 0) {
-        await propagateOverrides(transaction, oldToNewEfId)
-      }
-
-      logReport(`Import Report (overrideMode: ${overrideMode})`, {
+      logReport('Import Report', {
         newCount,
-        updatedCount: oldToNewEfId.length,
+        updatedCount: changedEfs.length,
         reusedCount,
         removedCount,
-        conflicts,
+        overriddenAndUpdatedCount,
       })
 
       console.log(`Save ${parts.length} emission factors parts...`)
-      await saveEmissionFactorsParts(transaction, importedIdToEfId, parts)
+      await saveEmissionFactorsParts(transaction, importedIdToEfId, parts, reusedEfIds)
+      await propagatePartOverrides(transaction, mergedOverrideEfIds)
       await cleanImport(transaction, newEmissionFactorIds)
 
       await addSourceToStudies(importFrom, transaction)

--- a/apps/bilan-carbone/src/services/importEmissionFactor/import.ts
+++ b/apps/bilan-carbone/src/services/importEmissionFactor/import.ts
@@ -86,12 +86,12 @@ export const getEmissionFactorImportVersion = async (
 ) => {
   const existingVersion = await transaction.emissionFactorImportVersion.findFirst({ where: { name, source } })
   if (existingVersion) {
-    return { success: false, id: existingVersion.id, alreadyExists: true }
+    return { id: existingVersion.id, alreadyExists: true }
   }
   const newVersion = await transaction.emissionFactorImportVersion.create({
     data: { name, source },
   })
-  return { success: true, id: newVersion.id, alreadyExists: false }
+  return { id: newVersion.id, alreadyExists: false }
 }
 
 export const getEmissionFactorImportVersionByName = async (
@@ -140,11 +140,14 @@ export const propagateOverrides = async (
   transaction: Prisma.TransactionClient,
   oldToNewEfId: { oldId: string; newId: string }[],
 ) => {
+  const existingOverrides = await transaction.emissionFactorOverride.findMany({
+    where: { emissionFactorId: { in: oldToNewEfId.map((e) => e.oldId) } },
+    include: { parts: { include: { metaData: true } }, metaData: true },
+  })
+  const byOldId = new Map(existingOverrides.map((o) => [o.emissionFactorId, o]))
+
   for (const { oldId, newId } of oldToNewEfId) {
-    const existing = await transaction.emissionFactorOverride.findUnique({
-      where: { emissionFactorId: oldId },
-      include: { parts: { include: { metaData: true } }, metaData: true },
-    })
+    const existing = byOldId.get(oldId)
     if (existing) {
       const newOverride = await transaction.emissionFactorOverride.create({
         data: {
@@ -594,16 +597,14 @@ export const saveEmissionFactorsParts = async (
   importedIdToEfId: Map<string, string>,
   parts: ImportEmissionFactor[],
 ) => {
-  for (const i in parts) {
-    if (Number(i) % 100 === 0) {
+  for (const [i, part] of parts.entries()) {
+    if (i % 100 === 0) {
       console.log(`${i}/${parts.length}`)
     }
-    const part = parts[i]
     const emissionFactorId = importedIdToEfId.get(part["Identifiant_de_l'élément"])
     if (!emissionFactorId) {
       throw new Error('No emission factor found for ' + part["Identifiant_de_l'élément"])
     }
-    const emissionFactor = { id: emissionFactorId }
 
     const metaData = []
     if (part.Nom_poste_français) {
@@ -615,7 +616,7 @@ export const saveEmissionFactorsParts = async (
 
     const data = {
       ...getGases(part),
-      emissionFactor: { connect: { id: emissionFactor.id } },
+      emissionFactor: { connect: { id: emissionFactorId } },
       type: getType(part.Type_poste),
       metaData: metaData.length > 0 ? { createMany: { data: metaData } } : undefined,
     } satisfies Prisma.EmissionFactorPartCreateInput

--- a/apps/bilan-carbone/src/services/importEmissionFactor/import.ts
+++ b/apps/bilan-carbone/src/services/importEmissionFactor/import.ts
@@ -1,7 +1,7 @@
 import { getSourceLatestImportVersionId } from '@/db/study'
 import { getEnvVar } from '@/lib/environment'
 import { isMonetaryEmissionFactor } from '@/utils/emissionFactors'
-import type { EmissionFactor, Prisma } from '@abc-transitionbascarbone/db-common'
+import type { Prisma } from '@abc-transitionbascarbone/db-common'
 import {
   EmissionFactorPartType,
   EmissionFactorStatus,
@@ -94,106 +94,6 @@ export const getEmissionFactorImportVersion = async (
   return { id: newVersion.id, alreadyExists: false }
 }
 
-export const getEmissionFactorImportVersionByName = async (
-  transaction: Prisma.TransactionClient,
-  name: string,
-  source: Import,
-) => {
-  return transaction.emissionFactorImportVersion.findFirst({ where: { name, source } })
-}
-
-export type ConflictReport = {
-  importedId: string
-}
-
-export type DryRunReport = {
-  newCount: number
-  updatedCount: number
-  reusedCount: number
-  removedCount: number
-  conflicts: ConflictReport[]
-}
-
-export const checkOverrideConflicts = async (
-  transaction: Prisma.TransactionClient,
-  changedEfIds: { importedId: string; efId: string }[],
-): Promise<ConflictReport[]> => {
-  if (changedEfIds.length === 0) {
-    return []
-  }
-
-  const overrides = await transaction.emissionFactorOverride.findMany({
-    where: { emissionFactorId: { in: changedEfIds.map((e) => e.efId) } },
-    select: { emissionFactorId: true },
-  })
-
-  if (overrides.length === 0) {
-    return []
-  }
-
-  const overrideEfIds = new Set(overrides.map((o) => o.emissionFactorId))
-
-  return changedEfIds.filter((e) => overrideEfIds.has(e.efId)).map((e) => ({ importedId: e.importedId }))
-}
-
-export const propagateOverrides = async (
-  transaction: Prisma.TransactionClient,
-  oldToNewEfId: { oldId: string; newId: string }[],
-) => {
-  const existingOverrides = await transaction.emissionFactorOverride.findMany({
-    where: { emissionFactorId: { in: oldToNewEfId.map((e) => e.oldId) } },
-    include: { parts: { include: { metaData: true } }, metaData: true },
-  })
-  const byOldId = new Map(existingOverrides.map((o) => [o.emissionFactorId, o]))
-
-  for (const { oldId, newId } of oldToNewEfId) {
-    const existing = byOldId.get(oldId)
-    if (existing) {
-      const newOverride = await transaction.emissionFactorOverride.create({
-        data: {
-          emissionFactorId: newId,
-          totalCo2: existing.totalCo2,
-          co2f: existing.co2f,
-          ch4f: existing.ch4f,
-          ch4b: existing.ch4b,
-          n2o: existing.n2o,
-          co2b: existing.co2b,
-          sf6: existing.sf6,
-          hfc: existing.hfc,
-          pfc: existing.pfc,
-          otherGES: existing.otherGES,
-          unit: existing.unit,
-          status: existing.status,
-          source: existing.source,
-          location: existing.location,
-          metaData: {
-            createMany: {
-              // eslint-disable-next-line @typescript-eslint/no-unused-vars
-              data: existing.metaData.map(({ overrideId: _overrideId, createdAt: _c, updatedAt: _u, ...meta }) => meta),
-            },
-          },
-        },
-      })
-      for (const part of existing.parts) {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { id: _id, overrideId: _overrideId, metaData: partMetaData, ...partData } = part
-        const newPart = await transaction.emissionFactorOverridePart.create({
-          data: { ...partData, overrideId: newOverride.id },
-        })
-        if (partMetaData.length > 0) {
-          await transaction.emissionFactorOverridePartMetaData.createMany({
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            data: partMetaData.map(({ overridePartId: _pid, createdAt: _c, updatedAt: _u, ...meta }) => ({
-              ...meta,
-              overridePartId: newPart.id,
-            })),
-          })
-        }
-      }
-    }
-  }
-}
-
 export const connectEmissionFactorToVersion = async (
   transaction: Prisma.TransactionClient,
   emissionFactorId: string,
@@ -206,117 +106,85 @@ export const connectEmissionFactorToVersion = async (
   })
 }
 
-type EFWithMetaData = EmissionFactor & {
-  metaData: {
-    language: string
-    title?: string | null
-    attribute?: string | null
-    frontiere?: string | null
-    tag?: string | null
-    location?: string | null
-    comment?: string | null
-  }[]
+/**
+ * Serializes a CSV row as "header\nvalues" so it can be stored and compared on next imports.
+ * The header line ensures comparisons remain correct even if column order changes between versions.
+ */
+export const serializeRowAsCsv = (row: ImportEmissionFactor): string => {
+  const keys = Object.keys(row) as (keyof ImportEmissionFactor)[]
+  const header = keys.join(';')
+  const values = keys.map((k) => (row[k] !== undefined && row[k] !== null ? String(row[k]) : '')).join(';')
+  return `${header}\n${values}`
 }
 
-// Relative tolerance comparison for floats — values that differ by less than 0.1% are considered equal
-export const eqFloat = (a: number | null, b: number | null) => {
-  const va = a || 0
-  const vb = b || 0
-  if (va === vb) {
-    return true
+const normalizeValue = (val: string): string => {
+  const normalized = val.replace(',', '.')
+  const n = Number(normalized)
+  if (!isNaN(n) && normalized.trim() !== '') {
+    return String(n)
   }
-  const magnitude = Math.max(Math.abs(va), Math.abs(vb), 1)
-  return Math.abs(va - vb) / magnitude < 1e-3
+  return val
 }
 
-// Normalizes CSV strings: removes triple-quote artifacts and applies NFC unicode normalization
-export const normalizeImportStr = (v: string | null | undefined): string | null => {
-  if (!v) {
-    return null
+const parseRawCsv = (rawCsv: string): Map<string, string> => {
+  const lines = rawCsv.split('\n')
+  if (lines.length !== 2) {
+    return new Map()
   }
-  return String(v).replaceAll('"""', '').normalize('NFC')
+  const headers = lines[0].split(';')
+  const values = lines[1].split(';')
+  return new Map(headers.map((h, i) => [h, values[i] ?? '']))
 }
 
-export const eqImportStr = (a: string | null | undefined, b: string | null | undefined) =>
-  normalizeImportStr(a) === normalizeImportStr(b)
+/**
+ * Merges a new CSV row with a previous override delta.
+ * Columns that were manually changed (differ between oldImportedRawCsv and overrideRawCsv)
+ * are preserved from the override. All other columns come from the new CSV row.
+ */
+export const mergeRowWithOverride = (
+  newRow: ImportEmissionFactor,
+  oldImportedRawCsv: string,
+  overrideRawCsv: string,
+): ImportEmissionFactor => {
+  const oldImportedMap = parseRawCsv(oldImportedRawCsv)
+  const overrideMap = parseRawCsv(overrideRawCsv)
 
-// Tags comparison is order-insensitive
-export const eqImportTags = (a: string | null | undefined, b: string | null | undefined) => {
-  if ((a ?? null) === (b ?? null)) {
-    return true
+  const merged = { ...newRow }
+  for (const [col, overrideVal] of overrideMap.entries()) {
+    const oldVal = oldImportedMap.get(col) ?? ''
+    if (normalizeValue(overrideVal) !== normalizeValue(oldVal)) {
+      const key = col as keyof ImportEmissionFactor
+      if (key in merged) {
+        ;(merged[key] as string | number) = numberColumns.includes(key) ? Number(overrideVal) : overrideVal
+      }
+    }
   }
-  if (!a || !b) {
+  return merged
+}
+
+export const isRowUnchanged = (existingRawCsv: string, newRow: ImportEmissionFactor): boolean => {
+  const newSerialized = serializeRowAsCsv(newRow)
+  const existingLines = existingRawCsv.split('\n')
+  const newLines = newSerialized.split('\n')
+  if (existingLines.length !== 2 || newLines.length !== 2) {
     return false
   }
-  const setA = new Set(a.split(',').map((t) => t.trim()))
-  const setB = new Set(b.split(',').map((t) => t.trim()))
-  return setA.size === setB.size && [...setA].every((t) => setB.has(t))
-}
+  const existingHeaders = existingLines[0].split(';')
+  const existingValues = existingLines[1].split(';')
+  const newHeaders = newLines[0].split(';')
+  const newValues = newLines[1].split(';')
 
-export const isEmissionFactorUnchanged = (
-  existing: EFWithMetaData,
-  row: ImportEmissionFactor,
-  parts: ImportEmissionFactor[],
-): boolean => {
-  // Simulate what cleanImport would store: if parts exist, gas values are summed from parts
-  let gases: ReturnType<typeof getGases>
-  if (parts.length > 0) {
-    const partGases = parts.map(getGases)
-    gases = {
-      totalCo2: partGases.reduce((s, p) => s + p.totalCo2, 0),
-      co2f: partGases.reduce((s, p) => s + p.co2f, 0),
-      ch4f: partGases.reduce((s, p) => s + p.ch4f, 0),
-      ch4b: partGases.reduce((s, p) => s + p.ch4b, 0),
-      n2o: partGases.reduce((s, p) => s + p.n2o, 0),
-      co2b: partGases.reduce((s, p) => s + p.co2b, 0),
-      sf6: partGases.reduce((s, p) => s + p.sf6, 0),
-      hfc: partGases.reduce((s, p) => s + p.hfc, 0),
-      pfc: partGases.reduce((s, p) => s + p.pfc, 0),
-      otherGES: partGases.reduce((s, p) => s + p.otherGES, 0),
+  const existingMap = new Map(existingHeaders.map((h, i) => [h, existingValues[i] ?? '']))
+
+  for (let i = 0; i < newHeaders.length; i++) {
+    const col = newHeaders[i]
+    const existingVal = normalizeValue(existingMap.get(col) ?? '')
+    const newVal = normalizeValue(newValues[i] ?? '')
+    if (existingVal !== newVal) {
+      return false
     }
-  } else {
-    gases = getGases(row)
   }
-
-  const frMeta = existing.metaData.find((m) => m.language === 'fr')
-  const enMeta = existing.metaData.find((m) => m.language === 'en')
-
-  const checks = {
-    totalCo2: eqFloat(existing.totalCo2, gases.totalCo2),
-    co2f: eqFloat(existing.co2f, gases.co2f),
-    ch4f: eqFloat(existing.ch4f, gases.ch4f),
-    ch4b: eqFloat(existing.ch4b, gases.ch4b),
-    n2o: eqFloat(existing.n2o, gases.n2o),
-    co2b: eqFloat(existing.co2b, gases.co2b),
-    sf6: eqFloat(existing.sf6, gases.sf6),
-    hfc: eqFloat(existing.hfc, gases.hfc),
-    pfc: eqFloat(existing.pfc, gases.pfc),
-    otherGES: eqFloat(existing.otherGES, gases.otherGES),
-    status:
-      existing.status ===
-      (row["Statut_de_l'élément"] === 'Archivé' ? EmissionFactorStatus.Archived : EmissionFactorStatus.Valid),
-    unit: existing.unit === getUnit(row.Unité_français),
-    source: eqImportStr(existing.source, row.Source),
-    location: eqImportStr(existing.location, row.Localisation_géographique),
-    frTitle: eqImportStr(frMeta?.title, row.Nom_base_français),
-    frAttribute: eqImportStr(frMeta?.attribute, row.Nom_attribut_français),
-    frFrontiere: eqImportStr(frMeta?.frontiere, row.Nom_frontière_français),
-    frTag: eqImportTags(frMeta?.tag, row.Tags_français),
-    frLocation: eqImportStr(frMeta?.location, row['Sous-localisation_géographique_français']),
-    frComment: eqImportStr(frMeta?.comment, row.Commentaire_français),
-    enTitle: eqImportStr(enMeta?.title, row.Nom_base_anglais),
-    enAttribute: eqImportStr(enMeta?.attribute, row.Nom_attribut_anglais),
-    enFrontiere: eqImportStr(enMeta?.frontiere, row.Nom_frontière_anglais),
-    enTag: eqImportTags(enMeta?.tag, row.Tags_anglais),
-    enLocation: eqImportStr(enMeta?.location, row['Sous-localisation_géographique_anglais']),
-    enComment: eqImportStr(enMeta?.comment, row.Commentaire_anglais),
-  }
-
-  const failed = Object.entries(checks)
-    .filter(([, ok]) => !ok)
-    .map(([key]) => key)
-
-  return failed.length === 0
+  return true
 }
 
 export type ImportEmissionFactor = {
@@ -481,7 +349,7 @@ const LABEL_TO_PART_TYPE = Object.fromEntries(
   Object.entries(PART_TYPE_LABELS).map(([type, label]) => [label, type as EmissionFactorPartType]),
 ) as Record<string, EmissionFactorPartType>
 
-const getType = (value: string): EmissionFactorPartType => {
+export const getType = (value: string): EmissionFactorPartType => {
   // Special case: CSV uses '?' for accented characters in this label
   const normalized = value.replace('d?électricité', "d'électricité")
   const type = LABEL_TO_PART_TYPE[normalized]
@@ -509,7 +377,7 @@ export const getEmissionQuality = (uncertainty?: number) => {
   }
 }
 
-const getGases = (emissionFactor: ImportEmissionFactor) => {
+export const getGases = (emissionFactor: ImportEmissionFactor) => {
   const gases = {
     totalCo2: Number(emissionFactor.Total_poste_non_décomposé),
     co2f: Number(emissionFactor.CO2f),
@@ -596,6 +464,7 @@ export const saveEmissionFactorsParts = async (
   transaction: Prisma.TransactionClient,
   importedIdToEfId: Map<string, string>,
   parts: ImportEmissionFactor[],
+  reusedEfIds: Set<string> = new Set(),
 ) => {
   for (const [i, part] of parts.entries()) {
     if (i % 100 === 0) {
@@ -604,6 +473,9 @@ export const saveEmissionFactorsParts = async (
     const emissionFactorId = importedIdToEfId.get(part["Identifiant_de_l'élément"])
     if (!emissionFactorId) {
       throw new Error('No emission factor found for ' + part["Identifiant_de_l'élément"])
+    }
+    if (reusedEfIds.has(emissionFactorId)) {
+      continue
     }
 
     const metaData = []
@@ -618,11 +490,108 @@ export const saveEmissionFactorsParts = async (
       ...getGases(part),
       emissionFactor: { connect: { id: emissionFactorId } },
       type: getType(part.Type_poste),
+      importedRawCsv: serializeRowAsCsv(part),
       metaData: metaData.length > 0 ? { createMany: { data: metaData } } : undefined,
     } satisfies Prisma.EmissionFactorPartCreateInput
 
     await transaction.emissionFactorPart.create({ data })
   }
+}
+
+export const propagatePartOverrides = async (
+  transaction: Prisma.TransactionClient,
+  mergedOverrideEfIds: Map<string, string>,
+) => {
+  if (mergedOverrideEfIds.size === 0) {
+    return
+  }
+
+  const oldEfIds = [...mergedOverrideEfIds.values()]
+  const oldParts = await transaction.emissionFactorPart.findMany({
+    where: { emissionFactorId: { in: oldEfIds }, overrideRawCsv: { not: null } },
+    select: { emissionFactorId: true, type: true, importedRawCsv: true, overrideRawCsv: true },
+  })
+
+  for (const [newEfId, oldEfId] of mergedOverrideEfIds.entries()) {
+    const oldPartsForEf = oldParts.filter((p) => p.emissionFactorId === oldEfId)
+    if (oldPartsForEf.length === 0) {
+      continue
+    }
+
+    const newParts = await transaction.emissionFactorPart.findMany({
+      where: { emissionFactorId: newEfId },
+      select: { id: true, type: true, importedRawCsv: true },
+    })
+
+    for (const oldPart of oldPartsForEf) {
+      if (!oldPart.importedRawCsv || !oldPart.overrideRawCsv) {
+        continue
+      }
+      const newPart = newParts.find((p) => p.type === oldPart.type)
+      if (!newPart?.importedRawCsv) {
+        continue
+      }
+
+      const oldImportedMap = parseRawCsv(oldPart.importedRawCsv)
+      const overrideMap = parseRawCsv(oldPart.overrideRawCsv)
+
+      const gasFields: (keyof ImportEmissionFactor)[] = [
+        'Total_poste_non_décomposé',
+        'CO2f',
+        'CH4f',
+        'CH4b',
+        'N2O',
+        'CO2b',
+        'Autres_GES',
+      ]
+      const updateData: Record<string, number | string> = {}
+      // Columns that were manually changed on the old part (delta)
+      const deltaColumns = new Map<string, string>()
+
+      for (const [col, overrideVal] of overrideMap.entries()) {
+        const oldVal = oldImportedMap.get(col) ?? ''
+        if (normalizeValue(overrideVal) !== normalizeValue(oldVal)) {
+          deltaColumns.set(col, overrideVal)
+          if (gasFields.includes(col as keyof ImportEmissionFactor)) {
+            const prismaField = csvColToPrismaGasField(col)
+            if (prismaField) {
+              updateData[prismaField] = Number(overrideVal)
+            }
+          }
+        }
+      }
+
+      if (Object.keys(updateData).length > 0) {
+        // Build overrideRawCsv relative to the new part's importedRawCsv so future
+        // imports compute the delta correctly.
+        const newImportedMap = parseRawCsv(newPart.importedRawCsv)
+        for (const [col, overrideVal] of deltaColumns) {
+          newImportedMap.set(col, overrideVal)
+        }
+        const headers = [...newImportedMap.keys()].join(';')
+        const values = [...newImportedMap.values()].join(';')
+        const newOverrideRawCsv = `${headers}\n${values}`
+
+        await transaction.emissionFactorPart.update({
+          where: { id: newPart.id },
+          data: { ...updateData, overrideRawCsv: newOverrideRawCsv },
+        })
+      }
+    }
+  }
+}
+
+const csvColToPrismaGasField = (col: string): string | null => {
+  const map: Record<string, string> = {
+    Total_poste_non_décomposé: 'totalCo2',
+    CO2f: 'co2f',
+    CH4f: 'ch4f',
+    CH4b: 'ch4b',
+    N2O: 'n2o',
+    CO2b: 'co2b',
+    Autres_GES: 'otherGES',
+  }
+  return map[col] ?? null
 }
 
 export const cleanImport = async (transaction: Prisma.TransactionClient, newEmissionFactorIds: string[]) => {

--- a/apps/bilan-carbone/src/services/importEmissionFactor/import.ts
+++ b/apps/bilan-carbone/src/services/importEmissionFactor/import.ts
@@ -1,7 +1,7 @@
 import { getSourceLatestImportVersionId } from '@/db/study'
 import { getEnvVar } from '@/lib/environment'
 import { isMonetaryEmissionFactor } from '@/utils/emissionFactors'
-import type { Prisma } from '@abc-transitionbascarbone/db-common'
+import type { EmissionFactor, Prisma } from '@abc-transitionbascarbone/db-common'
 import {
   EmissionFactorPartType,
   EmissionFactorStatus,
@@ -15,20 +15,305 @@ import { additionalParts } from './parts.config'
 
 export const validStatuses = ['Valide générique', 'Valide spécifique', 'Archivé']
 
+export const numberColumns: (keyof ImportEmissionFactor)[] = [
+  'Total_poste_non_décomposé',
+  'CO2b',
+  'CH4f',
+  'CH4b',
+  'Autres_GES',
+  'N2O',
+  'CO2f',
+  'Qualité',
+  'Qualité_TeR',
+  'Qualité_GR',
+  'Qualité_TiR',
+  'Qualité_C',
+  'Valeur_gaz_supplémentaire_1',
+  'Valeur_gaz_supplémentaire_2',
+]
+
+export const PART_TYPE_LABELS: Record<EmissionFactorPartType, string> = {
+  [EmissionFactorPartType.CarburantAmontCombustion]: 'Carburant (amont/combustion)',
+  [EmissionFactorPartType.Amont]: 'Amont',
+  [EmissionFactorPartType.Intrants]: 'Intrants',
+  [EmissionFactorPartType.Combustion]: 'Combustion',
+  [EmissionFactorPartType.TransportEtDistribution]: 'Transport et distribution',
+  [EmissionFactorPartType.Energie]: 'Energie',
+  [EmissionFactorPartType.Fabrication]: 'Fabrication',
+  [EmissionFactorPartType.Traitement]: 'Traitement',
+  [EmissionFactorPartType.Collecte]: 'Collecte',
+  [EmissionFactorPartType.Autre]: 'Autre',
+  [EmissionFactorPartType.Amortissement]: 'Amortissement',
+  [EmissionFactorPartType.Incineration]: 'Incinération',
+  [EmissionFactorPartType.EmissionsFugitives]: 'Emissions fugitives',
+  [EmissionFactorPartType.Fuites]: 'Fuites',
+  [EmissionFactorPartType.Transport]: 'Transport',
+  [EmissionFactorPartType.CombustionALaCentrale]: 'Combustion à la centrale',
+  [EmissionFactorPartType.Pertes]: 'Pertes',
+  [EmissionFactorPartType.AutresEmissionsLieesALaConsommationDElectriciteBarrage]:
+    "Autres émissions liées à la consommation d'électricité (barrage?)",
+}
+
+export const UNIT_LABELS: Partial<Record<Unit, string>> = {
+  [Unit.KG]: 'kg',
+  [Unit.LITER]: 'litre',
+  [Unit.HA]: 'ha',
+  [Unit.KWH_PCI]: 'kWh PCI',
+  [Unit.KWH_PCS]: 'kWh PCS',
+  [Unit.M2_SHON]: 'm² SHON',
+  [Unit.TEP_PCI]: 'tep PCI',
+  [Unit.TEP_PCS]: 'tep PCS',
+}
+
+export const unitLabel = (unit: Unit | null | undefined): string => {
+  if (!unit) {
+    return 'kg'
+  }
+  return UNIT_LABELS[unit] ?? String(unit)
+}
+
+export const statusLabel = (status: EmissionFactorStatus | null | undefined): string => {
+  if (!status) {
+    return 'Valide générique'
+  }
+  return status === EmissionFactorStatus.Archived ? 'Archivé' : 'Valide générique'
+}
+
 export const getEmissionFactorImportVersion = async (
   transaction: Prisma.TransactionClient,
   name: string,
   source: Import,
-  id: string,
 ) => {
-  const existingVersion = await transaction.emissionFactorImportVersion.findFirst({ where: { internId: id } })
+  const existingVersion = await transaction.emissionFactorImportVersion.findFirst({ where: { name, source } })
   if (existingVersion) {
-    return { success: false, id: existingVersion.id }
+    return { success: false, id: existingVersion.id, alreadyExists: true }
   }
   const newVersion = await transaction.emissionFactorImportVersion.create({
-    data: { name, source, internId: id },
+    data: { name, source },
   })
-  return { success: true, id: newVersion.id }
+  return { success: true, id: newVersion.id, alreadyExists: false }
+}
+
+export const getEmissionFactorImportVersionByName = async (
+  transaction: Prisma.TransactionClient,
+  name: string,
+  source: Import,
+) => {
+  return transaction.emissionFactorImportVersion.findFirst({ where: { name, source } })
+}
+
+export type ConflictReport = {
+  importedId: string
+}
+
+export type DryRunReport = {
+  newCount: number
+  updatedCount: number
+  reusedCount: number
+  removedCount: number
+  conflicts: ConflictReport[]
+}
+
+export const checkOverrideConflicts = async (
+  transaction: Prisma.TransactionClient,
+  changedEfIds: { importedId: string; efId: string }[],
+): Promise<ConflictReport[]> => {
+  if (changedEfIds.length === 0) {
+    return []
+  }
+
+  const overrides = await transaction.emissionFactorOverride.findMany({
+    where: { emissionFactorId: { in: changedEfIds.map((e) => e.efId) } },
+    select: { emissionFactorId: true },
+  })
+
+  if (overrides.length === 0) {
+    return []
+  }
+
+  const overrideEfIds = new Set(overrides.map((o) => o.emissionFactorId))
+
+  return changedEfIds.filter((e) => overrideEfIds.has(e.efId)).map((e) => ({ importedId: e.importedId }))
+}
+
+export const propagateOverrides = async (
+  transaction: Prisma.TransactionClient,
+  oldToNewEfId: { oldId: string; newId: string }[],
+) => {
+  for (const { oldId, newId } of oldToNewEfId) {
+    const existing = await transaction.emissionFactorOverride.findUnique({
+      where: { emissionFactorId: oldId },
+      include: { parts: { include: { metaData: true } }, metaData: true },
+    })
+    if (existing) {
+      const newOverride = await transaction.emissionFactorOverride.create({
+        data: {
+          emissionFactorId: newId,
+          totalCo2: existing.totalCo2,
+          co2f: existing.co2f,
+          ch4f: existing.ch4f,
+          ch4b: existing.ch4b,
+          n2o: existing.n2o,
+          co2b: existing.co2b,
+          sf6: existing.sf6,
+          hfc: existing.hfc,
+          pfc: existing.pfc,
+          otherGES: existing.otherGES,
+          unit: existing.unit,
+          status: existing.status,
+          source: existing.source,
+          location: existing.location,
+          metaData: {
+            createMany: {
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+              data: existing.metaData.map(({ overrideId: _overrideId, createdAt: _c, updatedAt: _u, ...meta }) => meta),
+            },
+          },
+        },
+      })
+      for (const part of existing.parts) {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { id: _id, overrideId: _overrideId, metaData: partMetaData, ...partData } = part
+        const newPart = await transaction.emissionFactorOverridePart.create({
+          data: { ...partData, overrideId: newOverride.id },
+        })
+        if (partMetaData.length > 0) {
+          await transaction.emissionFactorOverridePartMetaData.createMany({
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            data: partMetaData.map(({ overridePartId: _pid, createdAt: _c, updatedAt: _u, ...meta }) => ({
+              ...meta,
+              overridePartId: newPart.id,
+            })),
+          })
+        }
+      }
+    }
+  }
+}
+
+export const connectEmissionFactorToVersion = async (
+  transaction: Prisma.TransactionClient,
+  emissionFactorId: string,
+  importVersionId: string,
+) => {
+  await transaction.emissionFactorVersion.upsert({
+    where: { emissionFactorId_importVersionId: { emissionFactorId, importVersionId } },
+    create: { emissionFactorId, importVersionId },
+    update: {},
+  })
+}
+
+type EFWithMetaData = EmissionFactor & {
+  metaData: {
+    language: string
+    title?: string | null
+    attribute?: string | null
+    frontiere?: string | null
+    tag?: string | null
+    location?: string | null
+    comment?: string | null
+  }[]
+}
+
+// Relative tolerance comparison for floats — values that differ by less than 0.1% are considered equal
+export const eqFloat = (a: number | null, b: number | null) => {
+  const va = a || 0
+  const vb = b || 0
+  if (va === vb) {
+    return true
+  }
+  const magnitude = Math.max(Math.abs(va), Math.abs(vb), 1)
+  return Math.abs(va - vb) / magnitude < 1e-3
+}
+
+// Normalizes CSV strings: removes triple-quote artifacts and applies NFC unicode normalization
+export const normalizeImportStr = (v: string | null | undefined): string | null => {
+  if (!v) {
+    return null
+  }
+  return String(v).replaceAll('"""', '').normalize('NFC')
+}
+
+export const eqImportStr = (a: string | null | undefined, b: string | null | undefined) =>
+  normalizeImportStr(a) === normalizeImportStr(b)
+
+// Tags comparison is order-insensitive
+export const eqImportTags = (a: string | null | undefined, b: string | null | undefined) => {
+  if ((a ?? null) === (b ?? null)) {
+    return true
+  }
+  if (!a || !b) {
+    return false
+  }
+  const setA = new Set(a.split(',').map((t) => t.trim()))
+  const setB = new Set(b.split(',').map((t) => t.trim()))
+  return setA.size === setB.size && [...setA].every((t) => setB.has(t))
+}
+
+export const isEmissionFactorUnchanged = (
+  existing: EFWithMetaData,
+  row: ImportEmissionFactor,
+  parts: ImportEmissionFactor[],
+): boolean => {
+  // Simulate what cleanImport would store: if parts exist, gas values are summed from parts
+  let gases: ReturnType<typeof getGases>
+  if (parts.length > 0) {
+    const partGases = parts.map(getGases)
+    gases = {
+      totalCo2: partGases.reduce((s, p) => s + p.totalCo2, 0),
+      co2f: partGases.reduce((s, p) => s + p.co2f, 0),
+      ch4f: partGases.reduce((s, p) => s + p.ch4f, 0),
+      ch4b: partGases.reduce((s, p) => s + p.ch4b, 0),
+      n2o: partGases.reduce((s, p) => s + p.n2o, 0),
+      co2b: partGases.reduce((s, p) => s + p.co2b, 0),
+      sf6: partGases.reduce((s, p) => s + p.sf6, 0),
+      hfc: partGases.reduce((s, p) => s + p.hfc, 0),
+      pfc: partGases.reduce((s, p) => s + p.pfc, 0),
+      otherGES: partGases.reduce((s, p) => s + p.otherGES, 0),
+    }
+  } else {
+    gases = getGases(row)
+  }
+
+  const frMeta = existing.metaData.find((m) => m.language === 'fr')
+  const enMeta = existing.metaData.find((m) => m.language === 'en')
+
+  const checks = {
+    totalCo2: eqFloat(existing.totalCo2, gases.totalCo2),
+    co2f: eqFloat(existing.co2f, gases.co2f),
+    ch4f: eqFloat(existing.ch4f, gases.ch4f),
+    ch4b: eqFloat(existing.ch4b, gases.ch4b),
+    n2o: eqFloat(existing.n2o, gases.n2o),
+    co2b: eqFloat(existing.co2b, gases.co2b),
+    sf6: eqFloat(existing.sf6, gases.sf6),
+    hfc: eqFloat(existing.hfc, gases.hfc),
+    pfc: eqFloat(existing.pfc, gases.pfc),
+    otherGES: eqFloat(existing.otherGES, gases.otherGES),
+    status:
+      existing.status ===
+      (row["Statut_de_l'élément"] === 'Archivé' ? EmissionFactorStatus.Archived : EmissionFactorStatus.Valid),
+    unit: existing.unit === getUnit(row.Unité_français),
+    source: eqImportStr(existing.source, row.Source),
+    location: eqImportStr(existing.location, row.Localisation_géographique),
+    frTitle: eqImportStr(frMeta?.title, row.Nom_base_français),
+    frAttribute: eqImportStr(frMeta?.attribute, row.Nom_attribut_français),
+    frFrontiere: eqImportStr(frMeta?.frontiere, row.Nom_frontière_français),
+    frTag: eqImportTags(frMeta?.tag, row.Tags_français),
+    frLocation: eqImportStr(frMeta?.location, row['Sous-localisation_géographique_français']),
+    frComment: eqImportStr(frMeta?.comment, row.Commentaire_français),
+    enTitle: eqImportStr(enMeta?.title, row.Nom_base_anglais),
+    enAttribute: eqImportStr(enMeta?.attribute, row.Nom_attribut_anglais),
+    enFrontiere: eqImportStr(enMeta?.frontiere, row.Nom_frontière_anglais),
+    enTag: eqImportTags(enMeta?.tag, row.Tags_anglais),
+    enLocation: eqImportStr(enMeta?.location, row['Sous-localisation_géographique_anglais']),
+    enComment: eqImportStr(enMeta?.comment, row.Commentaire_anglais),
+  }
+
+  const failed = Object.entries(checks)
+    .filter(([, ok]) => !ok)
+    .map(([key]) => key)
+
+  return failed.length === 0
 }
 
 export type ImportEmissionFactor = {
@@ -75,48 +360,76 @@ export type ImportEmissionFactor = {
 }
 
 export const requiredColumns = [
-  "Identifiant_de_l'élément",
-  "Statut_de_l'élément",
   'Type_Ligne',
+  "Identifiant_de_l'élément",
+  'Structure',
+  "Type_de_l'élément",
+  "Statut_de_l'élément",
+  'Nom_base_français',
+  'Nom_base_anglais',
+  'Nom_base_espagnol',
+  'Nom_attribut_français',
+  'Nom_attribut_anglais',
+  'Nom_attribut_espagnol',
+  'Nom_frontière_français',
+  'Nom_frontière_anglais',
+  'Nom_frontière_espagnol',
+  'Code_de_la_catégorie',
+  'Tags_français',
+  'Tags_anglais',
+  'Tags_espagnol',
+  'Unité_français',
+  'Unité_anglais',
+  'Unité_espagnol',
+  'Contributeur',
+  'Autres_Contributeurs',
+  'Programme',
+  'Url_du_programme',
   'Source',
-  'Type_poste',
   'Localisation_géographique',
   'Sous-localisation_géographique_français',
   'Sous-localisation_géographique_anglais',
-  'Commentaire_français',
-  'Commentaire_anglais',
-  'Nom_poste_français',
-  'Nom_poste_anglais',
-  'Unité_français',
-  'Unité_anglais',
-  'Tags_français',
-  'Tags_anglais',
-  'Nom_attribut_français',
-  'Nom_attribut_anglais',
-  'Nom_base_français',
-  'Nom_base_anglais',
-  'Nom_frontière_français',
-  'Nom_frontière_anglais',
-  'Total_poste_non_décomposé',
-  'CO2b',
-  'CH4f',
-  'CH4b',
-  'Autres_GES',
-  'N2O',
-  'CO2f',
+  'Sous-localisation_géographique_espagnol',
+  'Date_de_création',
+  'Date_de_modification',
+  'Période_de_validité',
   'Incertitude',
+  'Réglementations',
+  'Transparence',
   'Qualité',
   'Qualité_TeR',
   'Qualité_GR',
   'Qualité_TiR',
   'Qualité_C',
+  'Qualité_P',
+  'Qualité_M',
+  'Commentaire_français',
+  'Commentaire_anglais',
+  'Commentaire_espagnol',
+  'Type_poste',
+  'Nom_poste_français',
+  'Nom_poste_anglais',
+  'Nom_poste_espagnol',
+  'Total_poste_non_décomposé',
+  'CO2f',
+  'CH4f',
+  'CH4b',
+  'N2O',
   'Code_gaz_supplémentaire_1',
   'Valeur_gaz_supplémentaire_1',
   'Code_gaz_supplémentaire_2',
   'Valeur_gaz_supplémentaire_2',
+  'Code_gaz_supplémentaire_3',
+  'Valeur_gaz_supplémentaire_3',
+  'Code_gaz_supplémentaire_4',
+  'Valeur_gaz_supplémentaire_4',
+  'Code_gaz_supplémentaire_5',
+  'Valeur_gaz_supplémentaire_5',
+  'Autres_GES',
+  'CO2b',
 ]
 
-const escapeTranslation = (value?: string) => (value ? value.replaceAll('"""', '') : value)
+const escapeTranslation = (value?: string) => (value ? String(value).replaceAll('"""', '') : value)
 
 const getUnit = (value?: string): Unit | null => {
   if (!value) {
@@ -161,47 +474,18 @@ const getUnit = (value?: string): Unit | null => {
   return unitsMatrix[value]
 }
 
-const getType = (value: string) => {
-  switch (value) {
-    case 'Carburant (amont/combustion)':
-      return EmissionFactorPartType.CarburantAmontCombustion
-    case 'Amont':
-      return EmissionFactorPartType.Amont
-    case 'Intrants':
-      return EmissionFactorPartType.Intrants
-    case 'Combustion':
-      return EmissionFactorPartType.Combustion
-    case 'Transport et distribution':
-      return EmissionFactorPartType.TransportEtDistribution
-    case 'Energie':
-      return EmissionFactorPartType.Energie
-    case 'Fabrication':
-      return EmissionFactorPartType.Fabrication
-    case 'Traitement':
-      return EmissionFactorPartType.Traitement
-    case 'Collecte':
-      return EmissionFactorPartType.Collecte
-    case 'Autre':
-      return EmissionFactorPartType.Autre
-    case 'Amortissement':
-      return EmissionFactorPartType.Amortissement
-    case 'Incinération':
-      return EmissionFactorPartType.Incineration
-    case 'Emissions fugitives':
-      return EmissionFactorPartType.EmissionsFugitives
-    case 'Fuites':
-      return EmissionFactorPartType.Fuites
-    case 'Transport':
-      return EmissionFactorPartType.Transport
-    case 'Combustion à la centrale':
-      return EmissionFactorPartType.CombustionALaCentrale
-    case 'Pertes':
-      return EmissionFactorPartType.Pertes
-    case 'Autres émissions liées à la consommation d?électricité (barrage?)':
-      return EmissionFactorPartType.AutresEmissionsLieesALaConsommationDElectriciteBarrage
-    default:
-      throw new Error(`Emission factor type not found: ${value}`)
+const LABEL_TO_PART_TYPE = Object.fromEntries(
+  Object.entries(PART_TYPE_LABELS).map(([type, label]) => [label, type as EmissionFactorPartType]),
+) as Record<string, EmissionFactorPartType>
+
+const getType = (value: string): EmissionFactorPartType => {
+  // Special case: CSV uses '?' for accented characters in this label
+  const normalized = value.replace('d?électricité', "d'électricité")
+  const type = LABEL_TO_PART_TYPE[normalized]
+  if (!type) {
+    throw new Error(`Emission factor type not found: ${value}`)
   }
+  return type
 }
 
 export const getEmissionQuality = (uncertainty?: number) => {
@@ -260,7 +544,6 @@ const getGases = (emissionFactor: ImportEmissionFactor) => {
 export const mapEmissionFactors = (
   emissionFactor: ImportEmissionFactor,
   importedFrom: Import,
-  versionId: string,
   getSubPost: (emissionFactor: ImportEmissionFactor) => SubPost[],
 ) => ({
   ...getGases(emissionFactor),
@@ -270,7 +553,6 @@ export const mapEmissionFactors = (
   status:
     emissionFactor["Statut_de_l'élément"] === 'Archivé' ? EmissionFactorStatus.Archived : EmissionFactorStatus.Valid,
   source: emissionFactor.Source,
-  versionId,
   location: emissionFactor.Localisation_géographique,
   technicalRepresentativeness: emissionFactor.Qualité_TeR || getEmissionQuality(emissionFactor.Incertitude),
   geographicRepresentativeness: emissionFactor.Qualité_GR || getEmissionQuality(emissionFactor.Incertitude),
@@ -309,29 +591,19 @@ export const mapEmissionFactors = (
 
 export const saveEmissionFactorsParts = async (
   transaction: Prisma.TransactionClient,
-  importVersionId: string,
+  importedIdToEfId: Map<string, string>,
   parts: ImportEmissionFactor[],
 ) => {
-  const emissionFactors = await transaction.emissionFactor.findMany({
-    where: {
-      importedId: {
-        in: parts.map((part) => part["Identifiant_de_l'élément"]),
-      },
-      versionId: importVersionId,
-    },
-  })
-
   for (const i in parts) {
     if (Number(i) % 100 === 0) {
       console.log(`${i}/${parts.length}`)
     }
     const part = parts[i]
-    const emissionFactor = emissionFactors.find(
-      (emissionFactor) => emissionFactor.importedId === part["Identifiant_de_l'élément"],
-    )
-    if (!emissionFactor) {
+    const emissionFactorId = importedIdToEfId.get(part["Identifiant_de_l'élément"])
+    if (!emissionFactorId) {
       throw new Error('No emission factor found for ' + part["Identifiant_de_l'élément"])
     }
+    const emissionFactor = { id: emissionFactorId }
 
     const metaData = []
     if (part.Nom_poste_français) {
@@ -352,10 +624,10 @@ export const saveEmissionFactorsParts = async (
   }
 }
 
-export const cleanImport = async (transaction: Prisma.TransactionClient, versionId: string) => {
+export const cleanImport = async (transaction: Prisma.TransactionClient, newEmissionFactorIds: string[]) => {
   console.log('Clean emission factors sums')
   const emissionFactors = await transaction.emissionFactor.findMany({
-    where: { versionId },
+    where: { id: { in: newEmissionFactorIds } },
     include: { emissionFactorParts: true },
   })
 

--- a/apps/bilan-carbone/src/services/importEmissionFactor/legifrance/getEmissionFactors.ts
+++ b/apps/bilan-carbone/src/services/importEmissionFactor/legifrance/getEmissionFactors.ts
@@ -16,10 +16,8 @@ const getSubPostsFunc = (emissionFactor: ImportEmissionFactor) => () => {
   return subPostByNetworkType[emissionFactor.reseau]
 }
 
-const mapLegifranceEmissionFactors = (emissionFactor: ImportEmissionFactor, versionId: string) =>
-  mapEmissionFactors(emissionFactor, Import.Legifrance, versionId, getSubPostsFunc(emissionFactor))
+const mapLegifranceEmissionFactors = (emissionFactor: ImportEmissionFactor) =>
+  mapEmissionFactors(emissionFactor, Import.Legifrance, getSubPostsFunc(emissionFactor))
 
 export const getEmissionFactorsFromCSV = async (name: string, file: string) =>
-  getEmissionFactors(name, file, Import.Legifrance, (emissionFactor: ImportEmissionFactor, versionId: string) =>
-    mapLegifranceEmissionFactors(emissionFactor, versionId),
-  )
+  getEmissionFactors(name, file, Import.Legifrance, mapLegifranceEmissionFactors)

--- a/apps/bilan-carbone/src/services/importEmissionFactor/negaOctet/getEmissionFactors.ts
+++ b/apps/bilan-carbone/src/services/importEmissionFactor/negaOctet/getEmissionFactors.ts
@@ -4,8 +4,8 @@ import { ImportEmissionFactor, mapEmissionFactors } from '../import'
 
 const getSubPostsFunc = () => [SubPost.UsagesNumeriques]
 
-const mapNegaOctetEmissionFactors = (emissionFactor: ImportEmissionFactor, versionId: string) =>
-  mapEmissionFactors(emissionFactor, Import.NegaOctet, versionId, getSubPostsFunc)
+const mapNegaOctetEmissionFactors = (emissionFactor: ImportEmissionFactor) =>
+  mapEmissionFactors(emissionFactor, Import.NegaOctet, getSubPostsFunc)
 
 export const getEmissionFactorsFromCSV = async (name: string, file: string) =>
   getEmissionFactors(name, file, Import.NegaOctet, mapNegaOctetEmissionFactors)

--- a/apps/bilan-carbone/src/services/importEmissionFactor/parseXlsx.ts
+++ b/apps/bilan-carbone/src/services/importEmissionFactor/parseXlsx.ts
@@ -1,0 +1,39 @@
+import * as XLSX from 'xlsx'
+import { ImportEmissionFactor, numberColumns, validStatuses } from './import'
+
+const parseNumber = (value: unknown): number => {
+  if (typeof value === 'number') {
+    return value
+  }
+  if (typeof value === 'string') {
+    return Number(value.replace(',', '.'))
+  }
+  return 0
+}
+
+export const parseSheetRows = (sheet: XLSX.WorkSheet): ImportEmissionFactor[] => {
+  const raw = XLSX.utils.sheet_to_json<Record<string, unknown>>(sheet, { defval: undefined })
+  return raw
+    .map((row) => {
+      const normalizedRow: Record<string, unknown> = {}
+      for (const [key, value] of Object.entries(row)) {
+        const normalizedKey = key.trim().replaceAll(' ', '_')
+        normalizedRow[normalizedKey] =
+          value === '' ? undefined : normalizedKey === "Identifiant_de_l'élément" ? String(value) : value
+      }
+      return normalizedRow
+    })
+    .filter((row) => {
+      const status = row["Statut_de_l'élément"] as string | undefined
+      return status && validStatuses.includes(status)
+    })
+    .map((row) => {
+      const xlsxNumberFields = [...numberColumns, 'Incertitude'] as string[]
+      for (const field of xlsxNumberFields) {
+        if (row[field] !== undefined) {
+          row[field] = parseNumber(row[field])
+        }
+      }
+      return row as unknown as ImportEmissionFactor
+    })
+}

--- a/apps/bilan-carbone/src/services/importEmissionFactor/parseXlsx.ts
+++ b/apps/bilan-carbone/src/services/importEmissionFactor/parseXlsx.ts
@@ -1,6 +1,8 @@
 import * as XLSX from 'xlsx'
 import { ImportEmissionFactor, numberColumns, validStatuses } from './import'
 
+const xlsxNumberFields = [...numberColumns, 'Incertitude'] as string[]
+
 const parseNumber = (value: unknown): number => {
   if (typeof value === 'number') {
     return value
@@ -28,7 +30,6 @@ export const parseSheetRows = (sheet: XLSX.WorkSheet): ImportEmissionFactor[] =>
       return status && validStatuses.includes(status)
     })
     .map((row) => {
-      const xlsxNumberFields = [...numberColumns, 'Incertitude'] as string[]
       for (const field of xlsxNumberFields) {
         if (row[field] !== undefined) {
           row[field] = parseNumber(row[field])

--- a/apps/bilan-carbone/src/services/serverFunctions/emissionFactor.ts
+++ b/apps/bilan-carbone/src/services/serverFunctions/emissionFactor.ts
@@ -17,6 +17,7 @@ import {
   getManualEmissionFactors,
   setEmissionFactorUnitAsCustom,
   updateEmissionFactor,
+  type EmissionFactorList,
 } from '@/db/emissionFactors'
 import { getOrganizationVersionByOrganizationIdAndEnvironment, getOrgVersionWithOrgId } from '@/db/organization'
 import { getStudyOrganizationVersion } from '@/db/study'
@@ -131,8 +132,8 @@ export const getEmissionFactorsByIds = async (ids: string[], studyId: string) =>
           ...emissionFactor,
           metaData: emissionFactor.metaData.find((metadata) => metadata.language === locale),
         }))
-        .filter((emissionFactor) => emissionFactor.metaData)
-        .sort((a, b) => sortAlphabetically(a?.metaData?.title, b?.metaData?.title))
+        .filter((emissionFactor) => !!emissionFactor.metaData)
+        .sort((a, b) => sortAlphabetically(a?.metaData?.title, b?.metaData?.title)) as unknown as EmissionFactorList[]
     } catch {
       return []
     }

--- a/apps/bilan-carbone/src/services/serverFunctions/emissionFactor.ts
+++ b/apps/bilan-carbone/src/services/serverFunctions/emissionFactor.ts
@@ -50,13 +50,13 @@ export const getFELocations = async () => {
         subPosts: { isEmpty: false },
         OR: [
           { organizationId: session.user.organizationId },
-          { AND: [{ versionId: { not: null }, version: { source: { not: Import.CUT } } }] },
+          { AND: [{ versions: { some: { importVersion: { source: { not: Import.CUT } } } } }] },
         ],
       },
     },
     distinct: ['location'],
     select: { location: true },
-  }) as Promise<{ location: string }[]>
+  })
 }
 export const getEmissionFactors = async (
   skip: number,
@@ -132,7 +132,7 @@ export const getEmissionFactorsByIds = async (ids: string[], studyId: string) =>
           metaData: emissionFactor.metaData.find((metadata) => metadata.language === locale),
         }))
         .filter((emissionFactor) => emissionFactor.metaData)
-        .sort((a, b) => sortAlphabetically(a?.metaData?.title, b?.metaData?.title)) as EmissionFactorWithMetaData[]
+        .sort((a, b) => sortAlphabetically(a?.metaData?.title, b?.metaData?.title))
     } catch {
       return []
     }
@@ -224,7 +224,7 @@ export const createEmissionFactorCommand = async ({
         importedFrom: Import.Manual,
         status: EmissionFactorStatus.Valid,
         organization: { connect: { id: account.organizationVersion?.organizationId } },
-        unit: unit as Unit,
+        unit,
         subPosts: flattenSubposts(subPosts),
         metaData: { create: { language: local, title: name, attribute, comment } },
       },

--- a/apps/bilan-carbone/src/services/serverFunctions/emissionSource.ts
+++ b/apps/bilan-carbone/src/services/serverFunctions/emissionSource.ts
@@ -60,10 +60,11 @@ export const createEmissionSource = async ({
     ])
 
     if (
-      emissionFactor?.version?.id &&
-      !study?.emissionFactorVersions
-        .map((emissionFactorVersion) => emissionFactorVersion.importVersionId)
-        .includes(emissionFactor.version.id)
+      emissionFactor &&
+      emissionFactor.versions.length > 0 &&
+      !emissionFactor.versions.some((v) =>
+        study?.emissionFactorVersions.map((sv) => sv.importVersionId).includes(v.importVersionId),
+      )
     ) {
       throw new Error(NOT_AUTHORIZED)
     }
@@ -113,10 +114,11 @@ export const updateEmissionSource = async ({
     }
 
     if (
-      emissionFactor?.version?.id &&
-      !study.emissionFactorVersions
-        .map((emissionFactorVersion) => emissionFactorVersion.importVersionId)
-        .includes(emissionFactor.version.id)
+      emissionFactor &&
+      emissionFactor.versions.length > 0 &&
+      !emissionFactor.versions.some((v) =>
+        study.emissionFactorVersions.map((sv) => sv.importVersionId).includes(v.importVersionId),
+      )
     ) {
       throw new Error(NOT_AUTHORIZED)
     }

--- a/apps/bilan-carbone/src/tests/utils/models/emissionSource.ts
+++ b/apps/bilan-carbone/src/tests/utils/models/emissionSource.ts
@@ -65,9 +65,12 @@ export const getMockedFullStudyEmissionSource = (
     isMonetary: false,
     location: '',
     customUnit: null,
-    version: {
-      id: 'version-id',
-    },
+    versions: [
+      {
+        importVersionId: 'mocked-import-version-id',
+        importVersion: { id: 'mocked-import-version-id', name: 'test', source: Import.BaseEmpreinte, archived: false },
+      },
+    ],
     metaData: [
       {
         language: 'fr',

--- a/apps/bilan-carbone/src/tests/utils/models/emissionSource.ts
+++ b/apps/bilan-carbone/src/tests/utils/models/emissionSource.ts
@@ -79,6 +79,7 @@ export const getMockedFullStudyEmissionSource = (
         title: 'Mocked Emission Factor',
         attribute: 'Mocked Attribute',
         comment: 'Mocked Comment',
+        tag: null,
       },
     ],
     emissionFactorParts: [],

--- a/apps/bilan-carbone/src/tests/utils/models/study.ts
+++ b/apps/bilan-carbone/src/tests/utils/models/study.ts
@@ -167,6 +167,7 @@ export const mockedEmissionSourceEmissionFactor = {
       title: 'Mocked Emission Factor',
       attribute: 'Mocked Attribute',
       comment: 'Mocked Comment',
+      tag: null,
     },
   ],
   emissionFactorParts: [],

--- a/apps/bilan-carbone/src/tests/utils/models/study.ts
+++ b/apps/bilan-carbone/src/tests/utils/models/study.ts
@@ -153,9 +153,12 @@ export const mockedEmissionSourceEmissionFactor = {
   isMonetary: false,
   location: '',
   customUnit: null,
-  version: {
-    id: 'version-id',
-  },
+  versions: [
+    {
+      importVersionId: TEST_IDS.importVersion,
+      importVersion: { id: TEST_IDS.importVersion, name: 'test', source: Import.BaseEmpreinte, archived: false },
+    },
+  ],
   metaData: [
     {
       language: 'fr',

--- a/apps/bilan-carbone/tsconfig.json
+++ b/apps/bilan-carbone/tsconfig.json
@@ -2,6 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "tsBuildInfoFile": ".next/cache/tsbuildinfo.json",
+    "ignoreDeprecations": "5.0", // Necessary for Cypress using downlevelIteration which is deprecated
+    "types": ["cypress", "node"],
     "plugins": [
       {
         "name": "next"

--- a/apps/bilan-carbone/tsconfig.json
+++ b/apps/bilan-carbone/tsconfig.json
@@ -25,6 +25,6 @@
       "module": "commonjs"
     }
   },
-  "include": ["next-env.d.ts", ".next/types/**/*.ts", "src/**/*.ts", "src/**/*.tsx", "cypress/**/*.ts", "**/*.cy.ts"],
+  "include": ["next-env.d.ts", ".next/types/**/*.ts", "src/**/*.ts", "src/**/*.tsx", "cypress/**/*.ts", "**/*.cy.ts", "prisma/**/*.ts"],
   "exclude": ["node_modules", "publicodes-packages"]
 }

--- a/apps/bilan-carbone/tsconfig.json
+++ b/apps/bilan-carbone/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "tsBuildInfoFile": ".next/cache/tsbuildinfo.json",
-    "ignoreDeprecations": "5.0", // Necessary for Cypress using downlevelIteration which is deprecated
     "types": ["cypress", "node"],
     "plugins": [
       {

--- a/apps/bilan-carbone/tsconfig.json
+++ b/apps/bilan-carbone/tsconfig.json
@@ -25,6 +25,14 @@
       "module": "commonjs"
     }
   },
-  "include": ["next-env.d.ts", ".next/types/**/*.ts", "src/**/*.ts", "src/**/*.tsx", "cypress/**/*.ts", "**/*.cy.ts", "prisma/**/*.ts"],
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "cypress/**/*.ts",
+    "**/*.cy.ts",
+    "prisma/**/*.ts"
+  ],
   "exclude": ["node_modules", "publicodes-packages"]
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "ts": "turbo run ts",
     "lint": "turbo run lint",
     "format": "turbo run format",
-    "prisma": "yarn workspace @repo/db-common run prisma"
+    "prisma": "yarn workspace @abc-transitionbascarbone/db-common run prisma"
   },
   "devDependencies": {
     "turbo": "^2.9.6"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test": "turbo run test",
     "ts": "turbo run ts",
     "lint": "turbo run lint",
-    "format": "turbo run format"
+    "format": "turbo run format",
+    "prisma": "yarn workspace @repo/db-common run prisma"
   },
   "devDependencies": {
     "turbo": "^2.9.6"

--- a/packages/db-common/package.json
+++ b/packages/db-common/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "db:migrate": "prisma migrate dev",
     "db:generate": "prisma generate",
-    "db:status": "prisma migrate status"
+    "db:status": "prisma migrate status",
+    "prisma": "prisma"
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.8.0",

--- a/packages/db-common/prisma/schema/bilan-carbone/emissionFactor.prisma
+++ b/packages/db-common/prisma/schema/bilan-carbone/emissionFactor.prisma
@@ -241,95 +241,6 @@ model EmissionFactorImportVersion {
   @@schema("bilan_carbone")
 }
 
-// Used to store manual overrides for an EmissionFactor.
-// This override is applied to all versions of the EmissionFactor.
-model EmissionFactorOverride {
-  id               String         @id @default(uuid())
-  emissionFactorId String         @unique @map("emission_factor_id")
-  emissionFactor   EmissionFactor @relation(fields: [emissionFactorId], references: [id])
-
-  totalCo2   Float    @map("total_co2")
-  co2f       Float?
-  ch4f       Float?
-  ch4b       Float?
-  n2o        Float?
-  co2b       Float?
-  sf6        Float?
-  hfc        Float?
-  pfc        Float?
-  otherGES   Float?   @map("other_ges")
-  unit       Unit?
-  status     EmissionFactorStatus?
-  source     String?
-  location   String?
-
-  parts    EmissionFactorOverridePart[]
-  metaData EmissionFactorOverrideMetaData[]
-
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
-
-  @@map("emission_factor_overrides")
-  @@schema("bilan_carbone")
-}
-
-model EmissionFactorOverrideMetaData {
-  overrideId String                @map("override_id")
-  override   EmissionFactorOverride @relation(fields: [overrideId], references: [id], onDelete: Cascade)
-  language   String
-
-  title     String?
-  attribute String?
-  frontiere String?
-  tag       String?
-  location  String?
-  comment   String?
-
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
-
-  @@id([overrideId, language])
-  @@map("emission_factor_override_metadata")
-  @@schema("bilan_carbone")
-}
-
-model EmissionFactorOverridePart {
-  id         String                @id @default(uuid())
-  overrideId String                @map("override_id")
-  override   EmissionFactorOverride @relation(fields: [overrideId], references: [id], onDelete: Cascade)
-  type       EmissionFactorPartType
-
-  totalCo2 Float  @map("total_co2")
-  co2f     Float?
-  ch4f     Float?
-  ch4b     Float?
-  n2o      Float?
-  co2b     Float?
-  sf6      Float?
-  hfc      Float?
-  pfc      Float?
-  otherGES Float? @map("other_ges")
-
-  metaData EmissionFactorOverridePartMetaData[]
-
-  @@map("emission_factor_override_parts")
-  @@schema("bilan_carbone")
-}
-
-model EmissionFactorOverridePartMetaData {
-  overridePartId String                      @map("override_part_id")
-  overridePart   EmissionFactorOverridePart  @relation(fields: [overridePartId], references: [id], onDelete: Cascade)
-  language       String
-  title          String
-
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
-
-  @@id([overridePartId, language])
-  @@map("emission_factor_override_part_metadata")
-  @@schema("bilan_carbone")
-}
-
 // Link table between EmissionFactor and EmissionFactorImportVersion
 model EmissionFactorVersion {
   emissionFactorId String         @map("emission_factor_id")
@@ -353,7 +264,6 @@ model EmissionFactor {
   oldBCId String? @map("old_bc_id")
 
   versions EmissionFactorVersion[]
-  override EmissionFactorOverride?
 
   importedFrom   Import        @map("imported_from")
   importedId     String?       @map("imported_id")
@@ -386,6 +296,9 @@ model EmissionFactor {
   unit       Unit?
   customUnit String?
   isMonetary Boolean @map("is_monetary")
+
+  importedRawCsv String? @map("imported_raw_csv")
+  overrideRawCsv String? @map("override_raw_csv")
 
   subPosts            SubPost[]             @map("sub_posts")
   studyEmissionSource StudyEmissionSource[]
@@ -439,6 +352,9 @@ model EmissionFactorPart {
   hfc      Float?
   pfc      Float?
   otherGES Float? @map("other_ges")
+
+  importedRawCsv String? @map("imported_raw_csv")
+  overrideRawCsv String? @map("override_raw_csv")
 
   @@map("emission_factor_parts")
   @@schema("bilan_carbone")

--- a/packages/db-common/prisma/schema/bilan-carbone/emissionFactor.prisma
+++ b/packages/db-common/prisma/schema/bilan-carbone/emissionFactor.prisma
@@ -224,12 +224,11 @@ enum EmissionFactorBase {
 }
 
 model EmissionFactorImportVersion {
-  id       String @id @default(uuid())
-  internId String @map("intern_id")
-  source   Import
-  name     String
+  id     String @id @default(uuid())
+  source Import
+  name   String // Version like 23.7
 
-  emissionFactors             EmissionFactor[]
+  emissionFactorVersions      EmissionFactorVersion[]
   studyEmissionFactorVersions StudyEmissionFactorVersion[]
 
   archived Boolean @default(false)
@@ -237,8 +236,111 @@ model EmissionFactorImportVersion {
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
 
-  @@unique([source, internId])
+  @@unique([source, name])
   @@map("emission_factor_import_version")
+  @@schema("bilan_carbone")
+}
+
+// Used to store manual overrides for an EmissionFactor.
+// This override is applied to all versions of the EmissionFactor.
+model EmissionFactorOverride {
+  id               String         @id @default(uuid())
+  emissionFactorId String         @unique @map("emission_factor_id")
+  emissionFactor   EmissionFactor @relation(fields: [emissionFactorId], references: [id])
+
+  totalCo2   Float    @map("total_co2")
+  co2f       Float?
+  ch4f       Float?
+  ch4b       Float?
+  n2o        Float?
+  co2b       Float?
+  sf6        Float?
+  hfc        Float?
+  pfc        Float?
+  otherGES   Float?   @map("other_ges")
+  unit       Unit?
+  status     EmissionFactorStatus?
+  source     String?
+  location   String?
+
+  parts    EmissionFactorOverridePart[]
+  metaData EmissionFactorOverrideMetaData[]
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
+
+  @@map("emission_factor_overrides")
+  @@schema("bilan_carbone")
+}
+
+model EmissionFactorOverrideMetaData {
+  overrideId String                @map("override_id")
+  override   EmissionFactorOverride @relation(fields: [overrideId], references: [id], onDelete: Cascade)
+  language   String
+
+  title     String?
+  attribute String?
+  frontiere String?
+  tag       String?
+  location  String?
+  comment   String?
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
+
+  @@id([overrideId, language])
+  @@map("emission_factor_override_metadata")
+  @@schema("bilan_carbone")
+}
+
+model EmissionFactorOverridePart {
+  id         String                @id @default(uuid())
+  overrideId String                @map("override_id")
+  override   EmissionFactorOverride @relation(fields: [overrideId], references: [id], onDelete: Cascade)
+  type       EmissionFactorPartType
+
+  totalCo2 Float  @map("total_co2")
+  co2f     Float?
+  ch4f     Float?
+  ch4b     Float?
+  n2o      Float?
+  co2b     Float?
+  sf6      Float?
+  hfc      Float?
+  pfc      Float?
+  otherGES Float? @map("other_ges")
+
+  metaData EmissionFactorOverridePartMetaData[]
+
+  @@map("emission_factor_override_parts")
+  @@schema("bilan_carbone")
+}
+
+model EmissionFactorOverridePartMetaData {
+  overridePartId String                      @map("override_part_id")
+  overridePart   EmissionFactorOverridePart  @relation(fields: [overridePartId], references: [id], onDelete: Cascade)
+  language       String
+  title          String
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
+
+  @@id([overridePartId, language])
+  @@map("emission_factor_override_part_metadata")
+  @@schema("bilan_carbone")
+}
+
+// Link table between EmissionFactor and EmissionFactorImportVersion
+model EmissionFactorVersion {
+  emissionFactorId String         @map("emission_factor_id")
+  emissionFactor   EmissionFactor @relation(fields: [emissionFactorId], references: [id])
+  importVersionId  String         @map("import_version_id")
+  importVersion    EmissionFactorImportVersion @relation(fields: [importVersionId], references: [id])
+  createdAt        DateTime       @default(now()) @map("created_at")
+
+  @@id([emissionFactorId, importVersionId])
+  @@index([importVersionId])
+  @@map("emission_factor_versions")
   @@schema("bilan_carbone")
 }
 
@@ -250,8 +352,8 @@ model EmissionFactor {
 
   oldBCId String? @map("old_bc_id")
 
-  versionId String?                      @map("version_id")
-  version   EmissionFactorImportVersion? @relation(fields: [versionId], references: [id])
+  versions EmissionFactorVersion[]
+  override EmissionFactorOverride?
 
   importedFrom   Import        @map("imported_from")
   importedId     String?       @map("imported_id")

--- a/packages/db-common/prisma/schema/migrations/20260420132037_emission_factor_versioning_and_override/migration.sql
+++ b/packages/db-common/prisma/schema/migrations/20260420132037_emission_factor_versioning_and_override/migration.sql
@@ -1,0 +1,149 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `version_id` on the `emission_factors` table.
+    Data is migrated to the new emission_factor_versions join table before the column is dropped.
+
+*/
+
+-- CreateTable (before dropping version_id so we can migrate the data)
+CREATE TABLE "bilan_carbone"."emission_factor_versions" (
+    "emission_factor_id" TEXT NOT NULL,
+    "import_version_id" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "emission_factor_versions_pkey" PRIMARY KEY ("emission_factor_id","import_version_id")
+);
+
+-- CreateIndex
+CREATE INDEX "emission_factor_versions_import_version_id_idx" ON "bilan_carbone"."emission_factor_versions"("import_version_id");
+
+-- AddForeignKey
+ALTER TABLE "bilan_carbone"."emission_factor_versions" ADD CONSTRAINT "emission_factor_versions_emission_factor_id_fkey" FOREIGN KEY ("emission_factor_id") REFERENCES "bilan_carbone"."emission_factors"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "bilan_carbone"."emission_factor_versions" ADD CONSTRAINT "emission_factor_versions_import_version_id_fkey" FOREIGN KEY ("import_version_id") REFERENCES "bilan_carbone"."emission_factor_import_version"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Migrate existing data: populate join table from version_id column before dropping it
+INSERT INTO "bilan_carbone"."emission_factor_versions" ("emission_factor_id", "import_version_id", "created_at")
+SELECT "id", "version_id", "created_at"
+FROM "bilan_carbone"."emission_factors"
+WHERE "version_id" IS NOT NULL;
+
+-- DropForeignKey
+ALTER TABLE "bilan_carbone"."emission_factors" DROP CONSTRAINT "emission_factors_version_id_fkey";
+
+-- AlterTable
+ALTER TABLE "bilan_carbone"."emission_factors" DROP COLUMN "version_id";
+
+-- CreateTable
+CREATE TABLE "bilan_carbone"."emission_factor_overrides" (
+    "id" TEXT NOT NULL,
+    "emission_factor_id" TEXT NOT NULL,
+    "total_co2" DOUBLE PRECISION NOT NULL,
+    "co2f" DOUBLE PRECISION,
+    "ch4f" DOUBLE PRECISION,
+    "ch4b" DOUBLE PRECISION,
+    "n2o" DOUBLE PRECISION,
+    "co2b" DOUBLE PRECISION,
+    "sf6" DOUBLE PRECISION,
+    "hfc" DOUBLE PRECISION,
+    "pfc" DOUBLE PRECISION,
+    "other_ges" DOUBLE PRECISION,
+    "unit" "common"."Unit",
+    "status" "bilan_carbone"."EmissionFactorStatus",
+    "source" TEXT,
+    "location" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "emission_factor_overrides_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "bilan_carbone"."emission_factor_override_metadata" (
+    "override_id" TEXT NOT NULL,
+    "language" TEXT NOT NULL,
+    "title" TEXT,
+    "attribute" TEXT,
+    "frontiere" TEXT,
+    "tag" TEXT,
+    "location" TEXT,
+    "comment" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "emission_factor_override_metadata_pkey" PRIMARY KEY ("override_id","language")
+);
+
+-- CreateTable
+CREATE TABLE "bilan_carbone"."emission_factor_override_parts" (
+    "id" TEXT NOT NULL,
+    "override_id" TEXT NOT NULL,
+    "type" "bilan_carbone"."EmissionFactorPartType" NOT NULL,
+    "total_co2" DOUBLE PRECISION NOT NULL,
+    "co2f" DOUBLE PRECISION,
+    "ch4f" DOUBLE PRECISION,
+    "ch4b" DOUBLE PRECISION,
+    "n2o" DOUBLE PRECISION,
+    "co2b" DOUBLE PRECISION,
+    "sf6" DOUBLE PRECISION,
+    "hfc" DOUBLE PRECISION,
+    "pfc" DOUBLE PRECISION,
+    "other_ges" DOUBLE PRECISION,
+
+    CONSTRAINT "emission_factor_override_parts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "emission_factor_overrides_emission_factor_id_key" ON "bilan_carbone"."emission_factor_overrides"("emission_factor_id");
+
+-- AddForeignKey
+ALTER TABLE "bilan_carbone"."emission_factor_overrides" ADD CONSTRAINT "emission_factor_overrides_emission_factor_id_fkey" FOREIGN KEY ("emission_factor_id") REFERENCES "bilan_carbone"."emission_factors"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "bilan_carbone"."emission_factor_override_metadata" ADD CONSTRAINT "emission_factor_override_metadata_override_id_fkey" FOREIGN KEY ("override_id") REFERENCES "bilan_carbone"."emission_factor_overrides"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "bilan_carbone"."emission_factor_override_parts" ADD CONSTRAINT "emission_factor_override_parts_override_id_fkey" FOREIGN KEY ("override_id") REFERENCES "bilan_carbone"."emission_factor_overrides"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- DropIndex
+DROP INDEX "bilan_carbone"."emission_factor_import_version_source_intern_id_key";
+
+-- AlterTable
+ALTER TABLE "bilan_carbone"."emission_factor_import_version" DROP COLUMN "intern_id";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "emission_factor_import_version_source_name_key" ON "bilan_carbone"."emission_factor_import_version"("source", "name");
+
+-- CreateTable
+CREATE TABLE "bilan_carbone"."emission_factor_override_part_metadata" (
+    "override_part_id" TEXT NOT NULL,
+    "language" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "emission_factor_override_part_metadata_pkey" PRIMARY KEY ("override_part_id","language")
+);
+
+-- AddForeignKey
+ALTER TABLE "bilan_carbone"."emission_factor_override_part_metadata" ADD CONSTRAINT "emission_factor_override_part_metadata_override_part_id_fkey" FOREIGN KEY ("override_part_id") REFERENCES "bilan_carbone"."emission_factor_override_parts"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- DropForeignKey
+ALTER TABLE "bilan_carbone"."emission_factor_override_metadata" DROP CONSTRAINT "emission_factor_override_metadata_override_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "bilan_carbone"."emission_factor_override_part_metadata" DROP CONSTRAINT "emission_factor_override_part_metadata_override_part_id_fkey";
+
+-- DropForeignKey
+ALTER TABLE "bilan_carbone"."emission_factor_override_parts" DROP CONSTRAINT "emission_factor_override_parts_override_id_fkey";
+
+-- AddForeignKey
+ALTER TABLE "bilan_carbone"."emission_factor_override_metadata" ADD CONSTRAINT "emission_factor_override_metadata_override_id_fkey" FOREIGN KEY ("override_id") REFERENCES "bilan_carbone"."emission_factor_overrides"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "bilan_carbone"."emission_factor_override_parts" ADD CONSTRAINT "emission_factor_override_parts_override_id_fkey" FOREIGN KEY ("override_id") REFERENCES "bilan_carbone"."emission_factor_overrides"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "bilan_carbone"."emission_factor_override_part_metadata" ADD CONSTRAINT "emission_factor_override_part_metadata_override_part_id_fkey" FOREIGN KEY ("override_part_id") REFERENCES "bilan_carbone"."emission_factor_override_parts"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db-common/prisma/schema/migrations/20260420132037_emission_factor_versioning_and_override/migration.sql
+++ b/packages/db-common/prisma/schema/migrations/20260420132037_emission_factor_versioning_and_override/migration.sql
@@ -4,6 +4,8 @@
   - You are about to drop the column `version_id` on the `emission_factors` table.
     Data is migrated to the new emission_factor_versions join table before the column is dropped.
 
+  - You are about to drop the column `intern_id` on the `emission_factor_import_version` table.
+
 */
 
 -- CreateTable (before dropping version_id so we can migrate the data)
@@ -33,79 +35,11 @@ WHERE "version_id" IS NOT NULL;
 -- DropForeignKey
 ALTER TABLE "bilan_carbone"."emission_factors" DROP CONSTRAINT "emission_factors_version_id_fkey";
 
--- AlterTable
-ALTER TABLE "bilan_carbone"."emission_factors" DROP COLUMN "version_id";
-
--- CreateTable
-CREATE TABLE "bilan_carbone"."emission_factor_overrides" (
-    "id" TEXT NOT NULL,
-    "emission_factor_id" TEXT NOT NULL,
-    "total_co2" DOUBLE PRECISION NOT NULL,
-    "co2f" DOUBLE PRECISION,
-    "ch4f" DOUBLE PRECISION,
-    "ch4b" DOUBLE PRECISION,
-    "n2o" DOUBLE PRECISION,
-    "co2b" DOUBLE PRECISION,
-    "sf6" DOUBLE PRECISION,
-    "hfc" DOUBLE PRECISION,
-    "pfc" DOUBLE PRECISION,
-    "other_ges" DOUBLE PRECISION,
-    "unit" "common"."Unit",
-    "status" "bilan_carbone"."EmissionFactorStatus",
-    "source" TEXT,
-    "location" TEXT,
-    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-
-    CONSTRAINT "emission_factor_overrides_pkey" PRIMARY KEY ("id")
-);
-
--- CreateTable
-CREATE TABLE "bilan_carbone"."emission_factor_override_metadata" (
-    "override_id" TEXT NOT NULL,
-    "language" TEXT NOT NULL,
-    "title" TEXT,
-    "attribute" TEXT,
-    "frontiere" TEXT,
-    "tag" TEXT,
-    "location" TEXT,
-    "comment" TEXT,
-    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-
-    CONSTRAINT "emission_factor_override_metadata_pkey" PRIMARY KEY ("override_id","language")
-);
-
--- CreateTable
-CREATE TABLE "bilan_carbone"."emission_factor_override_parts" (
-    "id" TEXT NOT NULL,
-    "override_id" TEXT NOT NULL,
-    "type" "bilan_carbone"."EmissionFactorPartType" NOT NULL,
-    "total_co2" DOUBLE PRECISION NOT NULL,
-    "co2f" DOUBLE PRECISION,
-    "ch4f" DOUBLE PRECISION,
-    "ch4b" DOUBLE PRECISION,
-    "n2o" DOUBLE PRECISION,
-    "co2b" DOUBLE PRECISION,
-    "sf6" DOUBLE PRECISION,
-    "hfc" DOUBLE PRECISION,
-    "pfc" DOUBLE PRECISION,
-    "other_ges" DOUBLE PRECISION,
-
-    CONSTRAINT "emission_factor_override_parts_pkey" PRIMARY KEY ("id")
-);
-
--- CreateIndex
-CREATE UNIQUE INDEX "emission_factor_overrides_emission_factor_id_key" ON "bilan_carbone"."emission_factor_overrides"("emission_factor_id");
-
--- AddForeignKey
-ALTER TABLE "bilan_carbone"."emission_factor_overrides" ADD CONSTRAINT "emission_factor_overrides_emission_factor_id_fkey" FOREIGN KEY ("emission_factor_id") REFERENCES "bilan_carbone"."emission_factors"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "bilan_carbone"."emission_factor_override_metadata" ADD CONSTRAINT "emission_factor_override_metadata_override_id_fkey" FOREIGN KEY ("override_id") REFERENCES "bilan_carbone"."emission_factor_overrides"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "bilan_carbone"."emission_factor_override_parts" ADD CONSTRAINT "emission_factor_override_parts_override_id_fkey" FOREIGN KEY ("override_id") REFERENCES "bilan_carbone"."emission_factor_overrides"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+-- AlterTable: drop version_id, add raw CSV fields
+ALTER TABLE "bilan_carbone"."emission_factors"
+  DROP COLUMN "version_id",
+  ADD COLUMN "imported_raw_csv" TEXT,
+  ADD COLUMN "override_raw_csv" TEXT;
 
 -- DropIndex
 DROP INDEX "bilan_carbone"."emission_factor_import_version_source_intern_id_key";
@@ -115,35 +49,3 @@ ALTER TABLE "bilan_carbone"."emission_factor_import_version" DROP COLUMN "intern
 
 -- CreateIndex
 CREATE UNIQUE INDEX "emission_factor_import_version_source_name_key" ON "bilan_carbone"."emission_factor_import_version"("source", "name");
-
--- CreateTable
-CREATE TABLE "bilan_carbone"."emission_factor_override_part_metadata" (
-    "override_part_id" TEXT NOT NULL,
-    "language" TEXT NOT NULL,
-    "title" TEXT NOT NULL,
-    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "updated_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
-
-    CONSTRAINT "emission_factor_override_part_metadata_pkey" PRIMARY KEY ("override_part_id","language")
-);
-
--- AddForeignKey
-ALTER TABLE "bilan_carbone"."emission_factor_override_part_metadata" ADD CONSTRAINT "emission_factor_override_part_metadata_override_part_id_fkey" FOREIGN KEY ("override_part_id") REFERENCES "bilan_carbone"."emission_factor_override_parts"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
-
--- DropForeignKey
-ALTER TABLE "bilan_carbone"."emission_factor_override_metadata" DROP CONSTRAINT "emission_factor_override_metadata_override_id_fkey";
-
--- DropForeignKey
-ALTER TABLE "bilan_carbone"."emission_factor_override_part_metadata" DROP CONSTRAINT "emission_factor_override_part_metadata_override_part_id_fkey";
-
--- DropForeignKey
-ALTER TABLE "bilan_carbone"."emission_factor_override_parts" DROP CONSTRAINT "emission_factor_override_parts_override_id_fkey";
-
--- AddForeignKey
-ALTER TABLE "bilan_carbone"."emission_factor_override_metadata" ADD CONSTRAINT "emission_factor_override_metadata_override_id_fkey" FOREIGN KEY ("override_id") REFERENCES "bilan_carbone"."emission_factor_overrides"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "bilan_carbone"."emission_factor_override_parts" ADD CONSTRAINT "emission_factor_override_parts_override_id_fkey" FOREIGN KEY ("override_id") REFERENCES "bilan_carbone"."emission_factor_overrides"("id") ON DELETE CASCADE ON UPDATE CASCADE;
-
--- AddForeignKey
-ALTER TABLE "bilan_carbone"."emission_factor_override_part_metadata" ADD CONSTRAINT "emission_factor_override_part_metadata_override_part_id_fkey" FOREIGN KEY ("override_part_id") REFERENCES "bilan_carbone"."emission_factor_override_parts"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db-common/prisma/schema/migrations/20260427000000_emission_factor_part_raw_csv/migration.sql
+++ b/packages/db-common/prisma/schema/migrations/20260427000000_emission_factor_part_raw_csv/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "bilan_carbone"."emission_factor_parts"
+  ADD COLUMN "imported_raw_csv" TEXT,
+  ADD COLUMN "override_raw_csv" TEXT;

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,8 +13,7 @@
     "jsx": "react-jsx",
     "target": "ES2017",
     "incremental": true,
-    "ignoreDeprecations": "6.0", // Necessary for Cypress using downlevelIteration which is deprecated
-    "types": ["cypress", "node"],
+    "types": ["node"],
     "paths": {
       "@abc-transitionbascarbone/db-common": ["packages/db-common/src/index.ts"],
       "@abc-transitionbascarbone/db-common/enums": ["packages/db-common/src/enums.ts"],

--- a/turbo.json
+++ b/turbo.json
@@ -12,6 +12,9 @@
     },
     "ts": {},
     "lint": {},
+    "prisma": {
+      "cache": false
+    },
     "format": {
       "cache": false
     },


### PR DESCRIPTION
Nouvel ajout : Deux champs `importedRawCsv` et `overrideRawCsv` sont ajoutés aux facteurs d'émission et à leurs postes pour tracer les changements par rapport à l'import original.

### Tests

- [X] J'ai bien testé ma PR sur tous les environnements concernés
- [X] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
