### PR TITLE
2782 bug subobjectives on default trajectory

### DIFF
--- a/apps/bilan-carbone/src/components/study/trajectory/ObjectivesExpandedRow.tsx
+++ b/apps/bilan-carbone/src/components/study/trajectory/ObjectivesExpandedRow.tsx
@@ -217,7 +217,9 @@ const ObjectivesExpandedRow = ({
             <Button variant="outlined" onClick={onAddObjective}>
               {t('table.addSubObjective')}
             </Button>
-          ) : null}
+          ) : (
+            <Typography variant="body2">{t('table.noSubObjectives')}</Typography>
+          )}
         </div>
       )}
     </div>

--- a/apps/bilan-carbone/src/components/study/trajectory/ObjectivesExpandedRow.tsx
+++ b/apps/bilan-carbone/src/components/study/trajectory/ObjectivesExpandedRow.tsx
@@ -203,21 +203,23 @@ const ObjectivesExpandedRow = ({
           title={t('table.defaultObjectives')}
         />
       )}
-      <div className="flex flex-col gapped-2">
-        <div className="flex align-end justify-between">
-          <Typography variant="body1" color="text.secondary">
-            {t('table.subObjectives')}
-          </Typography>
-          {canEdit && subObjectives.length > 0 && <TableActionButton type="add" onClick={onAddObjective} />}
+      {!isDefaultSnbc && (
+        <div className="flex flex-col gapped-2">
+          <div className="flex align-end justify-between">
+            <Typography variant="body1" color="text.secondary">
+              {t('table.subObjectives')}
+            </Typography>
+            {canEdit && subObjectives.length > 0 && <TableActionButton type="add" onClick={onAddObjective} />}
+          </div>
+          {subObjectives.length > 0 ? (
+            <ObjectivesInnerTable rows={subObjectiveRows} canEdit={canEdit} isDefaultSnbc={isDefaultSnbc} />
+          ) : canEdit ? (
+            <Button variant="outlined" onClick={onAddObjective}>
+              {t('table.addSubObjective')}
+            </Button>
+          ) : null}
         </div>
-        {subObjectives.length > 0 ? (
-          <ObjectivesInnerTable rows={subObjectiveRows} canEdit={canEdit} isDefaultSnbc={isDefaultSnbc} />
-        ) : (
-          <Button variant="outlined" onClick={onAddObjective}>
-            {t('table.addSubObjective')}
-          </Button>
-        )}
-      </div>
+      )}
     </div>
   )
 }

--- a/apps/bilan-carbone/src/components/study/transitionPlan/SectorAllocationBlock.tsx
+++ b/apps/bilan-carbone/src/components/study/transitionPlan/SectorAllocationBlock.tsx
@@ -124,6 +124,7 @@ const SectorAllocationBlock = ({
       nextButtonLabel={isActive ? tCommon('action.confirm') : tBlock('update')}
       nextButtonLoading={loading}
       nextButtonDisabled={isOverLimit}
+      showNextButton={canEdit}
     >
       <div className="flex-col gapped1">
         <Typography variant="body1">{customRich(tBlock, 'description')}</Typography>

--- a/apps/bilan-carbone/src/i18n/translations/en/bc.json
+++ b/apps/bilan-carbone/src/i18n/translations/en/bc.json
@@ -1312,7 +1312,8 @@
           "period": "Period",
           "defaultObjectives": "Default objectives",
           "subObjectives": "Sub-objectives",
-          "addSubObjective": "Add sub-objective"
+          "addSubObjective": "Add sub-objective",
+          "noSubObjectives": "No sub-objectives yet"
         },
         "cancel": "Cancel",
         "deleteTrajectory": {

--- a/apps/bilan-carbone/src/i18n/translations/fr/bc.json
+++ b/apps/bilan-carbone/src/i18n/translations/fr/bc.json
@@ -1312,7 +1312,8 @@
           "period": "Période",
           "defaultObjectives": "Objectifs par défaut",
           "subObjectives": "Sous-objectifs",
-          "addSubObjective": "Ajouter un sous-objectif"
+          "addSubObjective": "Ajouter un sous-objectif",
+          "noSubObjectives": "Aucun sous-objectif pour le moment"
         },
         "cancel": "Annuler",
         "deleteTrajectory": {


### PR DESCRIPTION
- Cacher le bouton d'ajout de sous objectif sur a trajectoire par défaut et si canEdit false, ajotu 'dun texte à la place si pas de sous objectifs à montrer
- Ajout d'un mini fix en plus pour cacher le bouton de sauvegarde des pourcentages sectoriels (page initialisation) en mode lecteur.

### Tests

- [X] J'ai bien testé ma PR sur tous les environnements concernés
- [X] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
