### PR TITLE
2787 bug no rate change with subobjective

### DIFF
--- a/apps/bilan-carbone/src/components/pages/TrajectoryPage.tsx
+++ b/apps/bilan-carbone/src/components/pages/TrajectoryPage.tsx
@@ -106,6 +106,7 @@ const TrajectoryPage = ({
         filteredTrajectories,
         selectedSiteIds,
         objectiveGroupsByTrajectoryId,
+        hasFilters,
       }) => (
         <>
           <div className="flex-col gapped1">
@@ -128,6 +129,7 @@ const TrajectoryPage = ({
               tagFamilies={study.tagFamilies}
               defaultSnbcSectoralTrajectoryId={defaultSnbcSectoralTrajectoryId}
               objectiveGroupsByTrajectoryId={objectiveGroupsByTrajectoryId}
+              hasFilters={hasFilters}
             />
           </div>
 

--- a/apps/bilan-carbone/src/components/study/trajectory/ObjectivesExpandedRow.tsx
+++ b/apps/bilan-carbone/src/components/study/trajectory/ObjectivesExpandedRow.tsx
@@ -29,6 +29,7 @@ interface Props {
   onEditObjective: (objective: ObjectiveWithScope) => void
   onDeleteObjective: (id: string, name: string) => void
   onEditTrajectory: () => void
+  hasFilters?: boolean
 }
 
 const ObjectivesExpandedRow = ({
@@ -43,6 +44,7 @@ const ObjectivesExpandedRow = ({
   onEditObjective,
   onDeleteObjective,
   onEditTrajectory,
+  hasFilters = false,
 }: Props) => {
   const t = useTranslations('study.transitionPlan.objectives')
   const tCommon = useTranslations('common')
@@ -194,6 +196,7 @@ const ObjectivesExpandedRow = ({
           canEdit={canEdit}
           isDefaultSnbc={isDefaultSnbc}
           title={t('table.defaultObjectives')}
+          hasFilters={hasFilters}
         />
       )}
       {!isDefaultSnbc && (
@@ -205,7 +208,12 @@ const ObjectivesExpandedRow = ({
             {canEdit && subObjectives.length > 0 && <TableActionButton type="add" onClick={onAddObjective} />}
           </div>
           {subObjectives.length > 0 ? (
-            <ObjectivesInnerTable rows={subObjectiveRows} canEdit={canEdit} isDefaultSnbc={isDefaultSnbc} />
+            <ObjectivesInnerTable
+              rows={subObjectiveRows}
+              canEdit={canEdit}
+              isDefaultSnbc={isDefaultSnbc}
+              hasFilters={hasFilters}
+            />
           ) : canEdit ? (
             <Button variant="outlined" onClick={onAddObjective}>
               {t('table.addSubObjective')}

--- a/apps/bilan-carbone/src/components/study/trajectory/ObjectivesInnerTable.tsx
+++ b/apps/bilan-carbone/src/components/study/trajectory/ObjectivesInnerTable.tsx
@@ -29,9 +29,10 @@ interface Props {
   canEdit: boolean
   isDefaultSnbc: boolean
   title?: string
+  hasFilters?: boolean
 }
 
-const ObjectivesInnerTable = ({ rows, canEdit, isDefaultSnbc, title }: Props) => {
+const ObjectivesInnerTable = ({ rows, canEdit, isDefaultSnbc, title, hasFilters = false }: Props) => {
   const t = useTranslations('study.transitionPlan.objectives')
   const tDocumentation = useTranslations('documentationUrl')
   const locale = useLocale()
@@ -49,7 +50,7 @@ const ObjectivesInnerTable = ({ rows, canEdit, isDefaultSnbc, title }: Props) =>
       {
         header: () => (
           <div className="flex align-center gapped025">
-            {t('table.rates')}
+            {`${t('table.rates')}${hasFilters ? ` ${t('table.ratesWithFilters')}` : ''}`}
             <GlossaryIconModal
               title="table.ratesGlossary.title"
               label="reduction-rates"
@@ -87,7 +88,7 @@ const ObjectivesInnerTable = ({ rows, canEdit, isDefaultSnbc, title }: Props) =>
     }
 
     return cols
-  }, [t, tCommon, canEdit, tDocumentation, locale])
+  }, [t, tCommon, canEdit, tDocumentation, locale, hasFilters])
 
   const table = useReactTable({
     columns,

--- a/apps/bilan-carbone/src/components/study/trajectory/ObjectivesTable.tsx
+++ b/apps/bilan-carbone/src/components/study/trajectory/ObjectivesTable.tsx
@@ -446,6 +446,7 @@ const ObjectivesTable = ({
                 onEditObjective={(objective) => handleEditObjectiveClick(objective, rowData.trajectory)}
                 onDeleteObjective={(id, name) => handleDeleteClick('objective', id, name)}
                 onEditTrajectory={() => handleEditClick(rowData.trajectory)}
+                hasFilters={hasFilters}
               />
             </TableCell>
           </TableRow>

--- a/apps/bilan-carbone/src/components/study/trajectory/ObjectivesTable.tsx
+++ b/apps/bilan-carbone/src/components/study/trajectory/ObjectivesTable.tsx
@@ -80,6 +80,7 @@ interface Props {
   }>
   defaultSnbcSectoralTrajectoryId?: string | null
   objectiveGroupsByTrajectoryId: Map<string, ObjectiveGroup[]>
+  hasFilters?: boolean
 }
 
 const fuseOptions = {
@@ -102,6 +103,7 @@ const ObjectivesTable = ({
   tagFamilies = [],
   defaultSnbcSectoralTrajectoryId,
   objectiveGroupsByTrajectoryId,
+  hasFilters = false,
 }: Props) => {
   const locale = useLocale()
   const tAction = useTranslations('common.action')
@@ -307,7 +309,7 @@ const ObjectivesTable = ({
         id: 'rates',
         header: () => (
           <div className="flex align-center gapped025">
-            {t('table.rates')}
+            {`${t('table.rates')}${hasFilters ? ` ${t('table.ratesWithFilters')}` : ''}`}
             <GlossaryIconModal
               title="table.ratesGlossary.title"
               label="reduction-rates"
@@ -363,7 +365,7 @@ const ObjectivesTable = ({
         },
       },
     ]
-  }, [t, defaultSnbcSectoralTrajectoryId, canEdit]) as ColumnDef<TrajectoryRow>[]
+  }, [t, tDocumentation, locale, defaultSnbcSectoralTrajectoryId, canEdit, hasFilters]) as ColumnDef<TrajectoryRow>[]
 
   const tableData = useMemo((): TrajectoryRow[] => {
     const filteredTrajectories = searchFilter ? fuse.search(searchFilter).map(({ item }) => item) : trajectories

--- a/apps/bilan-carbone/src/components/study/transitionPlan/TransitionPlanBase.tsx
+++ b/apps/bilan-carbone/src/components/study/transitionPlan/TransitionPlanBase.tsx
@@ -5,6 +5,7 @@ import Breadcrumbs from '@/components/breadcrumbs/Breadcrumbs'
 import type { FullStudy } from '@/db/study'
 import { useTransitionPlan } from '@/hooks/useTransitionPlan'
 import { useTransitionPlanFilters } from '@/hooks/useTransitionPlanFilters'
+import { environmentSubPostsMapping } from '@/services/posts'
 import type {
   ActionWithRelations,
   ObjectiveGroup,
@@ -30,6 +31,7 @@ export interface TransitionPlanBaseChildProps {
   selectedSubPosts: SubPost[]
   selectedTagIds: string[]
   objectiveGroupsByTrajectoryId: Map<string, ObjectiveGroup[]>
+  hasFilters: boolean
 }
 
 interface Props {
@@ -82,6 +84,27 @@ const TransitionPlanBase = ({
   } = useTransitionPlanFilters(study.id)
 
   const allTagIds = useMemo(() => study.tagFamilies.flatMap((f) => f.tags.map((tag) => tag.id)), [study.tagFamilies])
+
+  const hasFilters = useMemo(() => {
+    const allSiteIds = study.sites.map((s) => s.site.id)
+    const envSubPostsByPost = environmentSubPostsMapping[study.organizationVersion.environment]
+    const allEnvSubPosts = Array.from(new Set(Object.values(envSubPostsByPost).flat()))
+    const allTagIdsWithOther = study.tagFamilies.some((f) => f.name !== 'DEFAULT_FAMILY_TAG')
+      ? [...allTagIds, 'other']
+      : allTagIds
+    const sitesFiltered = allSiteIds.length > 0 && selectedSiteIds.length < allSiteIds.length
+    const subPostsFiltered = allEnvSubPosts.length > 0 && selectedSubPosts.length < allEnvSubPosts.length
+    const tagsFiltered = allTagIdsWithOther.length > 0 && selectedTagIds.length < allTagIdsWithOther.length
+    return sitesFiltered || subPostsFiltered || tagsFiltered
+  }, [
+    study.sites,
+    study.organizationVersion.environment,
+    study.tagFamilies,
+    allTagIds,
+    selectedSiteIds,
+    selectedSubPosts,
+    selectedTagIds,
+  ])
 
   const { filteredStudyEmissions, filteredPastStudies } = useTransitionPlan({
     study,
@@ -236,6 +259,7 @@ const TransitionPlanBase = ({
             selectedSubPosts,
             selectedTagIds,
             objectiveGroupsByTrajectoryId,
+            hasFilters,
           })}
         </div>
       </Block>

--- a/apps/bilan-carbone/src/i18n/translations/en/bc.json
+++ b/apps/bilan-carbone/src/i18n/translations/en/bc.json
@@ -1289,6 +1289,7 @@
           "startYear": "Start year",
           "targetYear": "Target year",
           "rates": "Annual reduction: reference / adjusted",
+          "ratesWithFilters": "(with filters)",
           "ratesGlossary": {
             "title": "Baseline reduction rate and adjusted reduction rate",
             "description": "The rates shown here are always calculated between the base year and the target year. The first rate is set when the pathway is created (or calculated based on the various rates defined at that time), while the second corresponds to the annual reduction you must achieve today to stay on track while <b>maintaining the <link>carbon budget</link> initially allocated to you</b>. <br></br> If only one rate is shown, this means that you are currently aligned with the corresponding pathway and that you are in line with the carbon budget that you were initially allocated."

--- a/apps/bilan-carbone/src/i18n/translations/fr/bc.json
+++ b/apps/bilan-carbone/src/i18n/translations/fr/bc.json
@@ -1289,6 +1289,7 @@
           "startYear": "Année de départ",
           "targetYear": "Année cible",
           "rates": "Taux de réduction annuel : référence/corrigé",
+          "ratesWithFilters": "(avec filtres)",
           "ratesGlossary": {
             "title": "Taux de réduction de référence et taux de réduction corrigé",
             "description": "Les taux affichés ici sont toujours calculés entre l'année de référence et l'année cible. Le premier taux est définit lors de la création de la trajectoire (ou calculé à partir des différents taux définis à la création), tandis que le second correspond à la réduction annuelle que vous devez aujourd'hui suivre pour respecter cette trajectoire tout en <b>conservant le <link>budget carbone</link> qui vous était initialement alloué</b>. <br></br> Si un seul taux est présent, cela signifie que vous êtes pour le moment aligné avec la trajectoire correspondante et que vous respectez le budget carbone qui vous est alloué."

--- a/apps/bilan-carbone/src/utils/customTrajectory.utils.ts
+++ b/apps/bilan-carbone/src/utils/customTrajectory.utils.ts
@@ -37,40 +37,6 @@ interface CalculateCustomTrajectoryParams {
 }
 
 /**
- * Extracts effective objectives (one per breakpoint year) from pre-computed trajectory data points.
- * Computes the average reduction rate per segment so the result can be fed
- * into getObjectivesWithOvershootCompensation.
- */
-const extractEffectiveObjectives = (
-  studyEmissions: number,
-  studyStartYear: number,
-  breakpointYears: number[],
-  dataPoints: TrajectoryDataPoint[],
-): BaseObjective[] => {
-  const getEmissionsAtYear = (year: number): number => {
-    if (year === studyStartYear) {
-      return studyEmissions
-    }
-    return dataPoints.find((p) => p.year === year)?.value ?? studyEmissions
-  }
-
-  const effectiveObjectives: BaseObjective[] = []
-  let prevYear = studyStartYear
-
-  for (const year of breakpointYears) {
-    if (year <= studyStartYear) {
-      continue
-    }
-    const prevEmissions = getEmissionsAtYear(prevYear)
-    const currentEmissions = getEmissionsAtYear(year)
-    const years = year - prevYear
-    const rate = years > 0 && prevEmissions > 0 ? (prevEmissions - currentEmissions) / prevEmissions / years : 0
-    effectiveObjectives.push({ targetYear: year, reductionRate: Math.max(0, rate) })
-    prevYear = year
-  }
-
-  return effectiveObjectives
-} /**
  * Build the custom trajectory without reference until study start year using past studies and the study data
  * Then pick the desired reference value at the target year
  */
@@ -226,44 +192,40 @@ export const calculateCustomTrajectory = ({
   addHistoricalDataAndStudyPoint(dataPoints, pastStudies, studyEmissions, studyStartYear, minYear)
 
   if (objectiveGroups && objectiveGroups.length > 0) {
-    const scopeDataPoints = calculateObjectiveGroupTrajectory(
-      studyEmissions,
-      studyStartYear,
-      objectiveGroups,
-      maxYear ?? 0,
-    )
-
     if (!overshootAdjustment) {
+      const scopeDataPoints = calculateObjectiveGroupTrajectory(
+        studyEmissions,
+        studyStartYear,
+        objectiveGroups,
+        maxYear ?? 0,
+      )
       dataPoints.push(...scopeDataPoints)
       return dataPoints
     }
 
-    const breakpointYears = [...new Set(objectiveGroups.flatMap((g) => g.objectives.map((o) => o.targetYear)))].sort(
-      (a, b) => a - b,
-    )
-    const effectiveObjectives = extractEffectiveObjectives(
+    // Apply overshoot compensation per group independently
+    const compensatedGroups: ObjectiveGroup[] = objectiveGroups.map((group) => {
+      const groupReferenceTrajectory = overshootAdjustment.referenceTrajectory.map((p) => ({
+        year: p.year,
+        value: p.value * group.ratio,
+      }))
+      const correctedObjectives = getObjectivesWithOvershootCompensation(
+        studyEmissions * group.ratio,
+        studyStartYear,
+        group.objectives,
+        { ...overshootAdjustment, referenceTrajectory: groupReferenceTrajectory },
+        pastStudies,
+      )
+      return { ratio: group.ratio, objectives: correctedObjectives }
+    })
+
+    const compensatedDataPoints = calculateObjectiveGroupTrajectory(
       studyEmissions,
       studyStartYear,
-      breakpointYears,
-      scopeDataPoints,
+      compensatedGroups,
+      maxYear ?? 0,
     )
-    const sortedObjectives = getObjectivesWithOvershootCompensation(
-      actualEmissions,
-      studyStartYear,
-      effectiveObjectives,
-      overshootAdjustment,
-      pastStudies,
-    )
-
-    for (const objective of sortedObjectives) {
-      const yearlyReduction = actualEmissions * Number(objective.reductionRate)
-      for (let year = startYear + 1; year <= objective.targetYear; year++) {
-        actualEmissions = Math.max(0, actualEmissions - yearlyReduction)
-        dataPoints.push({ year, value: actualEmissions })
-      }
-      startYear = objective.targetYear
-    }
-
+    dataPoints.push(...compensatedDataPoints)
     return dataPoints
   }
 

--- a/apps/bilan-carbone/src/utils/trajectory.test.ts
+++ b/apps/bilan-carbone/src/utils/trajectory.test.ts
@@ -9,7 +9,12 @@ import { calculateSBTiTrajectory, getDefaultSBTIReductionRate } from './sbti'
 import { createGeneralSectenData } from './secten.test-utils'
 import { calculateSNBCTrajectory } from './snbc'
 import { calculateTrajectoryYearBounds } from './trajectory'
-import { calculateTrajectoryIntegral, getTrajectoryEmissionsAtYear, isWithinThreshold } from './trajectory-shared.utils'
+import {
+  calculateTrajectoryIntegral,
+  getTrajectoryEmissionsAtYear,
+  isFailedTrajectory,
+  isWithinThreshold,
+} from './trajectory-shared.utils'
 
 // TODO: ESM module issue with Jest. Remove these mocks when moving to Vitest
 jest.mock('../services/file', () => ({ download: jest.fn() }))
@@ -791,6 +796,56 @@ describe('calculateTrajectory', () => {
       // At 2050: non-energy also reaches 0 (900 - 20*45 = 0)
       const point2050 = result.find((p) => p.year === 2050)
       expect(point2050?.value).toBeCloseTo(0, 1)
+    })
+
+    test('overshoot + groups: aggressive sub-objective does not produce false isFailed', () => {
+      const studyEmissions = 1000
+      const studyStartYear = 2025
+      const referenceYear = 2020
+      const referenceEmissions = 1000
+
+      const objectiveGroups = [
+        {
+          ratio: 0.3,
+          objectives: [
+            { targetYear: 2030, reductionRate: 0.042 },
+            { targetYear: 2050, reductionRate: 0.2 }, // aggressive sub-objective, compensation still doable
+          ],
+        },
+        {
+          ratio: 0.7,
+          objectives: [
+            { targetYear: 2030, reductionRate: 0.042 },
+            { targetYear: 2050, reductionRate: 0.042 },
+          ],
+        },
+      ]
+
+      // Reference trajectory: built from referenceYear with same groups
+      const referenceTrajectory = calculateCustomTrajectory({
+        studyEmissions: referenceEmissions,
+        studyStartYear: referenceYear,
+        objectives: [{ targetYear: 2035, reductionRate: 0.05 }],
+        objectiveGroups,
+        defaultTrajectory: DEFAULT_TRAJECTORY,
+      })
+
+      const referenceAt2024 = referenceTrajectory.find((p) => p.year === studyStartYear)?.value ?? 0
+      // Actual emissions (1000) exceed reference at study year → overshoot scenario
+      expect(studyEmissions).toBeGreaterThan(referenceAt2024)
+
+      const currentTrajectory = calculateCustomTrajectory({
+        studyEmissions,
+        studyStartYear,
+        objectives: [{ targetYear: 2035, reductionRate: 0.05 }],
+        objectiveGroups,
+        overshootAdjustment: { referenceTrajectory, referenceStudyYear: referenceYear },
+        defaultTrajectory: DEFAULT_TRAJECTORY,
+      })
+
+      // Current trajectory must not exceed reference budget (isFailed must be false).
+      const isFailed = isFailedTrajectory(2050, referenceYear, referenceTrajectory, currentTrajectory, false)
+      expect(isFailed).toBe(false)
     })
   })
 


### PR DESCRIPTION
Je ne suis pas sûr d'avoir résolu le problème de Gabriel mais dans mes tests j'arrive bien à modifier le taux global en modifiant le taux d'un sous objectif. 
- Par contre j'ai résolu un bug (peut-être lié) qui mettait en erreur les trajectoires avec des sous objectifs trop agressifs. 
- J'ai aussi ajouté la mention "avec filtres" dans la table des objectifs quand des filtres changent les taux de réduction en préparation de ce ticket : https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/2809

### Tests

- [X] J'ai bien testé ma PR sur tous les environnements concernés
- [X] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [X] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
