### PR TITLE
Fix contribution

### DIFF
--- a/apps/bilan-carbone/src/components/auth/SignUpFormTilt.tsx
+++ b/apps/bilan-carbone/src/components/auth/SignUpFormTilt.tsx
@@ -31,13 +31,6 @@ const SignUpFormTilt = () => {
 
   const searchParams = useSearchParams()
 
-  useEffect(() => {
-    const email = searchParams.get('email')
-    if (email) {
-      setValue('email', email)
-    }
-  }, [searchParams])
-
   const { control, getValues, setValue, handleSubmit } = useForm<SignUpTiltCommand>({
     resolver: zodResolver(SignUpTiltCommandValidation),
     mode: 'onBlur',
@@ -46,6 +39,13 @@ const SignUpFormTilt = () => {
       email: searchParams.get('email') ?? '',
     },
   })
+
+  useEffect(() => {
+    const email = searchParams.get('email')
+    if (email) {
+      setValue('email', email)
+    }
+  }, [searchParams, setValue])
 
   const onSubmit = async () => {
     setMessage('')

--- a/apps/bilan-carbone/src/components/study/StudiesContainer.tsx
+++ b/apps/bilan-carbone/src/components/study/StudiesContainer.tsx
@@ -92,7 +92,7 @@ const StudiesContainer = async ({ user, organizationVersionId, isCR, simplified 
   } else {
     displaySimplifiedStudies = await isTiltSimplifiedFeatureActive(user.environment)
     if (!displaySimplifiedStudies) {
-      hasStudies = advancedStudies.length > 0
+      hasStudies = advancedStudies.length > 0 || collaborationStudies.length > 0
     }
   }
 

--- a/apps/bilan-carbone/src/services/permissions/environment.ts
+++ b/apps/bilan-carbone/src/services/permissions/environment.ts
@@ -8,7 +8,7 @@ const simplifiedEnvironments: Environment[] = [CUT, CLICKSON]
 export const isAdvanced = (environment: Environment) => advancedEnvironments.includes(environment)
 export const isSimplified = (environment: Environment) => simplifiedEnvironments.includes(environment)
 
-const isBC = (environment: Environment) => environment === BC
+export const isBC = (environment: Environment) => environment === BC
 export const isTilt = (environment: Environment) => environment === TILT
 export const isCut = (environment: Environment) => environment === CUT
 export const isClickson = (environment: Environment) => environment === CLICKSON

--- a/apps/bilan-carbone/src/services/serverFunctions/user.ts
+++ b/apps/bilan-carbone/src/services/serverFunctions/user.ts
@@ -90,7 +90,7 @@ import {
   UNKNOWN_SCHOOL,
   UNKNOWN_SIRET_OR_CNC,
 } from '../permissions/check'
-import { isTilt } from '../permissions/environment'
+import { isBC, isTilt } from '../permissions/environment'
 import { canAddMember, canChangeRole, canDeleteMember, canEditSelfRole } from '../permissions/user'
 import { establishmentTypeMap, School } from '../schoolApi'
 import { getDeactivableFeatureRestrictions } from './deactivableFeatures'
@@ -342,9 +342,9 @@ export const resetPassword = async (email: string, userEnv: Environment | undefi
     }
   })
 
-export const activateEmail = async (email: string, userEnv: Environment | undefined, fromReset: boolean = false) =>
+export const activateEmail = async (email: string, userEnv: Environment, fromReset: boolean = false) =>
   withServerResponse('activateEmail', async () => {
-    const env = userEnv || Environment.BC
+    const env = userEnv
 
     const user = await getUserByEmail(email.toLowerCase())
     const account = (await getAccountById(
@@ -672,7 +672,8 @@ export const signUpWithSiretOrCNC = async (email: string, siretOrCNC: string, en
       throw new Error(NOT_AUTHORIZED)
     }
 
-    const newOrganizationRole = isTilt(environment) ? Role.GESTIONNAIRE : Role.ADMIN
+    const newOrganizationRole =
+      isTilt(environment) || (isBC(environment) && !user.level) ? Role.GESTIONNAIRE : Role.ADMIN
     await updateAccount(account.id, {
       role: organization?.id ? Role.DEFAULT : newOrganizationRole,
       organizationVersion: { connect: { id: organizationVersion.id } },


### PR DESCRIPTION
PR liée au(x) ticket(s) : #2721 #2244 

Fait dans ce ticket : 
- Les utilisateurs TILT formé et dans une orga ont bien accès aux contributions
- Si l'utilisateur n'est pas formé (accueil simplifié) ou n'a pas d'asso alors il n'a pas accès à sa contribution. Je créé un ticket pour ces cas car je pense qu'il faudrait retravailler le parcours utilisateur. En attendant : on leur demande d'aller directement sur l'étude via le lien dans leur mail.


### Tests

- [x] J'ai bien testé ma PR sur tous les environnements concernés
- [ ] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés 
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
