### PR TITLE
2889 multi-choice fe during source import

### DIFF
--- a/apps/bilan-carbone/src/components/base/ImportFileModal/AmbiguousEmissionFactorList.tsx
+++ b/apps/bilan-carbone/src/components/base/ImportFileModal/AmbiguousEmissionFactorList.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { AmbiguousRow, FEChoices } from '@/types/import.types'
+import { FormControlLabel, Radio, RadioGroup, Typography } from '@mui/material'
+import classNames from 'classnames'
+import { useTranslations } from 'next-intl'
+import styles from './ImportFileModal.module.css'
+
+interface Props {
+  rows: AmbiguousRow[]
+  choices: FEChoices
+  onChange: (lineNumber: number, value: string | null) => void
+}
+
+const AmbiguousEmissionFactorList = ({ rows, choices, onChange }: Props) => {
+  const t = useTranslations('importFileModal')
+  const tCommon = useTranslations('common')
+
+  return (
+    <div className={classNames(styles.ambiguousWrapper, 'flex-col gapped1')}>
+      <Typography variant="body2" color="textSecondary">
+        {t('ambiguousTitle')}
+      </Typography>
+      {rows.map((row) => (
+        <div key={row.lineNumber} className={styles.ambiguousRow}>
+          <Typography variant="body2" fontWeight="medium">
+            {tCommon('label.line', { line: row.lineNumber })}
+            {row.sourceName ? ` — ${row.sourceName}` : ''}
+          </Typography>
+          {row.searchedName && (
+            <Typography variant="caption" color="textSecondary">
+              {t('ambiguousSearched', { name: row.searchedName })}
+            </Typography>
+          )}
+          {row.tooMany ? (
+            <Typography variant="body2">{t('ambiguousTooMany')}</Typography>
+          ) : (
+            <RadioGroup
+              value={choices[row.lineNumber] ?? 'null'}
+              onChange={(e) => onChange(row.lineNumber, e.target.value === 'null' ? null : e.target.value)}
+            >
+              {row.candidates.map((c) => (
+                <FormControlLabel
+                  key={c.id}
+                  value={c.id}
+                  control={<Radio size="small" />}
+                  label={
+                    <Typography variant="body2">
+                      {[c.foundTitle, c.foundValue !== undefined ? `${c.foundValue}` : undefined, c.foundUnit]
+                        .filter(Boolean)
+                        .join(' · ')}
+                    </Typography>
+                  }
+                />
+              ))}
+              <FormControlLabel
+                value="null"
+                control={<Radio size="small" />}
+                label={
+                  <Typography variant="body2" color="textSecondary">
+                    {t('leaveEmpty')}
+                  </Typography>
+                }
+              />
+            </RadioGroup>
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default AmbiguousEmissionFactorList

--- a/apps/bilan-carbone/src/components/base/ImportFileModal/ImportFileModal.module.css
+++ b/apps/bilan-carbone/src/components/base/ImportFileModal/ImportFileModal.module.css
@@ -71,3 +71,15 @@
   font-size: 0.9rem !important;
   flex-shrink: 0;
 }
+
+.ambiguousWrapper {
+  max-height: 28rem;
+  overflow-y: auto;
+}
+
+.ambiguousRow {
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--mui-palette-divider);
+  border-radius: 0.5rem;
+  background-color: var(--mui-palette-grey-50);
+}

--- a/apps/bilan-carbone/src/components/base/ImportFileModal/ImportFileModal.tsx
+++ b/apps/bilan-carbone/src/components/base/ImportFileModal/ImportFileModal.tsx
@@ -39,7 +39,7 @@ interface Props<TPreviewRow> {
     file: File,
     choices: FEChoices,
   ) => Promise<{ status: 'error'; errors: ImportError[] } | { status: 'ok'; rows: TPreviewRow[] }>
-  onConfirmImport: (file: File, choices?: FEChoices) => Promise<ImportResult>
+  onConfirmImport: (file: File, choices: FEChoices) => Promise<ImportResult>
   onDownloadTemplate: () => Promise<void>
   renderPreviewTable: (rows: TPreviewRow[]) => ReactNode
   previewTitle: (count: number) => string

--- a/apps/bilan-carbone/src/components/base/ImportFileModal/ImportFileModal.tsx
+++ b/apps/bilan-carbone/src/components/base/ImportFileModal/ImportFileModal.tsx
@@ -277,7 +277,7 @@ const ImportFileModal = <TPreviewRow,>({
         {isWarning && <WarningList warnings={warnings} t={t} tCommon={tCommon} />}
 
         {isAmbiguous && (
-          <div className={styles.ambiguousWrapper}>
+          <div className={classNames(styles.ambiguousWrapper, 'flex-col gapped1')}>
             <Typography variant="body2" color="textSecondary">
               {t('ambiguousTitle')}
             </Typography>

--- a/apps/bilan-carbone/src/components/base/ImportFileModal/ImportFileModal.tsx
+++ b/apps/bilan-carbone/src/components/base/ImportFileModal/ImportFileModal.tsx
@@ -310,9 +310,7 @@ const ImportFileModal = <TPreviewRow,>({
                   </Typography>
                 )}
                 {row.tooMany ? (
-                  <Typography variant="body2" color="warning.main">
-                    {t('ambiguousTooMany')}
-                  </Typography>
+                  <Typography variant="body2">{t('ambiguousTooMany')}</Typography>
                 ) : (
                   <RadioGroup
                     className={styles.ambiguousRadioGroup}

--- a/apps/bilan-carbone/src/components/base/ImportFileModal/ImportFileModal.tsx
+++ b/apps/bilan-carbone/src/components/base/ImportFileModal/ImportFileModal.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import Modal from '@/components/modals/Modal'
-import { ImportError, ImportResult, ImportWarning } from '@/types/import.types'
+import { AmbiguousRow, FEChoices, ImportError, ImportResult, ImportWarning } from '@/types/import.types'
 import LoadingButton from '@abc-transitionbascarbone/components/src/base/LoadingButton'
 import DownloadIcon from '@mui/icons-material/Download'
 import UploadFileIcon from '@mui/icons-material/UploadFile'
-import { CircularProgress, Typography } from '@mui/material'
+import { CircularProgress, FormControlLabel, Radio, RadioGroup, Typography } from '@mui/material'
 import classNames from 'classnames'
 import { useTranslations } from 'next-intl'
 import { DragEvent, ReactNode, useRef, useState, useTransition } from 'react'
@@ -32,9 +32,16 @@ interface Props<TPreviewRow> {
   title: string
   onClose: () => void
   onSuccess: () => void
-  onPreview: (file: File) => Promise<{ success: true; rows: TPreviewRow[] } | { success: false; errors: ImportError[] }>
-  onConfirmImport: (file: File) => Promise<ImportResult>
-  onForceImport?: (file: File) => Promise<ImportResult>
+  onPreview: (
+    file: File,
+    choices?: FEChoices,
+  ) => Promise<
+    | { success: true; rows: TPreviewRow[] }
+    | { success: false; errors: ImportError[] }
+    | { success: 'warnings'; warnings: ImportWarning[]; ambiguousRows: AmbiguousRow[] }
+    | { success: 'ambiguous'; rows: AmbiguousRow[] }
+  >
+  onConfirmImport: (file: File, choices?: FEChoices) => Promise<ImportResult>
   onDownloadTemplate: () => Promise<void>
   renderPreviewTable: (rows: TPreviewRow[]) => ReactNode
   previewTitle: (count: number) => string
@@ -49,7 +56,6 @@ const ImportFileModal = <TPreviewRow,>({
   onSuccess,
   onPreview,
   onConfirmImport,
-  onForceImport,
   onDownloadTemplate,
   renderPreviewTable,
   previewTitle,
@@ -61,6 +67,9 @@ const ImportFileModal = <TPreviewRow,>({
   const [isDownloading, setIsDownloading] = useState(false)
   const [errors, setErrors] = useState<{ lineNumber: number | null; items: ImportError[] }[]>([])
   const [warnings, setWarnings] = useState<{ lineNumber: number | null; items: ImportWarning[] }[]>([])
+  const [pendingAmbiguousRows, setPendingAmbiguousRows] = useState<AmbiguousRow[]>([])
+  const [ambiguousRows, setAmbiguousRows] = useState<AmbiguousRow[]>([])
+  const [feChoices, setFeChoices] = useState<FEChoices>({})
   const [previewRows, setPreviewRows] = useState<TPreviewRow[]>([])
   const [isDragOver, setIsDragOver] = useState(false)
   const [pendingFile, setPendingFile] = useState<File | null>(null)
@@ -68,11 +77,15 @@ const ImportFileModal = <TPreviewRow,>({
 
   const isPreview = previewRows.length > 0
   const isWarning = warnings.length > 0
+  const isAmbiguous = ambiguousRows.length > 0
   const isError = errors.length > 0
 
   const reset = () => {
     setErrors([])
     setWarnings([])
+    setPendingAmbiguousRows([])
+    setAmbiguousRows([])
+    setFeChoices({})
     setPreviewRows([])
     setIsDragOver(false)
     setPendingFile(null)
@@ -86,8 +99,23 @@ const ImportFileModal = <TPreviewRow,>({
     onClose()
   }
 
+  const initAmbiguousRows = (rows: AmbiguousRow[]) => {
+    setAmbiguousRows(rows)
+    const initial: FEChoices = {}
+    for (const row of rows) {
+      if (!(row.lineNumber in feChoices)) {
+        initial[row.lineNumber] = null
+      }
+    }
+    setFeChoices((prev) => ({ ...prev, ...initial }))
+  }
+
   const previewFile = (file: File) => {
     setErrors([])
+    setWarnings([])
+    setPendingAmbiguousRows([])
+    setAmbiguousRows([])
+    setFeChoices({})
     setPreviewRows([])
     setPendingFile(file)
 
@@ -97,9 +125,64 @@ const ImportFileModal = <TPreviewRow,>({
 
     startTransition(async () => {
       const result = await onPreview(file)
-      if (result.success) {
+      if (result.success === true) {
         setPreviewRows(result.rows)
+      } else if (result.success === 'warnings') {
+        setWarnings(groupByLine(result.warnings))
+        setPendingAmbiguousRows(result.ambiguousRows)
+      } else if (result.success === 'ambiguous') {
+        initAmbiguousRows(result.rows)
       } else {
+        setErrors(groupByLine(result.errors))
+      }
+    })
+  }
+
+  const handleContinueFromWarnings = () => {
+    if (!pendingFile) {
+      return
+    }
+    if (pendingAmbiguousRows.length > 0) {
+      setWarnings([])
+      initAmbiguousRows(pendingAmbiguousRows)
+      setPendingAmbiguousRows([])
+      return
+    }
+    startTransition(async () => {
+      const result = await onPreview(pendingFile, feChoices)
+      if (result.success === true) {
+        setWarnings([])
+        setPreviewRows(result.rows)
+      } else if (result.success === 'ambiguous') {
+        setWarnings([])
+        initAmbiguousRows(result.rows)
+      } else if (result.success === 'warnings') {
+        setWarnings(groupByLine(result.warnings))
+        setPendingAmbiguousRows(result.ambiguousRows)
+      } else {
+        setWarnings([])
+        setErrors(groupByLine(result.errors))
+      }
+    })
+  }
+
+  const handleResolveAmbiguities = () => {
+    if (!pendingFile) {
+      return
+    }
+    startTransition(async () => {
+      const result = await onPreview(pendingFile, feChoices)
+      if (result.success === true) {
+        setAmbiguousRows([])
+        setPreviewRows(result.rows)
+      } else if (result.success === 'ambiguous') {
+        initAmbiguousRows(result.rows)
+      } else if (result.success === 'warnings') {
+        setAmbiguousRows([])
+        setWarnings(groupByLine(result.warnings))
+        setPendingAmbiguousRows(result.ambiguousRows)
+      } else {
+        setAmbiguousRows([])
         setErrors(groupByLine(result.errors))
       }
     })
@@ -110,30 +193,11 @@ const ImportFileModal = <TPreviewRow,>({
       return
     }
     startTransition(async () => {
-      const result = await onConfirmImport(pendingFile)
-      if (result.success) {
-        reset()
-        onSuccess()
-      } else if (result.warnings) {
-        setPreviewRows([])
-        setWarnings(groupByLine(result.warnings))
-      } else {
-        setErrors(groupByLine(result.errors ?? []))
-      }
-    })
-  }
-
-  const forceImport = () => {
-    if (!pendingFile || !onForceImport) {
-      return
-    }
-    startTransition(async () => {
-      const result = await onForceImport(pendingFile)
+      const result = await onConfirmImport(pendingFile, feChoices)
       if (result.success) {
         reset()
         onSuccess()
       } else {
-        setWarnings([])
         setErrors(groupByLine(result.errors ?? []))
       }
     })
@@ -147,8 +211,7 @@ const ImportFileModal = <TPreviewRow,>({
       setErrors(groupByLine([{ lineNumber: null, key: 'tooManyFiles' }]))
       return
     }
-    const file = files[0]
-    previewFile(file)
+    previewFile(files[0])
   }
 
   const handleDragOver = (e: DragEvent<HTMLDivElement>) => {
@@ -191,27 +254,31 @@ const ImportFileModal = <TPreviewRow,>({
                 children: tCommon('action.confirm'),
               },
             ]
-          : isWarning && onForceImport
+          : isAmbiguous
             ? [
-                {
-                  actionType: 'button',
-                  variant: 'outlined',
-                  color: 'error',
-                  onClick: reset,
-                  children: tCommon('action.cancel'),
-                },
+                { actionType: 'button', variant: 'outlined', onClick: reset, children: tCommon('action.back') },
                 {
                   actionType: 'loadingButton',
-                  onClick: forceImport,
+                  onClick: handleResolveAmbiguities,
                   loading: isPending,
-                  children: t('confirmAnyway'),
+                  children: tCommon('action.continue'),
                 },
               ]
-            : undefined
+            : isWarning
+              ? [
+                  { actionType: 'button', variant: 'outlined', onClick: reset, children: tCommon('action.cancel') },
+                  {
+                    actionType: 'loadingButton',
+                    onClick: handleContinueFromWarnings,
+                    loading: isPending,
+                    children: t('confirmAnyway'),
+                  },
+                ]
+              : undefined
       }
     >
-      <div className={classNames('flex-col gapped15', { 'grow overflow-hidden': isPreview && !isWarning })}>
-        {!isPreview && (
+      <div className={classNames('flex-col gapped15', { 'grow overflow-hidden': isPreview })}>
+        {!isPreview && !isWarning && !isAmbiguous && (
           <div className="flex align-center">
             <LoadingButton
               variant="outlined"
@@ -224,7 +291,70 @@ const ImportFileModal = <TPreviewRow,>({
           </div>
         )}
 
-        {isPreview && !isWarning && (
+        {isWarning && <WarningList warnings={warnings} t={t} tCommon={tCommon} />}
+
+        {isAmbiguous && (
+          <div className={styles.ambiguousWrapper}>
+            <Typography variant="body2" color="textSecondary">
+              {t('ambiguousTitle')}
+            </Typography>
+            {ambiguousRows.map((row) => (
+              <div key={row.lineNumber} className={styles.ambiguousRow}>
+                <Typography variant="body2" fontWeight="medium">
+                  {tCommon('label.line', { line: row.lineNumber })}
+                  {row.sourceName ? ` — ${row.sourceName}` : ''}
+                </Typography>
+                {row.searchedName && (
+                  <Typography variant="caption" color="textSecondary">
+                    {t('ambiguousSearched', { name: row.searchedName })}
+                  </Typography>
+                )}
+                {row.tooMany ? (
+                  <Typography variant="body2" color="warning.main">
+                    {t('ambiguousTooMany')}
+                  </Typography>
+                ) : (
+                  <RadioGroup
+                    className={styles.ambiguousRadioGroup}
+                    value={feChoices[row.lineNumber] ?? 'null'}
+                    onChange={(e) =>
+                      setFeChoices((prev) => ({
+                        ...prev,
+                        [row.lineNumber]: e.target.value === 'null' ? null : e.target.value,
+                      }))
+                    }
+                  >
+                    {row.candidates.map((c) => (
+                      <FormControlLabel
+                        key={c.id}
+                        value={c.id}
+                        control={<Radio size="small" />}
+                        label={
+                          <Typography variant="body2">
+                            {[c.foundTitle, c.foundValue !== undefined ? `${c.foundValue}` : undefined, c.foundUnit]
+                              .filter(Boolean)
+                              .join(' · ')}
+                          </Typography>
+                        }
+                      />
+                    ))}
+                    <FormControlLabel
+                      value="null"
+                      control={<Radio size="small" />}
+                      label={
+                        <Typography variant="body2" color="textSecondary">
+                          {t('leaveEmpty')}
+                        </Typography>
+                      }
+                    />
+                  </RadioGroup>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        {isPreview && (
           <>
             <Typography variant="body2" color="textSecondary">
               {previewTitle(previewRows.length)} — {t('previewWarning')}
@@ -233,9 +363,7 @@ const ImportFileModal = <TPreviewRow,>({
           </>
         )}
 
-        {isWarning && <WarningList warnings={warnings} t={t} tCommon={tCommon} />}
-
-        {!isPreview && !isWarning && (
+        {!isPreview && !isWarning && !isAmbiguous && (
           <>
             <div
               className={classNames(styles.dropzone, 'flex-col align-center justify-center gapped075 pointer')}

--- a/apps/bilan-carbone/src/components/base/ImportFileModal/ImportFileModal.tsx
+++ b/apps/bilan-carbone/src/components/base/ImportFileModal/ImportFileModal.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Modal from '@/components/modals/Modal'
-import { AmbiguousRow, FEChoices, ImportError, ImportResult, ImportWarning } from '@/types/import.types'
+import { AmbiguousRow, FEChoices, ImportError, ImportResult, ImportWarning, Phase } from '@/types/import.types'
 import { ValidateEmissionSourcesResult } from '@/types/importEmissionSources.types'
 import LoadingButton from '@abc-transitionbascarbone/components/src/base/LoadingButton'
 import DownloadIcon from '@mui/icons-material/Download'
@@ -64,9 +64,9 @@ const ImportFileModal = <TPreviewRow,>({
   const tCommon = useTranslations('common')
   const [isPending, startTransition] = useTransition()
   const [isDownloading, setIsDownloading] = useState(false)
+  const [phase, setPhase] = useState<Phase>('idle')
   const [errors, setErrors] = useState<{ lineNumber: number | null; items: ImportError[] }[]>([])
   const [warnings, setWarnings] = useState<{ lineNumber: number | null; items: ImportWarning[] }[]>([])
-  const [pendingAmbiguousRows, setPendingAmbiguousRows] = useState<AmbiguousRow[]>([])
   const [ambiguousRows, setAmbiguousRows] = useState<AmbiguousRow[]>([])
   const [feChoices, setFeChoices] = useState<FEChoices>({})
   const [previewRows, setPreviewRows] = useState<TPreviewRow[]>([])
@@ -74,15 +74,10 @@ const ImportFileModal = <TPreviewRow,>({
   const [pendingFile, setPendingFile] = useState<File | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
-  const isPreview = previewRows.length > 0
-  const isWarning = warnings.length > 0
-  const isAmbiguous = ambiguousRows.length > 0
-  const isError = errors.length > 0
-
   const reset = () => {
+    setPhase('idle')
     setErrors([])
     setWarnings([])
-    setPendingAmbiguousRows([])
     setAmbiguousRows([])
     setFeChoices({})
     setPreviewRows([])
@@ -98,22 +93,9 @@ const ImportFileModal = <TPreviewRow,>({
     onClose()
   }
 
-  const initAmbiguousRows = (rows: AmbiguousRow[]) => {
-    setAmbiguousRows(rows)
-  }
-
   const previewFile = (file: File) => {
-    setErrors([])
-    setWarnings([])
-    setPendingAmbiguousRows([])
-    setAmbiguousRows([])
-    setFeChoices({})
-    setPreviewRows([])
+    reset()
     setPendingFile(file)
-
-    if (fileInputRef.current) {
-      fileInputRef.current.value = ''
-    }
 
     startTransition(async () => {
       const result = await onValidate(file)
@@ -122,32 +104,38 @@ const ImportFileModal = <TPreviewRow,>({
           const resolved = await onResolve(file, {})
           if (resolved.status === 'ok') {
             setPreviewRows(resolved.rows)
+            setPhase('preview')
           } else {
             setErrors(groupByLine(resolved.errors))
+            setPhase('error')
           }
         }
       } else if (result.status === 'warnings') {
         setWarnings(groupByLine(result.warnings))
-        setPendingAmbiguousRows(result.ambiguousRows)
+        setAmbiguousRows(result.ambiguousRows)
+        setPhase('warnings')
       } else if (result.status === 'ambiguous') {
-        initAmbiguousRows(result.rows)
+        setAmbiguousRows(result.rows)
+        setPhase('ambiguous')
       } else {
         setErrors(groupByLine(result.errors))
+        setPhase('error')
       }
     })
   }
 
-  const resolveAndPreview = (file: File, choices: FEChoices, onDone: () => void) => {
+  const resolveAndPreview = (file: File, choices: FEChoices) => {
     if (!onResolve) {
       return
     }
     startTransition(async () => {
       const result = await onResolve(file, choices)
-      onDone()
       if (result.status === 'ok') {
         setPreviewRows(result.rows)
+        setPhase('preview')
       } else {
         setErrors(groupByLine(result.errors))
+        setPhase('error')
       }
     })
   }
@@ -156,20 +144,18 @@ const ImportFileModal = <TPreviewRow,>({
     if (!pendingFile) {
       return
     }
-    if (pendingAmbiguousRows.length > 0) {
-      setWarnings([])
-      initAmbiguousRows(pendingAmbiguousRows)
-      setPendingAmbiguousRows([])
+    if (ambiguousRows.length > 0) {
+      setPhase('ambiguous')
       return
     }
-    resolveAndPreview(pendingFile, feChoices, () => setWarnings([]))
+    resolveAndPreview(pendingFile, feChoices)
   }
 
   const handleResolveAmbiguities = () => {
     if (!pendingFile) {
       return
     }
-    resolveAndPreview(pendingFile, feChoices, () => setAmbiguousRows([]))
+    resolveAndPreview(pendingFile, feChoices)
   }
 
   const confirmImport = () => {
@@ -183,6 +169,7 @@ const ImportFileModal = <TPreviewRow,>({
         onSuccess()
       } else {
         setErrors(groupByLine(result.errors ?? []))
+        setPhase('error')
       }
     })
   }
@@ -226,9 +213,9 @@ const ImportFileModal = <TPreviewRow,>({
       label={label}
       title={title}
       onClose={handleClose}
-      big={isPreview}
+      big={phase === 'preview'}
       actions={
-        isPreview
+        phase === 'preview'
           ? [
               { actionType: 'button', variant: 'outlined', onClick: reset, children: tCommon('action.back') },
               {
@@ -238,7 +225,7 @@ const ImportFileModal = <TPreviewRow,>({
                 children: tCommon('action.confirm'),
               },
             ]
-          : isAmbiguous
+          : phase === 'ambiguous'
             ? [
                 { actionType: 'button', variant: 'outlined', onClick: reset, children: tCommon('action.back') },
                 {
@@ -248,7 +235,7 @@ const ImportFileModal = <TPreviewRow,>({
                   children: tCommon('action.continue'),
                 },
               ]
-            : isWarning
+            : phase === 'warnings'
               ? [
                   { actionType: 'button', variant: 'outlined', onClick: reset, children: tCommon('action.cancel') },
                   {
@@ -261,8 +248,8 @@ const ImportFileModal = <TPreviewRow,>({
               : undefined
       }
     >
-      <div className={classNames('flex-col gapped15', { 'grow overflow-hidden': isPreview })}>
-        {!isPreview && !isWarning && !isAmbiguous && (
+      <div className={classNames('flex-col gapped15', { 'grow overflow-hidden': phase === 'preview' })}>
+        {phase === 'idle' && (
           <div className="flex align-center">
             <LoadingButton
               variant="outlined"
@@ -275,9 +262,9 @@ const ImportFileModal = <TPreviewRow,>({
           </div>
         )}
 
-        {isWarning && <WarningList warnings={warnings} t={t} tCommon={tCommon} />}
+        {phase === 'warnings' && <WarningList warnings={warnings} t={t} tCommon={tCommon} />}
 
-        {isAmbiguous && (
+        {phase === 'ambiguous' && (
           <AmbiguousEmissionFactorList
             rows={ambiguousRows}
             choices={feChoices}
@@ -285,7 +272,7 @@ const ImportFileModal = <TPreviewRow,>({
           />
         )}
 
-        {isPreview && (
+        {phase === 'preview' && (
           <>
             <Typography variant="body2" color="textSecondary">
               {previewTitle(previewRows.length)} — {t('previewWarning')}
@@ -294,7 +281,7 @@ const ImportFileModal = <TPreviewRow,>({
           </>
         )}
 
-        {!isPreview && !isWarning && !isAmbiguous && (
+        {(phase === 'idle' || phase === 'error') && (
           <>
             <div
               className={classNames(styles.dropzone, 'flex-col align-center justify-center gapped075 pointer')}
@@ -326,7 +313,7 @@ const ImportFileModal = <TPreviewRow,>({
               )}
             </div>
 
-            {isError && <ErrorList errors={errors} t={t} tCommon={tCommon} />}
+            {phase === 'error' && <ErrorList errors={errors} t={t} tCommon={tCommon} />}
           </>
         )}
       </div>

--- a/apps/bilan-carbone/src/components/base/ImportFileModal/ImportFileModal.tsx
+++ b/apps/bilan-carbone/src/components/base/ImportFileModal/ImportFileModal.tsx
@@ -35,7 +35,7 @@ interface Props<TPreviewRow> {
   onClose: () => void
   onSuccess: () => void
   onValidate: (file: File) => Promise<ValidateEmissionSourcesResult>
-  onResolve?: (
+  onResolve: (
     file: File,
     choices: FEChoices,
   ) => Promise<{ status: 'error'; errors: ImportError[] } | { status: 'ok'; rows: TPreviewRow[] }>
@@ -100,15 +100,13 @@ const ImportFileModal = <TPreviewRow,>({
     startTransition(async () => {
       const result = await onValidate(file)
       if (result.status === 'ok') {
-        if (onResolve) {
-          const resolved = await onResolve(file, {})
-          if (resolved.status === 'ok') {
-            setPreviewRows(resolved.rows)
-            setPhase('preview')
-          } else {
-            setErrors(groupByLine(resolved.errors))
-            setPhase('error')
-          }
+        const resolved = await onResolve(file, {})
+        if (resolved.status === 'ok') {
+          setPreviewRows(resolved.rows)
+          setPhase('preview')
+        } else {
+          setErrors(groupByLine(resolved.errors))
+          setPhase('error')
         }
       } else if (result.status === 'warnings') {
         setWarnings(groupByLine(result.warnings))
@@ -125,9 +123,6 @@ const ImportFileModal = <TPreviewRow,>({
   }
 
   const resolveAndPreview = (file: File, choices: FEChoices) => {
-    if (!onResolve) {
-      return
-    }
     startTransition(async () => {
       const result = await onResolve(file, choices)
       if (result.status === 'ok') {

--- a/apps/bilan-carbone/src/components/base/ImportFileModal/ImportFileModal.tsx
+++ b/apps/bilan-carbone/src/components/base/ImportFileModal/ImportFileModal.tsx
@@ -6,10 +6,11 @@ import { ValidateEmissionSourcesResult } from '@/types/importEmissionSources.typ
 import LoadingButton from '@abc-transitionbascarbone/components/src/base/LoadingButton'
 import DownloadIcon from '@mui/icons-material/Download'
 import UploadFileIcon from '@mui/icons-material/UploadFile'
-import { CircularProgress, FormControlLabel, Radio, RadioGroup, Typography } from '@mui/material'
+import { CircularProgress, Typography } from '@mui/material'
 import classNames from 'classnames'
 import { useTranslations } from 'next-intl'
 import { DragEvent, ReactNode, useRef, useState, useTransition } from 'react'
+import AmbiguousEmissionFactorList from './AmbiguousEmissionFactorList'
 import ErrorList from './ErrorList'
 import styles from './ImportFileModal.module.css'
 import WarningList from './WarningList'
@@ -277,61 +278,11 @@ const ImportFileModal = <TPreviewRow,>({
         {isWarning && <WarningList warnings={warnings} t={t} tCommon={tCommon} />}
 
         {isAmbiguous && (
-          <div className={classNames(styles.ambiguousWrapper, 'flex-col gapped1')}>
-            <Typography variant="body2" color="textSecondary">
-              {t('ambiguousTitle')}
-            </Typography>
-            {ambiguousRows.map((row) => (
-              <div key={row.lineNumber} className={styles.ambiguousRow}>
-                <Typography variant="body2" fontWeight="medium">
-                  {tCommon('label.line', { line: row.lineNumber })}
-                  {row.sourceName ? ` — ${row.sourceName}` : ''}
-                </Typography>
-                {row.searchedName && (
-                  <Typography variant="caption" color="textSecondary">
-                    {t('ambiguousSearched', { name: row.searchedName })}
-                  </Typography>
-                )}
-                {row.tooMany ? (
-                  <Typography variant="body2">{t('ambiguousTooMany')}</Typography>
-                ) : (
-                  <RadioGroup
-                    value={feChoices[row.lineNumber] ?? 'null'}
-                    onChange={(e) =>
-                      setFeChoices((prev) => ({
-                        ...prev,
-                        [row.lineNumber]: e.target.value === 'null' ? null : e.target.value,
-                      }))
-                    }
-                  >
-                    {row.candidates.map((c) => (
-                      <FormControlLabel
-                        key={c.id}
-                        value={c.id}
-                        control={<Radio size="small" />}
-                        label={
-                          <Typography variant="body2">
-                            {[c.foundTitle, c.foundValue !== undefined ? `${c.foundValue}` : undefined, c.foundUnit]
-                              .filter(Boolean)
-                              .join(' · ')}
-                          </Typography>
-                        }
-                      />
-                    ))}
-                    <FormControlLabel
-                      value="null"
-                      control={<Radio size="small" />}
-                      label={
-                        <Typography variant="body2" color="textSecondary">
-                          {t('leaveEmpty')}
-                        </Typography>
-                      }
-                    />
-                  </RadioGroup>
-                )}
-              </div>
-            ))}
-          </div>
+          <AmbiguousEmissionFactorList
+            rows={ambiguousRows}
+            choices={feChoices}
+            onChange={(lineNumber, value) => setFeChoices((prev) => ({ ...prev, [lineNumber]: value }))}
+          />
         )}
 
         {isPreview && (

--- a/apps/bilan-carbone/src/components/base/ImportFileModal/ImportFileModal.tsx
+++ b/apps/bilan-carbone/src/components/base/ImportFileModal/ImportFileModal.tsx
@@ -2,6 +2,7 @@
 
 import Modal from '@/components/modals/Modal'
 import { AmbiguousRow, FEChoices, ImportError, ImportResult, ImportWarning } from '@/types/import.types'
+import { ValidateEmissionSourcesResult } from '@/types/importEmissionSources.types'
 import LoadingButton from '@abc-transitionbascarbone/components/src/base/LoadingButton'
 import DownloadIcon from '@mui/icons-material/Download'
 import UploadFileIcon from '@mui/icons-material/UploadFile'
@@ -32,15 +33,11 @@ interface Props<TPreviewRow> {
   title: string
   onClose: () => void
   onSuccess: () => void
-  onPreview: (
+  onValidate: (file: File) => Promise<ValidateEmissionSourcesResult>
+  onResolve?: (
     file: File,
-    choices?: FEChoices,
-  ) => Promise<
-    | { success: true; rows: TPreviewRow[] }
-    | { success: false; errors: ImportError[] }
-    | { success: 'warnings'; warnings: ImportWarning[]; ambiguousRows: AmbiguousRow[] }
-    | { success: 'ambiguous'; rows: AmbiguousRow[] }
-  >
+    choices: FEChoices,
+  ) => Promise<{ status: 'error'; errors: ImportError[] } | { status: 'ok'; rows: TPreviewRow[] }>
   onConfirmImport: (file: File, choices?: FEChoices) => Promise<ImportResult>
   onDownloadTemplate: () => Promise<void>
   renderPreviewTable: (rows: TPreviewRow[]) => ReactNode
@@ -54,7 +51,8 @@ const ImportFileModal = <TPreviewRow,>({
   title,
   onClose,
   onSuccess,
-  onPreview,
+  onValidate,
+  onResolve,
   onConfirmImport,
   onDownloadTemplate,
   renderPreviewTable,
@@ -101,13 +99,6 @@ const ImportFileModal = <TPreviewRow,>({
 
   const initAmbiguousRows = (rows: AmbiguousRow[]) => {
     setAmbiguousRows(rows)
-    const initial: FEChoices = {}
-    for (const row of rows) {
-      if (!(row.lineNumber in feChoices)) {
-        initial[row.lineNumber] = null
-      }
-    }
-    setFeChoices((prev) => ({ ...prev, ...initial }))
   }
 
   const previewFile = (file: File) => {
@@ -124,14 +115,36 @@ const ImportFileModal = <TPreviewRow,>({
     }
 
     startTransition(async () => {
-      const result = await onPreview(file)
-      if (result.success === true) {
-        setPreviewRows(result.rows)
-      } else if (result.success === 'warnings') {
+      const result = await onValidate(file)
+      if (result.status === 'ok') {
+        if (onResolve) {
+          const resolved = await onResolve(file, {})
+          if (resolved.status === 'ok') {
+            setPreviewRows(resolved.rows)
+          } else {
+            setErrors(groupByLine(resolved.errors))
+          }
+        }
+      } else if (result.status === 'warnings') {
         setWarnings(groupByLine(result.warnings))
         setPendingAmbiguousRows(result.ambiguousRows)
-      } else if (result.success === 'ambiguous') {
+      } else if (result.status === 'ambiguous') {
         initAmbiguousRows(result.rows)
+      } else {
+        setErrors(groupByLine(result.errors))
+      }
+    })
+  }
+
+  const resolveAndPreview = (file: File, choices: FEChoices, onDone: () => void) => {
+    if (!onResolve) {
+      return
+    }
+    startTransition(async () => {
+      const result = await onResolve(file, choices)
+      onDone()
+      if (result.status === 'ok') {
+        setPreviewRows(result.rows)
       } else {
         setErrors(groupByLine(result.errors))
       }
@@ -148,44 +161,14 @@ const ImportFileModal = <TPreviewRow,>({
       setPendingAmbiguousRows([])
       return
     }
-    startTransition(async () => {
-      const result = await onPreview(pendingFile, feChoices)
-      if (result.success === true) {
-        setWarnings([])
-        setPreviewRows(result.rows)
-      } else if (result.success === 'ambiguous') {
-        setWarnings([])
-        initAmbiguousRows(result.rows)
-      } else if (result.success === 'warnings') {
-        setWarnings(groupByLine(result.warnings))
-        setPendingAmbiguousRows(result.ambiguousRows)
-      } else {
-        setWarnings([])
-        setErrors(groupByLine(result.errors))
-      }
-    })
+    resolveAndPreview(pendingFile, feChoices, () => setWarnings([]))
   }
 
   const handleResolveAmbiguities = () => {
     if (!pendingFile) {
       return
     }
-    startTransition(async () => {
-      const result = await onPreview(pendingFile, feChoices)
-      if (result.success === true) {
-        setAmbiguousRows([])
-        setPreviewRows(result.rows)
-      } else if (result.success === 'ambiguous') {
-        initAmbiguousRows(result.rows)
-      } else if (result.success === 'warnings') {
-        setAmbiguousRows([])
-        setWarnings(groupByLine(result.warnings))
-        setPendingAmbiguousRows(result.ambiguousRows)
-      } else {
-        setAmbiguousRows([])
-        setErrors(groupByLine(result.errors))
-      }
-    })
+    resolveAndPreview(pendingFile, feChoices, () => setAmbiguousRows([]))
   }
 
   const confirmImport = () => {
@@ -313,7 +296,6 @@ const ImportFileModal = <TPreviewRow,>({
                   <Typography variant="body2">{t('ambiguousTooMany')}</Typography>
                 ) : (
                   <RadioGroup
-                    className={styles.ambiguousRadioGroup}
                     value={feChoices[row.lineNumber] ?? 'null'}
                     onChange={(e) =>
                       setFeChoices((prev) => ({

--- a/apps/bilan-carbone/src/components/base/ImportFileModal/WarningItem.tsx
+++ b/apps/bilan-carbone/src/components/base/ImportFileModal/WarningItem.tsx
@@ -19,6 +19,9 @@ const WarningItem = ({ w, lineNumber, t }: Props) => {
   if (w.type === 'efMissing') {
     warningMessage = t('warningEfMissing', { sourceName: w.sourceName ?? '' })
   }
+  if (w.type === 'efMissingUnit') {
+    warningMessage = t('warningEfMissingUnit', { searched: w.searchedName ?? '' })
+  }
   if (w.type === 'unitMissingPrefix') {
     warningMessage = t('warningUnitMissingPrefix', {
       foundUnit: w.foundUnit ?? '',

--- a/apps/bilan-carbone/src/components/emissionFactor/ImportEmissionFactorsModal.tsx
+++ b/apps/bilan-carbone/src/components/emissionFactor/ImportEmissionFactorsModal.tsx
@@ -70,7 +70,11 @@ const ImportEmissionFactorsModal = ({ open, onClose, onSuccess }: Props) => {
       title={t('title')}
       onClose={onClose}
       onSuccess={onSuccess}
-      onPreview={previewEmissionFactorsFromFile}
+      onValidate={async () => ({ status: 'ok' })}
+      onResolve={async (file) => {
+        const result = await previewEmissionFactorsFromFile(file)
+        return result.success ? { status: 'ok', rows: result.rows } : { status: 'error', errors: result.errors }
+      }}
       onConfirmImport={(file) => importEmissionFactorsFromFile(file)}
       onDownloadTemplate={handleDownloadTemplate}
       renderPreviewTable={renderPreviewTable}

--- a/apps/bilan-carbone/src/components/emissionFactor/ImportEmissionFactorsModal.tsx
+++ b/apps/bilan-carbone/src/components/emissionFactor/ImportEmissionFactorsModal.tsx
@@ -72,7 +72,6 @@ const ImportEmissionFactorsModal = ({ open, onClose, onSuccess }: Props) => {
       onSuccess={onSuccess}
       onPreview={previewEmissionFactorsFromFile}
       onConfirmImport={(file) => importEmissionFactorsFromFile(file)}
-      onForceImport={(file) => importEmissionFactorsFromFile(file, true)}
       onDownloadTemplate={handleDownloadTemplate}
       renderPreviewTable={renderPreviewTable}
       previewTitle={(count) => t('previewTitle', { count })}

--- a/apps/bilan-carbone/src/components/study/ImportEmissionSourcesModal.tsx
+++ b/apps/bilan-carbone/src/components/study/ImportEmissionSourcesModal.tsx
@@ -6,7 +6,8 @@ import { Post } from '@/services/posts'
 import {
   getImportEmissionSourcesTemplate,
   importEmissionSourcesFromFile,
-  previewEmissionSourcesFromFile,
+  resolveEmissionSourcesFromFile,
+  validateEmissionSourcesFromFile,
 } from '@/services/serverFunctions/importEmissionSources'
 import { PreviewEmissionSourceRow } from '@/types/importEmissionSources.types'
 import { Table, TableBody, TableCell, TableHead, TableRow } from '@mui/material'
@@ -84,7 +85,8 @@ const ImportEmissionSourcesModal = ({ studyId, post, siteId, open, onClose, onSu
       title={t('title')}
       onClose={onClose}
       onSuccess={onSuccess}
-      onPreview={(file, choices) => previewEmissionSourcesFromFile(file, studyId, choices)}
+      onValidate={(file) => validateEmissionSourcesFromFile(file, studyId)}
+      onResolve={(file, choices) => resolveEmissionSourcesFromFile(file, studyId, choices)}
       onConfirmImport={(file, choices) => importEmissionSourcesFromFile(file, studyId, choices)}
       onDownloadTemplate={handleDownloadTemplate}
       renderPreviewTable={renderPreviewTable}

--- a/apps/bilan-carbone/src/components/study/ImportEmissionSourcesModal.tsx
+++ b/apps/bilan-carbone/src/components/study/ImportEmissionSourcesModal.tsx
@@ -84,9 +84,8 @@ const ImportEmissionSourcesModal = ({ studyId, post, siteId, open, onClose, onSu
       title={t('title')}
       onClose={onClose}
       onSuccess={onSuccess}
-      onPreview={(file) => previewEmissionSourcesFromFile(file, studyId)}
-      onConfirmImport={(file) => importEmissionSourcesFromFile(file, studyId)}
-      onForceImport={(file) => importEmissionSourcesFromFile(file, studyId, true)}
+      onPreview={(file, choices) => previewEmissionSourcesFromFile(file, studyId, choices)}
+      onConfirmImport={(file, choices) => importEmissionSourcesFromFile(file, studyId, choices)}
       onDownloadTemplate={handleDownloadTemplate}
       renderPreviewTable={renderPreviewTable}
       previewTitle={(count) => t('previewTitle', { count })}

--- a/apps/bilan-carbone/src/db/emissionFactors.ts
+++ b/apps/bilan-carbone/src/db/emissionFactors.ts
@@ -594,6 +594,19 @@ const getOrganizationAndImportedVersionsFilters = (organizationId: string, versi
   { organizationId, importedFrom: Import.Manual },
 ]
 
+export const findEmissionFactorByIdForMatch = (id: string) =>
+  prismaClient.emissionFactor.findUnique({
+    where: { id },
+    select: {
+      id: true,
+      importedId: true,
+      totalCo2: true,
+      unit: true,
+      customUnit: true,
+      metaData: { select: { title: true, attribute: true, frontiere: true, language: true } },
+    },
+  })
+
 export const findEmissionFactorByImportedIdForMatch = (id: string, organizationId: string, versionIds: string[]) =>
   prismaClient.emissionFactor.findFirst({
     where: {
@@ -602,6 +615,7 @@ export const findEmissionFactorByImportedIdForMatch = (id: string, organizationI
     },
     select: {
       id: true,
+      importedId: true,
       totalCo2: true,
       unit: true,
       customUnit: true,
@@ -624,6 +638,7 @@ export const findEmissionFactorsByNameAndUnit = (
     },
     select: {
       id: true,
+      importedId: true,
       totalCo2: true,
       unit: true,
       customUnit: true,
@@ -639,6 +654,7 @@ export const findEmissionFactorsByUnit = (organizationId: string, unit: Unit, ve
     },
     select: {
       id: true,
+      importedId: true,
       totalCo2: true,
       unit: true,
       customUnit: true,

--- a/apps/bilan-carbone/src/db/emissionFactors.ts
+++ b/apps/bilan-carbone/src/db/emissionFactors.ts
@@ -600,6 +600,7 @@ export const findEmissionFactorByIdForMatch = (id: string) =>
     select: {
       id: true,
       importedId: true,
+      importedFrom: true,
       totalCo2: true,
       unit: true,
       customUnit: true,
@@ -616,6 +617,7 @@ export const findEmissionFactorByImportedIdForMatch = (id: string, organizationI
     select: {
       id: true,
       importedId: true,
+      importedFrom: true,
       totalCo2: true,
       unit: true,
       customUnit: true,
@@ -639,6 +641,7 @@ export const findEmissionFactorsByNameAndUnit = (
     select: {
       id: true,
       importedId: true,
+      importedFrom: true,
       totalCo2: true,
       unit: true,
       customUnit: true,
@@ -655,6 +658,7 @@ export const findEmissionFactorsByUnit = (organizationId: string, unit: Unit, ve
     select: {
       id: true,
       importedId: true,
+      importedFrom: true,
       totalCo2: true,
       unit: true,
       customUnit: true,

--- a/apps/bilan-carbone/src/i18n/translations/en/bc.json
+++ b/apps/bilan-carbone/src/i18n/translations/en/bc.json
@@ -1579,6 +1579,7 @@
     "missingEmissionFactorValue": "Emission factor value is missing",
     "missingEmissionFactorUnit": "Emission factor unit is missing",
     "warningEfMissing": "No emission factor provided for \"{sourceName}\"",
+    "warningEfMissingUnit": "Emission factor \"{searched}\" not found — unit is missing",
     "ambiguousTitle": "Multiple emission factors match for the following sources. Select the one to use:",
     "ambiguousSearched": "Searched: \"{name}\"",
     "ambiguousTooMany": "Too many emission factors match this input. Refine the name in your file to reduce results. This source will be imported without an emission factor.",

--- a/apps/bilan-carbone/src/i18n/translations/en/bc.json
+++ b/apps/bilan-carbone/src/i18n/translations/en/bc.json
@@ -1538,7 +1538,7 @@
     "acceptedFormats": "Accepted formats: .xlsx, .xls",
     "errorTitle": "Errors detected",
     "warningTitle": "Warnings",
-    "confirmAnyway": "Import anyway",
+    "confirmAnyway": "Continue anyway",
     "previewWarning": "Please review the data below before confirming the import.",
     "warningEfNotFound": "Emission factor not found for \"{searched}\"",
     "warningEfReplacedBy": "It will be replaced by",
@@ -1578,7 +1578,11 @@
     "missingEmissionFactorName": "Emission factor name is missing",
     "missingEmissionFactorValue": "Emission factor value is missing",
     "missingEmissionFactorUnit": "Emission factor unit is missing",
-    "warningEfMissing": "No emission factor provided for \"{sourceName}\""
+    "warningEfMissing": "No emission factor provided for \"{sourceName}\"",
+    "ambiguousTitle": "Multiple emission factors match for the following sources. Select the one to use:",
+    "ambiguousSearched": "Searched: \"{name}\"",
+    "ambiguousTooMany": "Too many emission factors match this input. Refine the name in your file to reduce results. This source will be imported without an emission factor.",
+    "leaveEmpty": "Leave empty"
   },
   "emissionFactors": {
     "manualSectionLabel": "Manage your manual EFs",

--- a/apps/bilan-carbone/src/i18n/translations/fr/bc.json
+++ b/apps/bilan-carbone/src/i18n/translations/fr/bc.json
@@ -1538,7 +1538,7 @@
     "acceptedFormats": "Formats acceptés : .xlsx, .xls",
     "errorTitle": "Erreurs détectées",
     "warningTitle": "Avertissements",
-    "confirmAnyway": "Importer quand même",
+    "confirmAnyway": "Continuer quand même",
     "previewWarning": "Vérifiez les données ci-dessous avant de confirmer l'import.",
     "warningEfNotFound": "Facteur d'émission non trouvé pour \"{searched}\"",
     "warningEfReplacedBy": "Il sera remplacé par",
@@ -1578,7 +1578,11 @@
     "missingEmissionFactorName": "Nom du facteur d'émission manquant",
     "missingEmissionFactorValue": "Valeur du facteur d'émission manquante",
     "missingEmissionFactorUnit": "Unité du facteur d'émission manquante",
-    "warningEfMissing": "Aucun facteur d'émission renseigné pour \"{sourceName}\""
+    "warningEfMissing": "Aucun facteur d'émission renseigné pour \"{sourceName}\"",
+    "ambiguousTitle": "Plusieurs facteurs d'émission correspondent pour les sources suivantes. Sélectionnez celui à utiliser :",
+    "ambiguousSearched": "Recherché : \"{name}\"",
+    "ambiguousTooMany": "Trop de facteurs d'émission correspondent à cette saisie. Affinez le nom dans le fichier pour réduire les résultats. Cette source sera importée sans facteur d'émission.",
+    "leaveEmpty": "Laisser vide"
   },
   "emissionFactors": {
     "manualSectionLabel": "Gérez vos FEs manuels",

--- a/apps/bilan-carbone/src/i18n/translations/fr/bc.json
+++ b/apps/bilan-carbone/src/i18n/translations/fr/bc.json
@@ -1579,6 +1579,7 @@
     "missingEmissionFactorValue": "Valeur du facteur d'émission manquante",
     "missingEmissionFactorUnit": "Unité du facteur d'émission manquante",
     "warningEfMissing": "Aucun facteur d'émission renseigné pour \"{sourceName}\"",
+    "warningEfMissingUnit": "Facteur d'émission \"{searched}\" non trouvé — unité manquante",
     "ambiguousTitle": "Plusieurs facteurs d'émission correspondent pour les sources suivantes. Sélectionnez celui à utiliser :",
     "ambiguousSearched": "Recherché : \"{name}\"",
     "ambiguousTooMany": "Trop de facteurs d'émission correspondent à cette saisie. Affinez le nom dans le fichier pour réduire les résultats. Cette source sera importée sans facteur d'émission.",

--- a/apps/bilan-carbone/src/services/serverFunctions/importEmissionSources.ts
+++ b/apps/bilan-carbone/src/services/serverFunctions/importEmissionSources.ts
@@ -1,13 +1,13 @@
 'use server'
 
 import { KG_CO2E_PREFIX_REGEX } from '@/constants/import'
-import { EmissionFactorList } from '@/db/emissionFactors'
+import { EmissionFactorList, findEmissionFactorByIdForMatch } from '@/db/emissionFactors'
 import { createEmissionSourcesOnStudy } from '@/db/emissionSource'
 import { FullStudy, getStudyById } from '@/db/study'
 import { getLocale } from '@/i18n/locale'
 import { Post, subPostsByPost } from '@/services/posts'
 import { AccountWithUser } from '@/types/account.types'
-import { ImportResult, ImportWarning } from '@/types/import.types'
+import { AmbiguousRow, FEChoices, ImportResult, ImportWarning } from '@/types/import.types'
 import {
   PreviewEmissionSourceRow,
   PreviewEmissionSourcesResult,
@@ -71,6 +71,7 @@ type ValidImportRow = {
 
 const TOTAL_EXCEL_COLS = Object.keys(SOURCE_IMPORT_COLUMNS).length
 const CAS_DEFAULT_DURATION = 20
+const MAX_FE_CANDIDATES = 10
 
 function getHectareAndDuration(isCAS: boolean, value: number | undefined) {
   if (!isCAS || value == null) {
@@ -90,6 +91,7 @@ async function getStudyOrThrow(studyId: string, account: AccountWithUser): Promi
 export async function previewEmissionSourcesFromFile(
   file: File,
   studyId: string,
+  choices?: FEChoices,
 ): Promise<PreviewEmissionSourcesResult> {
   const account = await getAuthenticatedAccount()
 
@@ -106,11 +108,145 @@ export async function previewEmissionSourcesFromFile(
     return result
   }
 
+  const organizationId = study.organizationVersion.organization?.id ?? ''
+  const versionIds = study.emissionFactorVersions.map((v) => v.importVersionId)
+
+  const warnings: ImportWarning[] = []
+  const ambiguousRows: AmbiguousRow[] = []
+  const resolvingChoices = choices !== undefined
+
+  type ResolvedEf = { efId: string; efName: string; efValue: string; efUnit: string }
+  const resolvedByLine = new Map<number, ResolvedEf>()
+
+  for (const row of result.rows) {
+    const lineNumber = row.lineNumber
+
+    if (
+      !resolvingChoices &&
+      row.emissionFactorUnitRaw &&
+      row.emissionFactorUnit &&
+      row.emissionFactorUnit !== Unit.CUSTOM &&
+      !KG_CO2E_PREFIX_REGEX.test(row.emissionFactorUnitRaw)
+    ) {
+      warnings.push({
+        type: 'unitMissingPrefix',
+        lineNumber,
+        sourceName: row.name,
+        foundUnit: row.emissionFactorUnitRaw,
+        resolvedValue: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
+      })
+    }
+
+    if (choices !== undefined && lineNumber in choices) {
+      const chosenId = choices[lineNumber]
+      if (chosenId) {
+        const chosenEf = await findEmissionFactorByIdForMatch(chosenId)
+        if (chosenEf) {
+          resolvedByLine.set(lineNumber, {
+            efId: chosenEf.importedId ?? chosenId,
+            efName:
+              getEmissionFactorFullName(
+                chosenEf.metaData.find((m) => m.language === locale) ??
+                  chosenEf.metaData[0] ?? { title: null, attribute: null, frontiere: null },
+              ) ||
+              (row.emissionFactorName ?? ''),
+            efValue: String(chosenEf.totalCo2),
+            efUnit: formatPrefixedUnitDisplayOptional(locale, chosenEf.customUnit ?? chosenEf.unit ?? undefined),
+          })
+        }
+      }
+      continue
+    }
+
+    const ef = await findEmissionFactorMatch(
+      row.emissionFactorId,
+      row.emissionFactorName,
+      row.emissionFactorValue,
+      row.emissionFactorUnit,
+      locale,
+      organizationId,
+      versionIds,
+    )
+
+    const hasSomeEfData = !!(row.emissionFactorId || row.emissionFactorName)
+
+    if (!ef) {
+      if (!resolvingChoices) {
+        if (hasSomeEfData) {
+          warnings.push({
+            type: 'efNotFound',
+            lineNumber,
+            sourceName: row.name,
+            searchedName: row.emissionFactorName,
+            searchedValue: row.emissionFactorValue,
+            searchedUnit: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
+          })
+        } else {
+          warnings.push({ type: 'efMissing', lineNumber, sourceName: row.name })
+        }
+      }
+    } else if (ef.matchType === EmissionFactorMatchType.NameAmbiguous) {
+      const tooMany = ef.candidates.length > MAX_FE_CANDIDATES
+      ambiguousRows.push({
+        lineNumber,
+        sourceName: row.name,
+        searchedName: row.emissionFactorName,
+        searchedValue: row.emissionFactorValue,
+        searchedUnit: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
+        tooMany,
+        candidates: tooMany
+          ? []
+          : ef.candidates.map((c) => ({
+              id: c.id,
+              foundTitle: c.foundTitle,
+              foundValue: c.foundValue,
+              foundUnit: formatPrefixedUnitDisplayOptional(locale, c.foundUnit),
+            })),
+      })
+    } else if (ef.matchType !== EmissionFactorMatchType.Exact) {
+      if (!resolvingChoices) {
+        warnings.push({
+          type: 'efNotFound',
+          lineNumber,
+          sourceName: row.name,
+          searchedName: row.emissionFactorName,
+          searchedValue: row.emissionFactorValue,
+          searchedUnit: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
+          foundTitle: ef.foundTitle,
+          foundValue: ef.foundValue,
+          foundUnit: formatPrefixedUnitDisplayOptional(locale, ef.foundUnit),
+        })
+      }
+      resolvedByLine.set(lineNumber, {
+        efId: ef.importedId ?? row.emissionFactorId ?? '',
+        efName: ef.foundTitle ?? row.emissionFactorName ?? '',
+        efValue: ef.foundValue !== undefined ? String(ef.foundValue) : '',
+        efUnit: formatPrefixedUnitDisplayOptional(locale, ef.foundUnit),
+      })
+    } else {
+      resolvedByLine.set(lineNumber, {
+        efId: ef.importedId ?? row.emissionFactorId ?? '',
+        efName: ef.foundTitle ?? row.emissionFactorName ?? '',
+        efValue: ef.foundValue !== undefined ? String(ef.foundValue) : '',
+        efUnit: formatPrefixedUnitDisplayOptional(locale, ef.foundUnit),
+      })
+    }
+  }
+
+  if (warnings.length > 0) {
+    return { success: 'warnings', warnings, ambiguousRows }
+  }
+
+  if (ambiguousRows.length > 0) {
+    return { success: 'ambiguous', rows: ambiguousRows }
+  }
+
   const bc = getBcTranslations(locale)
   const postTranslations = bc.emissionFactors.post as unknown as Record<string, string>
 
   const rows: PreviewEmissionSourceRow[] = result.rows.map((row) => {
     const post = getPost(row.subPost)
+    const resolved = resolvedByLine.get(row.lineNumber)
     return {
       site: row.siteName,
       post: post ? (postTranslations[post] ?? post) : '',
@@ -118,10 +254,11 @@ export async function previewEmissionSourcesFromFile(
       name: row.name,
       value: row.value !== undefined ? String(row.value) : '',
       unit: row.unit ?? '',
-      emissionFactorId: row.emissionFactorId ?? '',
-      emissionFactorName: row.emissionFactorName ?? '',
-      emissionFactorValue: row.emissionFactorValue !== undefined ? String(row.emissionFactorValue) : '',
-      emissionFactorUnit: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
+      emissionFactorId: resolved?.efId ?? row.emissionFactorId ?? '',
+      emissionFactorName: resolved?.efName ?? row.emissionFactorName ?? '',
+      emissionFactorValue:
+        resolved?.efValue ?? (row.emissionFactorValue !== undefined ? String(row.emissionFactorValue) : ''),
+      emissionFactorUnit: resolved?.efUnit ?? formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
     }
   })
 
@@ -131,7 +268,7 @@ export async function previewEmissionSourcesFromFile(
 export async function importEmissionSourcesFromFile(
   file: File,
   studyId: string,
-  forceImport = false,
+  choices?: FEChoices,
 ): Promise<ImportResult> {
   const account = await getAuthenticatedAccount()
 
@@ -151,90 +288,36 @@ export async function importEmissionSourcesFromFile(
   const organizationId = study.organizationVersion.organization?.id ?? ''
   const versionIds = study.emissionFactorVersions.map((v) => v.importVersionId)
 
-  const rowWarnings: ImportWarning[] = []
   const validRows: ValidImportRow[] = []
 
-  for (let i = 0; i < result.rows.length; i++) {
-    const row = result.rows[i]
+  for (const row of result.rows) {
     const lineNumber = row.lineNumber
-
-    if (
-      row.emissionFactorUnitRaw &&
-      row.emissionFactorUnit &&
-      row.emissionFactorUnit !== Unit.CUSTOM &&
-      !KG_CO2E_PREFIX_REGEX.test(row.emissionFactorUnitRaw)
-    ) {
-      rowWarnings.push({
-        type: 'unitMissingPrefix',
-        lineNumber,
-        sourceName: row.name,
-        foundUnit: row.emissionFactorUnitRaw,
-        resolvedValue: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
-      })
-    }
-
-    const ef = await findEmissionFactorMatch(
-      row.emissionFactorId,
-      row.emissionFactorName,
-      row.emissionFactorValue,
-      row.emissionFactorUnit,
-      locale,
-      organizationId,
-      versionIds,
-    )
-
-    const hasSomeEfData = !!(row.emissionFactorId || row.emissionFactorName)
 
     let emissionFactorId: string | undefined
     let efUnit: string | undefined
-    if (!ef) {
-      if (hasSomeEfData) {
-        rowWarnings.push({
-          type: 'efNotFound',
-          lineNumber,
-          sourceName: row.name,
-          searchedName: row.emissionFactorName,
-          searchedValue: row.emissionFactorValue,
-          searchedUnit: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
-        })
-      } else {
-        rowWarnings.push({
-          type: 'efMissing',
-          lineNumber,
-          sourceName: row.name,
-        })
+
+    if (choices !== undefined && lineNumber in choices) {
+      const chosenId = choices[lineNumber]
+      emissionFactorId = chosenId ?? undefined
+      if (emissionFactorId) {
+        const byId = await findEmissionFactorByIdForMatch(emissionFactorId)
+        efUnit = byId?.customUnit ?? byId?.unit ?? undefined
       }
-    } else if (ef.matchType === EmissionFactorMatchType.NameAmbiguous) {
-      rowWarnings.push({
-        type: 'efNotFound',
-        lineNumber,
-        sourceName: row.name,
-        searchedName: row.emissionFactorName,
-        searchedValue: row.emissionFactorValue,
-        searchedUnit: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
-        candidates: ef.candidates.map((c) => ({
-          foundTitle: c.foundTitle,
-          foundValue: c.foundValue,
-          foundUnit: formatPrefixedUnitDisplayOptional(locale, c.foundUnit),
-        })),
-      })
-    } else if (ef.matchType !== EmissionFactorMatchType.Exact) {
-      rowWarnings.push({
-        type: 'efNotFound',
-        lineNumber,
-        sourceName: row.name,
-        searchedName: row.emissionFactorName,
-        searchedValue: row.emissionFactorValue,
-        searchedUnit: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
-        foundTitle: ef.foundTitle,
-        foundValue: ef.foundValue,
-        foundUnit: formatPrefixedUnitDisplayOptional(locale, ef.foundUnit),
-      })
-      emissionFactorId = ef.id
-      efUnit = ef.foundUnit
     } else {
-      emissionFactorId = ef.id
-      efUnit = ef.foundUnit
+      const ef = await findEmissionFactorMatch(
+        row.emissionFactorId,
+        row.emissionFactorName,
+        row.emissionFactorValue,
+        row.emissionFactorUnit,
+        locale,
+        organizationId,
+        versionIds,
+      )
+
+      if (ef && ef.matchType !== EmissionFactorMatchType.NameAmbiguous) {
+        emissionFactorId = ef.id
+        efUnit = ef.foundUnit
+      }
     }
 
     let validated = row.validated
@@ -260,7 +343,6 @@ export async function importEmissionSourcesFromFile(
       )
       if (!canValidate) {
         validated = false
-        rowWarnings.push({ type: 'validationSkipped', lineNumber: lineNumber, sourceName: row.name })
       }
     }
 
@@ -302,10 +384,6 @@ export async function importEmissionSourcesFromFile(
       duration: casFields.duration ?? undefined,
       validated,
     })
-  }
-
-  if (rowWarnings.length > 0 && !forceImport) {
-    return { success: false, warnings: rowWarnings }
   }
 
   await createEmissionSourcesOnStudy(validRows)

--- a/apps/bilan-carbone/src/services/serverFunctions/importEmissionSources.ts
+++ b/apps/bilan-carbone/src/services/serverFunctions/importEmissionSources.ts
@@ -9,8 +9,9 @@ import { AccountWithUser } from '@/types/account.types'
 import { FEChoices, ImportResult } from '@/types/import.types'
 import {
   PreviewEmissionSourceRow,
-  PreviewEmissionSourcesResult,
+  ResolveEmissionSourcesResult,
   SOURCE_IMPORT_COLUMNS,
+  ValidateEmissionSourcesResult,
 } from '@/types/importEmissionSources.types'
 import { getEmissionFactorFullName, getEmissionFactorValue } from '@/utils/emissionFactors'
 import { EmissionFactorMatchType, findEmissionFactorMatch } from '@/utils/findEmissionFactor.utils'
@@ -90,11 +91,11 @@ async function getStudyOrThrow(studyId: string, account: AccountWithUser): Promi
   return study
 }
 
-export async function previewEmissionSourcesFromFile(
+// Parse the file and detect warnings/ambiguities before showing the preview
+export async function validateEmissionSourcesFromFile(
   file: File,
   studyId: string,
-  choices?: FEChoices,
-): Promise<PreviewEmissionSourcesResult> {
+): Promise<ValidateEmissionSourcesResult> {
   const account = await getAuthenticatedAccount()
 
   const study = await getStudyOrThrow(studyId, account)
@@ -107,7 +108,44 @@ export async function previewEmissionSourcesFromFile(
   const result = parseEmissionSourcesFile(buffer, locale, study.sites)
 
   if (!result.success) {
-    return result
+    return { status: 'error', errors: result.errors }
+  }
+
+  const organizationId = study.organizationVersion.organization?.id ?? ''
+  const versionIds = study.emissionFactorVersions.map((v) => v.importVersionId)
+
+  const resolved = await resolveEmissionFactorRows(result.rows, undefined, locale, organizationId, versionIds)
+
+  if (resolved.type === 'warnings') {
+    return { status: 'warnings', warnings: resolved.warnings, ambiguousRows: resolved.ambiguousRows }
+  }
+
+  if (resolved.type === 'ambiguous') {
+    return { status: 'ambiguous', rows: resolved.ambiguousRows }
+  }
+
+  return { status: 'ok' }
+}
+
+// Apply user choices and return the resolved preview rows
+export async function resolveEmissionSourcesFromFile(
+  file: File,
+  studyId: string,
+  choices: FEChoices,
+): Promise<ResolveEmissionSourcesResult> {
+  const account = await getAuthenticatedAccount()
+
+  const study = await getStudyOrThrow(studyId, account)
+  if (!(await hasStudyBasicRights(account, study))) {
+    throw new Error(NOT_AUTHORIZED)
+  }
+
+  const locale = await getLocale()
+  const buffer = Buffer.from(await file.arrayBuffer())
+  const result = parseEmissionSourcesFile(buffer, locale, study.sites)
+
+  if (!result.success) {
+    return { status: 'error', errors: result.errors }
   }
 
   const organizationId = study.organizationVersion.organization?.id ?? ''
@@ -115,20 +153,12 @@ export async function previewEmissionSourcesFromFile(
 
   const resolved = await resolveEmissionFactorRows(result.rows, choices, locale, organizationId, versionIds)
 
-  if (resolved.type === 'warnings') {
-    return { success: 'warnings', warnings: resolved.warnings, ambiguousRows: resolved.ambiguousRows }
-  }
-
-  if (resolved.type === 'ambiguous') {
-    return { success: 'ambiguous', rows: resolved.ambiguousRows }
-  }
-
   const bc = getBcTranslations(locale)
   const postTranslations = bc.emissionFactors.post as unknown as Record<string, string>
 
   const rows: PreviewEmissionSourceRow[] = result.rows.map((row) => {
     const post = getPost(row.subPost)
-    const ef = resolved.resolvedByLine.get(row.lineNumber)
+    const ef = resolved.type === 'resolved' ? resolved.resolvedByLine.get(row.lineNumber) : undefined
     return {
       site: row.siteName,
       post: post ? (postTranslations[post] ?? post) : '',
@@ -143,7 +173,7 @@ export async function previewEmissionSourcesFromFile(
     }
   })
 
-  return { success: true, rows }
+  return { status: 'ok', rows }
 }
 
 export async function importEmissionSourcesFromFile(

--- a/apps/bilan-carbone/src/services/serverFunctions/importEmissionSources.ts
+++ b/apps/bilan-carbone/src/services/serverFunctions/importEmissionSources.ts
@@ -91,7 +91,6 @@ async function getStudyOrThrow(studyId: string, account: AccountWithUser): Promi
   return study
 }
 
-// Parse the file and detect warnings/ambiguities before showing the preview
 export async function validateEmissionSourcesFromFile(
   file: File,
   studyId: string,

--- a/apps/bilan-carbone/src/services/serverFunctions/importEmissionSources.ts
+++ b/apps/bilan-carbone/src/services/serverFunctions/importEmissionSources.ts
@@ -49,7 +49,7 @@ import {
 } from '../uncertainty'
 import { getEmissionFactorsByIds } from './emissionFactor'
 
-type ValidImportRow = {
+type NewEmissionSourceRow = {
   studySiteId: string
   studyId: string
   subPost: SubPost
@@ -126,7 +126,7 @@ export async function validateEmissionSourcesFromFile(
   return { status: 'ok' }
 }
 
-// Apply user choices and return the resolved preview rows
+// Preview-only: parse the file, apply user choices, and return display rows without persisting anything
 export async function resolveEmissionSourcesFromFile(
   file: File,
   studyId: string,
@@ -175,6 +175,7 @@ export async function resolveEmissionSourcesFromFile(
   return { status: 'ok', rows }
 }
 
+// Final import: parse the file, apply choices, persist emission sources to the database
 export async function importEmissionSourcesFromFile(
   file: File,
   studyId: string,
@@ -198,7 +199,7 @@ export async function importEmissionSourcesFromFile(
   const organizationId = study.organizationVersion.organization?.id ?? ''
   const versionIds = study.emissionFactorVersions.map((v) => v.importVersionId)
 
-  const validRows: ValidImportRow[] = []
+  const newEmissionSourceRows: NewEmissionSourceRow[] = []
 
   for (const row of result.rows) {
     const lineNumber = row.lineNumber
@@ -270,7 +271,7 @@ export async function importEmissionSourcesFromFile(
     }
 
     const casFields = getHectareAndDuration(isCASSubPost(row.subPost, efUnit), row.value)
-    validRows.push({
+    newEmissionSourceRows.push({
       studySiteId: row.studySiteId,
       studyId,
       subPost: row.subPost,
@@ -296,7 +297,7 @@ export async function importEmissionSourcesFromFile(
     })
   }
 
-  await createEmissionSourcesOnStudy(validRows)
+  await createEmissionSourcesOnStudy(newEmissionSourceRows)
 
   return { success: true, errors: [], warnings: [] }
 }

--- a/apps/bilan-carbone/src/services/serverFunctions/importEmissionSources.ts
+++ b/apps/bilan-carbone/src/services/serverFunctions/importEmissionSources.ts
@@ -113,7 +113,7 @@ export async function validateEmissionSourcesFromFile(
   const organizationId = study.organizationVersion.organization?.id ?? ''
   const versionIds = study.emissionFactorVersions.map((v) => v.importVersionId)
 
-  const resolved = await resolveEmissionFactorRows(result.rows, undefined, locale, organizationId, versionIds)
+  const resolved = await resolveEmissionFactorRows(result.rows, {}, locale, organizationId, versionIds)
 
   if (resolved.type === 'warnings') {
     return { status: 'warnings', warnings: resolved.warnings, ambiguousRows: resolved.ambiguousRows }
@@ -178,7 +178,7 @@ export async function resolveEmissionSourcesFromFile(
 export async function importEmissionSourcesFromFile(
   file: File,
   studyId: string,
-  choices?: FEChoices,
+  choices: FEChoices,
 ): Promise<ImportResult> {
   const account = await getAuthenticatedAccount()
 
@@ -206,7 +206,7 @@ export async function importEmissionSourcesFromFile(
     let emissionFactorId: string | undefined
     let efUnit: string | undefined
 
-    if (choices !== undefined && lineNumber in choices) {
+    if (lineNumber in choices) {
       const chosenId = choices[lineNumber]
       emissionFactorId = chosenId ?? undefined
       if (emissionFactorId) {

--- a/apps/bilan-carbone/src/services/serverFunctions/importEmissionSources.ts
+++ b/apps/bilan-carbone/src/services/serverFunctions/importEmissionSources.ts
@@ -1,13 +1,12 @@
 'use server'
 
-import { KG_CO2E_PREFIX_REGEX } from '@/constants/import'
 import { EmissionFactorList, findEmissionFactorByIdForMatch } from '@/db/emissionFactors'
 import { createEmissionSourcesOnStudy } from '@/db/emissionSource'
 import { FullStudy, getStudyById } from '@/db/study'
 import { getLocale } from '@/i18n/locale'
 import { Post, subPostsByPost } from '@/services/posts'
 import { AccountWithUser } from '@/types/account.types'
-import { AmbiguousRow, FEChoices, ImportResult, ImportWarning } from '@/types/import.types'
+import { FEChoices, ImportResult } from '@/types/import.types'
 import {
   PreviewEmissionSourceRow,
   PreviewEmissionSourcesResult,
@@ -15,8 +14,12 @@ import {
 } from '@/types/importEmissionSources.types'
 import { getEmissionFactorFullName, getEmissionFactorValue } from '@/utils/emissionFactors'
 import { EmissionFactorMatchType, findEmissionFactorMatch } from '@/utils/findEmissionFactor.utils'
-import { formatPrefixedUnitDisplay, formatPrefixedUnitDisplayOptional } from '@/utils/import.utils'
-import { getImportEmissionSourcesTranslations, parseEmissionSourcesFile } from '@/utils/importEmissionSources.utils'
+import { formatPrefixedUnitDisplay } from '@/utils/import.utils'
+import {
+  getImportEmissionSourcesTranslations,
+  parseEmissionSourcesFile,
+  resolveEmissionFactorRows,
+} from '@/utils/importEmissionSources.utils'
 import { getPost } from '@/utils/post'
 import { withServerResponse } from '@/utils/serverResponse'
 import { formatEmissionValueForExport, isCASSubPost } from '@/utils/study'
@@ -71,7 +74,6 @@ type ValidImportRow = {
 
 const TOTAL_EXCEL_COLS = Object.keys(SOURCE_IMPORT_COLUMNS).length
 const CAS_DEFAULT_DURATION = 20
-const MAX_FE_CANDIDATES = 10
 
 function getHectareAndDuration(isCAS: boolean, value: number | undefined) {
   if (!isCAS || value == null) {
@@ -111,134 +113,14 @@ export async function previewEmissionSourcesFromFile(
   const organizationId = study.organizationVersion.organization?.id ?? ''
   const versionIds = study.emissionFactorVersions.map((v) => v.importVersionId)
 
-  const warnings: ImportWarning[] = []
-  const ambiguousRows: AmbiguousRow[] = []
-  const resolvingChoices = choices !== undefined
+  const resolved = await resolveEmissionFactorRows(result.rows, choices, locale, organizationId, versionIds)
 
-  type ResolvedEf = { efId: string; efName: string; efValue: string; efUnit: string }
-  const resolvedByLine = new Map<number, ResolvedEf>()
-
-  for (const row of result.rows) {
-    const lineNumber = row.lineNumber
-
-    if (
-      !resolvingChoices &&
-      row.emissionFactorUnitRaw &&
-      row.emissionFactorUnit &&
-      row.emissionFactorUnit !== Unit.CUSTOM &&
-      !KG_CO2E_PREFIX_REGEX.test(row.emissionFactorUnitRaw)
-    ) {
-      warnings.push({
-        type: 'unitMissingPrefix',
-        lineNumber,
-        sourceName: row.name,
-        foundUnit: row.emissionFactorUnitRaw,
-        resolvedValue: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
-      })
-    }
-
-    if (choices !== undefined && lineNumber in choices) {
-      const chosenId = choices[lineNumber]
-      if (chosenId) {
-        const chosenEf = await findEmissionFactorByIdForMatch(chosenId)
-        if (chosenEf) {
-          resolvedByLine.set(lineNumber, {
-            efId: chosenEf.importedId ?? chosenId,
-            efName:
-              getEmissionFactorFullName(
-                chosenEf.metaData.find((m) => m.language === locale) ??
-                  chosenEf.metaData[0] ?? { title: null, attribute: null, frontiere: null },
-              ) ||
-              (row.emissionFactorName ?? ''),
-            efValue: String(chosenEf.totalCo2),
-            efUnit: formatPrefixedUnitDisplayOptional(locale, chosenEf.customUnit ?? chosenEf.unit ?? undefined),
-          })
-        }
-      }
-      continue
-    }
-
-    const ef = await findEmissionFactorMatch(
-      row.emissionFactorId,
-      row.emissionFactorName,
-      row.emissionFactorValue,
-      row.emissionFactorUnit,
-      locale,
-      organizationId,
-      versionIds,
-    )
-
-    const hasSomeEfData = !!(row.emissionFactorId || row.emissionFactorName)
-
-    if (!ef) {
-      if (!resolvingChoices) {
-        if (hasSomeEfData) {
-          warnings.push({
-            type: 'efNotFound',
-            lineNumber,
-            sourceName: row.name,
-            searchedName: row.emissionFactorName,
-            searchedValue: row.emissionFactorValue,
-            searchedUnit: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
-          })
-        } else {
-          warnings.push({ type: 'efMissing', lineNumber, sourceName: row.name })
-        }
-      }
-    } else if (ef.matchType === EmissionFactorMatchType.NameAmbiguous) {
-      const tooMany = ef.candidates.length > MAX_FE_CANDIDATES
-      ambiguousRows.push({
-        lineNumber,
-        sourceName: row.name,
-        searchedName: row.emissionFactorName,
-        searchedValue: row.emissionFactorValue,
-        searchedUnit: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
-        tooMany,
-        candidates: tooMany
-          ? []
-          : ef.candidates.map((c) => ({
-              id: c.id,
-              foundTitle: c.foundTitle,
-              foundValue: c.foundValue,
-              foundUnit: formatPrefixedUnitDisplayOptional(locale, c.foundUnit),
-            })),
-      })
-    } else if (ef.matchType !== EmissionFactorMatchType.Exact) {
-      if (!resolvingChoices) {
-        warnings.push({
-          type: 'efNotFound',
-          lineNumber,
-          sourceName: row.name,
-          searchedName: row.emissionFactorName,
-          searchedValue: row.emissionFactorValue,
-          searchedUnit: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
-          foundTitle: ef.foundTitle,
-          foundValue: ef.foundValue,
-          foundUnit: formatPrefixedUnitDisplayOptional(locale, ef.foundUnit),
-        })
-      }
-      resolvedByLine.set(lineNumber, {
-        efId: ef.importedId ?? row.emissionFactorId ?? '',
-        efName: ef.foundTitle ?? row.emissionFactorName ?? '',
-        efValue: ef.foundValue !== undefined ? String(ef.foundValue) : '',
-        efUnit: formatPrefixedUnitDisplayOptional(locale, ef.foundUnit),
-      })
-    } else {
-      resolvedByLine.set(lineNumber, {
-        efId: ef.importedId ?? row.emissionFactorId ?? '',
-        efName: ef.foundTitle ?? row.emissionFactorName ?? '',
-        efValue: ef.foundValue !== undefined ? String(ef.foundValue) : '',
-        efUnit: formatPrefixedUnitDisplayOptional(locale, ef.foundUnit),
-      })
-    }
+  if (resolved.type === 'warnings') {
+    return { success: 'warnings', warnings: resolved.warnings, ambiguousRows: resolved.ambiguousRows }
   }
 
-  if (warnings.length > 0) {
-    return { success: 'warnings', warnings, ambiguousRows }
-  }
-
-  if (ambiguousRows.length > 0) {
-    return { success: 'ambiguous', rows: ambiguousRows }
+  if (resolved.type === 'ambiguous') {
+    return { success: 'ambiguous', rows: resolved.ambiguousRows }
   }
 
   const bc = getBcTranslations(locale)
@@ -246,7 +128,7 @@ export async function previewEmissionSourcesFromFile(
 
   const rows: PreviewEmissionSourceRow[] = result.rows.map((row) => {
     const post = getPost(row.subPost)
-    const resolved = resolvedByLine.get(row.lineNumber)
+    const ef = resolved.resolvedByLine.get(row.lineNumber)
     return {
       site: row.siteName,
       post: post ? (postTranslations[post] ?? post) : '',
@@ -254,11 +136,10 @@ export async function previewEmissionSourcesFromFile(
       name: row.name,
       value: row.value !== undefined ? String(row.value) : '',
       unit: row.unit ?? '',
-      emissionFactorId: resolved?.efId ?? row.emissionFactorId ?? '',
-      emissionFactorName: resolved?.efName ?? row.emissionFactorName ?? '',
-      emissionFactorValue:
-        resolved?.efValue ?? (row.emissionFactorValue !== undefined ? String(row.emissionFactorValue) : ''),
-      emissionFactorUnit: resolved?.efUnit ?? formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
+      emissionFactorId: ef?.efId ?? '',
+      emissionFactorName: ef?.efName ?? '',
+      emissionFactorValue: ef?.efValue ?? '',
+      emissionFactorUnit: ef?.efUnit ?? '',
     }
   })
 

--- a/apps/bilan-carbone/src/types/import.types.ts
+++ b/apps/bilan-carbone/src/types/import.types.ts
@@ -34,3 +34,5 @@ export type ImportWarning = {
 export type ImportError = { lineNumber: number | null; key: string; value?: string }
 
 export type ImportResult = { success: boolean; errors?: ImportError[]; warnings?: ImportWarning[] }
+
+export type Phase = 'idle' | 'warnings' | 'ambiguous' | 'preview' | 'error'

--- a/apps/bilan-carbone/src/types/import.types.ts
+++ b/apps/bilan-carbone/src/types/import.types.ts
@@ -18,7 +18,7 @@ export type AmbiguousRow = {
 export type FEChoices = Record<number, string | null>
 
 export type ImportWarning = {
-  type: 'efNotFound' | 'efMissing' | 'validationSkipped' | 'unitMissingPrefix'
+  type: 'efNotFound' | 'efMissingUnit' | 'efMissing' | 'validationSkipped' | 'unitMissingPrefix'
   lineNumber: number | null
   sourceName?: string
   searchedName?: string

--- a/apps/bilan-carbone/src/types/import.types.ts
+++ b/apps/bilan-carbone/src/types/import.types.ts
@@ -1,4 +1,21 @@
-export type ImportWarningCandidate = { foundTitle?: string; foundValue?: number; foundUnit?: string }
+export type ImportWarningCandidate = {
+  id: string
+  foundTitle?: string
+  foundValue?: number
+  foundUnit?: string
+}
+
+export type AmbiguousRow = {
+  lineNumber: number
+  sourceName?: string
+  searchedName?: string
+  searchedValue?: number
+  searchedUnit?: string
+  candidates: ImportWarningCandidate[]
+  tooMany?: boolean
+}
+
+export type FEChoices = Record<number, string | null>
 
 export type ImportWarning = {
   type: 'efNotFound' | 'efMissing' | 'validationSkipped' | 'unitMissingPrefix'

--- a/apps/bilan-carbone/src/types/importEmissionSources.types.ts
+++ b/apps/bilan-carbone/src/types/importEmissionSources.types.ts
@@ -19,11 +19,15 @@ export type PreviewEmissionSourceRow = {
   emissionFactorUnit: string
 }
 
-export type PreviewEmissionSourcesResult =
-  | { success: true; rows: PreviewEmissionSourceRow[] }
-  | { success: false; errors: ImportError[] }
-  | { success: 'warnings'; warnings: ImportWarning[]; ambiguousRows: AmbiguousRow[] }
-  | { success: 'ambiguous'; rows: AmbiguousRow[] }
+export type ValidateEmissionSourcesResult =
+  | { status: 'error'; errors: ImportError[] }
+  | { status: 'warnings'; warnings: ImportWarning[]; ambiguousRows: AmbiguousRow[] }
+  | { status: 'ambiguous'; rows: AmbiguousRow[] }
+  | { status: 'ok' }
+
+export type ResolveEmissionSourcesResult =
+  | { status: 'error'; errors: ImportError[] }
+  | { status: 'ok'; rows: PreviewEmissionSourceRow[] }
 
 export type ParsedEmissionSourceRow = {
   lineNumber: number

--- a/apps/bilan-carbone/src/types/importEmissionSources.types.ts
+++ b/apps/bilan-carbone/src/types/importEmissionSources.types.ts
@@ -4,7 +4,7 @@ import {
   SubPost,
   Unit,
 } from '@abc-transitionbascarbone/db-common/enums'
-import { ImportError } from './import.types'
+import { AmbiguousRow, ImportError, ImportWarning } from './import.types'
 
 export type PreviewEmissionSourceRow = {
   site: string
@@ -22,6 +22,8 @@ export type PreviewEmissionSourceRow = {
 export type PreviewEmissionSourcesResult =
   | { success: true; rows: PreviewEmissionSourceRow[] }
   | { success: false; errors: ImportError[] }
+  | { success: 'warnings'; warnings: ImportWarning[]; ambiguousRows: AmbiguousRow[] }
+  | { success: 'ambiguous'; rows: AmbiguousRow[] }
 
 export type ParsedEmissionSourceRow = {
   lineNumber: number

--- a/apps/bilan-carbone/src/utils/findEmissionFactor.utils.test.ts
+++ b/apps/bilan-carbone/src/utils/findEmissionFactor.utils.test.ts
@@ -119,7 +119,7 @@ describe('findEmissionFactorMatch', () => {
       expect(result).toMatchObject({ matchType: 'nameAndUnitOnly', id: 'ef-1' })
     })
 
-    it('returns nameOnly when single match and no value provided', async () => {
+    it('returns exact when single match and no value provided', async () => {
       const ef = makeEf('ef-1', 3.0, 'KG', 'Électricité')
       mockFindByNameAndUnit.mockResolvedValue([ef])
 
@@ -133,7 +133,7 @@ describe('findEmissionFactorMatch', () => {
         versionIds,
       )
 
-      expect(result).toMatchObject({ matchType: 'nameAndUnitOnly', id: 'ef-1' })
+      expect(result).toMatchObject({ matchType: 'exact', id: 'ef-1' })
     })
 
     it('returns nameAmbiguous when multiple matches by name+unit and value matches none', async () => {

--- a/apps/bilan-carbone/src/utils/findEmissionFactor.utils.test.ts
+++ b/apps/bilan-carbone/src/utils/findEmissionFactor.utils.test.ts
@@ -137,8 +137,8 @@ describe('findEmissionFactorMatch', () => {
     })
 
     it('returns nameAmbiguous when multiple matches by name+unit and value matches none', async () => {
-      const ef1 = makeEf('ef-1', 2.5, 'KG', 'Électricité')
-      const ef2 = makeEf('ef-2', 3.0, 'KG', 'Électricité')
+      const ef1 = makeEf('ef-1', 2.5, 'KG', 'Électricité', 'France')
+      const ef2 = makeEf('ef-2', 3.0, 'KG', 'Électricité', 'Allemagne')
       mockFindByNameAndUnit.mockResolvedValue([ef1, ef2])
 
       const result = await findEmissionFactorMatch(
@@ -236,6 +236,25 @@ describe('findEmissionFactorMatch', () => {
       )
 
       expect(result).toMatchObject({ matchType: 'exact', id: 'ef-3' })
+    })
+
+    it('returns exact when full name matches exactly despite multiple fuzzy candidates in byUnit pool', async () => {
+      mockFindByNameAndUnit.mockResolvedValue([])
+      const ef1 = makeEf('ef-1', 938, 'KG', 'Acier ou fer blanc', 'France')
+      const ef2 = makeEf('ef-2', 938, 'KG', 'Acier ou fer blanc', 'Allemagne')
+      mockFindByUnit.mockResolvedValue([ef1, ef2])
+
+      const result = await findEmissionFactorMatch(
+        undefined,
+        'Acier ou fer blanc - France',
+        undefined,
+        'KG',
+        locale,
+        organizationId,
+        versionIds,
+      )
+
+      expect(result).toMatchObject({ matchType: 'exact', id: 'ef-1' })
     })
 
     it('returns nameAmbiguous when fuzzy finds multiple candidates and value matches none', async () => {
@@ -367,7 +386,7 @@ describe('findEmissionFactorMatch', () => {
         versionIds,
       )
 
-      expect(result).toMatchObject({ matchType: 'nameAndUnitOnly', id: 'ef-1' })
+      expect(result).toMatchObject({ matchType: 'exact', id: 'ef-1' })
     })
 
     it('finds EF when import name is "title - attribute - frontiere" and returns full name as foundTitle', async () => {
@@ -387,7 +406,7 @@ describe('findEmissionFactorMatch', () => {
       )
 
       expect(result).toMatchObject({
-        matchType: 'nameAndUnitOnly',
+        matchType: 'exact',
         id: 'ef-1',
         foundTitle: 'Emballages - Acier - Stockage - Impacts',
       })
@@ -409,7 +428,7 @@ describe('findEmissionFactorMatch', () => {
         versionIds,
       )
 
-      expect(result).toMatchObject({ matchType: 'nameAndUnitOnly', id: 'ef-1' })
+      expect(result).toMatchObject({ matchType: 'exact', id: 'ef-1' })
     })
 
     it('matches despite extra spaces around dashes', async () => {
@@ -428,7 +447,7 @@ describe('findEmissionFactorMatch', () => {
         versionIds,
       )
 
-      expect(result).toMatchObject({ matchType: 'nameAndUnitOnly', id: 'ef-1' })
+      expect(result).toMatchObject({ matchType: 'exact', id: 'ef-1' })
     })
 
     it('still calls findEmissionFactorsByNameAndUnit once with raw trimmed title', async () => {

--- a/apps/bilan-carbone/src/utils/findEmissionFactor.utils.ts
+++ b/apps/bilan-carbone/src/utils/findEmissionFactor.utils.ts
@@ -24,6 +24,7 @@ type EfMatchResult =
         | EmissionFactorMatchType.ValueAndUnitOnly
       id: string
       importedId?: string | null
+      importedFrom?: string | null
       foundTitle?: string
       foundValue?: number
       foundUnit?: string
@@ -36,6 +37,7 @@ type EfMatchResult =
 export type EfRow = {
   id: string
   importedId?: string | null
+  importedFrom?: string | null
   totalCo2: number
   unit: string | null
   customUnit: string | null
@@ -65,6 +67,7 @@ function toEfMatch(
     matchType,
     id: ef.id,
     importedId: ef.importedId,
+    importedFrom: ef.importedFrom,
     foundTitle: getEfFullName(ef, locale) || undefined,
     foundValue: ef.totalCo2,
     foundUnit: ef.customUnit ?? ef.unit ?? undefined,
@@ -105,7 +108,9 @@ export async function findEmissionFactorMatch(
   }
 
   if (byNameAndUnit.length === 1) {
-    return toEfMatch(byNameAndUnit[0], EmissionFactorMatchType.NameAndUnitOnly, locale)
+    // If there is no value provided to compare, we consider it as an exact match
+    const matchType = value === undefined ? EmissionFactorMatchType.Exact : EmissionFactorMatchType.NameAndUnitOnly
+    return toEfMatch(byNameAndUnit[0], matchType, locale)
   }
 
   if (byNameAndUnit.length > 1 && title) {

--- a/apps/bilan-carbone/src/utils/findEmissionFactor.utils.ts
+++ b/apps/bilan-carbone/src/utils/findEmissionFactor.utils.ts
@@ -23,17 +23,19 @@ type EfMatchResult =
         | EmissionFactorMatchType.NameAndUnitOnly
         | EmissionFactorMatchType.ValueAndUnitOnly
       id: string
+      importedId?: string | null
       foundTitle?: string
       foundValue?: number
       foundUnit?: string
     }
   | {
       matchType: EmissionFactorMatchType.NameAmbiguous
-      candidates: { foundTitle?: string; foundValue?: number; foundUnit?: string }[]
+      candidates: { id: string; foundTitle?: string; foundValue?: number; foundUnit?: string }[]
     }
 
 export type EfRow = {
   id: string
+  importedId?: string | null
   totalCo2: number
   unit: string | null
   customUnit: string | null
@@ -51,6 +53,7 @@ function toEfMatch(
   return {
     matchType,
     id: ef.id,
+    importedId: ef.importedId,
     foundTitle:
       getEmissionFactorFullName(
         ef.metaData.find((m) => m.language === locale) ??

--- a/apps/bilan-carbone/src/utils/findEmissionFactor.utils.ts
+++ b/apps/bilan-carbone/src/utils/findEmissionFactor.utils.ts
@@ -42,6 +42,17 @@ export type EfRow = {
   metaData: { title: string | null; attribute: string | null; frontiere: string | null; language: string }[]
 }
 
+function getEfFullName(ef: EfRow, locale: string): string {
+  return getEmissionFactorFullName(
+    ef.metaData.find((m) => m.language === locale) ??
+      ef.metaData[0] ?? { title: null, attribute: null, frontiere: null },
+  )
+}
+
+function findExactFullNameMatch(efs: EfRow[], normalizedSearch: string, locale: string): EfRow | undefined {
+  return efs.find((ef) => normalizeStringForSearch(getEfFullName(ef, locale)) === normalizedSearch)
+}
+
 function toEfMatch(
   ef: EfRow,
   matchType:
@@ -54,11 +65,7 @@ function toEfMatch(
     matchType,
     id: ef.id,
     importedId: ef.importedId,
-    foundTitle:
-      getEmissionFactorFullName(
-        ef.metaData.find((m) => m.language === locale) ??
-          ef.metaData[0] ?? { title: null, attribute: null, frontiere: null },
-      ) || undefined,
+    foundTitle: getEfFullName(ef, locale) || undefined,
     foundValue: ef.totalCo2,
     foundUnit: ef.customUnit ?? ef.unit ?? undefined,
   }
@@ -101,6 +108,13 @@ export async function findEmissionFactorMatch(
     return toEfMatch(byNameAndUnit[0], EmissionFactorMatchType.NameAndUnitOnly, locale)
   }
 
+  if (byNameAndUnit.length > 1 && title) {
+    const exactFullName = findExactFullNameMatch(byNameAndUnit, normalizeStringForSearch(title), locale)
+    if (exactFullName) {
+      return toEfMatch(exactFullName, EmissionFactorMatchType.Exact, locale)
+    }
+  }
+
   if (byNameAndUnit.length > 1) {
     return {
       matchType: EmissionFactorMatchType.NameAmbiguous,
@@ -113,20 +127,22 @@ export async function findEmissionFactorMatch(
 
     if (title) {
       const normalizedSearch = normalizeStringForSearch(title)
+
+      const exactFullName = findExactFullNameMatch(byUnit, normalizedSearch, locale)
+      if (exactFullName) {
+        return toEfMatch(exactFullName, EmissionFactorMatchType.Exact, locale)
+      }
+
       const candidates = byUnit.map((ef) => ({
         ef,
-        normalizedFullName: normalizeStringForSearch(
-          getEmissionFactorFullName(
-            ef.metaData.find((m) => m.language === locale) ??
-              ef.metaData[0] ?? { title: null, attribute: null, frontiere: null },
-          ),
-        ),
+        normalizedFullName: normalizeStringForSearch(getEfFullName(ef, locale)),
       }))
 
       const fuse = new Fuse(candidates, {
         keys: ['normalizedFullName'],
         ...DEFAULT_FUZZY_OPTIONS,
       })
+
       const results = fuse.search(normalizedSearch)
 
       if (results.length === 1) {

--- a/apps/bilan-carbone/src/utils/importEmissionFactors.utils.test.ts
+++ b/apps/bilan-carbone/src/utils/importEmissionFactors.utils.test.ts
@@ -11,6 +11,10 @@ import {
   parsePostsAndSubPostsCell,
 } from './importEmissionFactors.utils'
 
+// TODO: ESM module issue with Jest. Remove these mocks when moving to Vitest
+jest.mock('../services/auth', () => ({ auth: jest.fn() }))
+jest.mock('next-intl/server', () => ({ getTranslations: jest.fn(() => (key: string) => key) }))
+
 // Ordered by COLUMNS index
 type RowInput = {
   name?: string

--- a/apps/bilan-carbone/src/utils/importEmissionSources.utils.test.ts
+++ b/apps/bilan-carbone/src/utils/importEmissionSources.utils.test.ts
@@ -379,7 +379,7 @@ describe('resolveEmissionFactorRows', () => {
       foundUnit: 'KG',
     })
 
-    const result = await resolveEmissionFactorRows([makeRow()], undefined, Locale.FR, ORG_ID, VERSION_IDS)
+    const result = await resolveEmissionFactorRows([makeRow()], {}, Locale.FR, ORG_ID, VERSION_IDS)
 
     expect(result.type).toBe('resolved')
     if (result.type === 'resolved') {
@@ -392,7 +392,7 @@ describe('resolveEmissionFactorRows', () => {
 
     const result = await resolveEmissionFactorRows(
       [makeRow({ emissionFactorName: '' })],
-      undefined,
+      {},
       Locale.FR,
       ORG_ID,
       VERSION_IDS,
@@ -407,7 +407,7 @@ describe('resolveEmissionFactorRows', () => {
   it('returns warnings with efMissingUnit when EF name present but no unit and no match', async () => {
     mockFindMatch.mockResolvedValue(null)
 
-    const result = await resolveEmissionFactorRows([makeRow()], undefined, Locale.FR, ORG_ID, VERSION_IDS)
+    const result = await resolveEmissionFactorRows([makeRow()], {}, Locale.FR, ORG_ID, VERSION_IDS)
 
     expect(result.type).toBe('warnings')
     if (result.type === 'warnings') {
@@ -420,7 +420,7 @@ describe('resolveEmissionFactorRows', () => {
 
     const result = await resolveEmissionFactorRows(
       [makeRow({ emissionFactorUnit: Unit.KG })],
-      undefined,
+      {},
       Locale.FR,
       ORG_ID,
       VERSION_IDS,
@@ -442,7 +442,7 @@ describe('resolveEmissionFactorRows', () => {
       foundUnit: 'KG',
     })
 
-    const result = await resolveEmissionFactorRows([makeRow()], undefined, Locale.FR, ORG_ID, VERSION_IDS)
+    const result = await resolveEmissionFactorRows([makeRow()], {}, Locale.FR, ORG_ID, VERSION_IDS)
 
     expect(result.type).toBe('warnings')
     if (result.type === 'warnings') {
@@ -460,7 +460,7 @@ describe('resolveEmissionFactorRows', () => {
       ],
     })
 
-    const result = await resolveEmissionFactorRows([makeRow()], undefined, Locale.FR, ORG_ID, VERSION_IDS)
+    const result = await resolveEmissionFactorRows([makeRow()], {}, Locale.FR, ORG_ID, VERSION_IDS)
 
     expect(result.type).toBe('ambiguous')
     if (result.type === 'ambiguous') {
@@ -480,7 +480,7 @@ describe('resolveEmissionFactorRows', () => {
       })),
     })
 
-    const result = await resolveEmissionFactorRows([makeRow()], undefined, Locale.FR, ORG_ID, VERSION_IDS)
+    const result = await resolveEmissionFactorRows([makeRow()], {}, Locale.FR, ORG_ID, VERSION_IDS)
 
     expect(result.type).toBe('ambiguous')
     if (result.type === 'ambiguous') {
@@ -500,7 +500,7 @@ describe('resolveEmissionFactorRows', () => {
 
     const result = await resolveEmissionFactorRows(
       [makeRow({ emissionFactorUnit: Unit.TON, emissionFactorUnitRaw: 'tonne' })],
-      undefined,
+      {},
       Locale.FR,
       ORG_ID,
       VERSION_IDS,

--- a/apps/bilan-carbone/src/utils/importEmissionSources.utils.test.ts
+++ b/apps/bilan-carbone/src/utils/importEmissionSources.utils.test.ts
@@ -1,3 +1,5 @@
+import { findEmissionFactorByIdForMatch } from '@/db/emissionFactors'
+import { Locale } from '@/i18n/config'
 import { SOURCE_IMPORT_COLUMNS } from '@/types/importEmissionSources.types'
 import {
   EmissionSourceCaracterisation,
@@ -5,9 +7,32 @@ import {
   SubPost,
   Unit,
 } from '@abc-transitionbascarbone/db-common/enums'
-import { Locale } from '@abc-transitionbascarbone/i18n/config'
 import xlsx from 'node-xlsx'
-import { parseEmissionSourcesFile, SOURCE_IMPORT_HEADER_ROW_INDEX } from './importEmissionSources.utils'
+import { EmissionFactorMatchType, findEmissionFactorMatch } from './findEmissionFactor.utils'
+import {
+  parseEmissionSourcesFile,
+  resolveEmissionFactorRows,
+  SOURCE_IMPORT_HEADER_ROW_INDEX,
+} from './importEmissionSources.utils'
+
+jest.mock('@/db/emissionFactors', () => ({
+  findEmissionFactorByIdForMatch: jest.fn(),
+  findEmissionFactorsByNameAndUnit: jest.fn(),
+  findEmissionFactorsByUnit: jest.fn(),
+  findEmissionFactorByImportedIdForMatch: jest.fn(),
+}))
+jest.mock('./findEmissionFactor.utils', () => ({
+  EmissionFactorMatchType: {
+    Exact: 'exact',
+    NameAndUnitOnly: 'nameAndUnitOnly',
+    ValueAndUnitOnly: 'valueAndUnitOnly',
+    NameAmbiguous: 'nameAmbiguous',
+  },
+  findEmissionFactorMatch: jest.fn(),
+}))
+
+const mockFindMatch = findEmissionFactorMatch as jest.Mock
+const mockFindById = findEmissionFactorByIdForMatch as jest.Mock
 
 const TEST_STUDY_SITES = [
   { id: 'study-site-a', site: { name: 'Site principal' } },
@@ -301,5 +326,205 @@ describe('parseEmissionSourcesFile', () => {
         expect(result.errors.some((e) => e.key === 'invalidUnit')).toBe(false)
       }
     })
+  })
+})
+
+const ORG_ID = 'org-1'
+const VERSION_IDS = ['v-1']
+
+const makeRow = (overrides: Partial<(typeof TEST_STUDY_SITES)[0]> & Record<string, unknown> = {}) =>
+  ({
+    lineNumber: 5,
+    studySiteId: 'study-site-a',
+    siteName: 'Site principal',
+    subPost: 'CombustiblesFossiles',
+    name: 'Ma source',
+    unit: undefined,
+    emissionFactorId: undefined,
+    emissionFactorName: 'Acier',
+    emissionFactorValue: undefined,
+    emissionFactorUnit: undefined,
+    emissionFactorUnitRaw: undefined,
+    value: undefined,
+    type: undefined,
+    caracterisation: undefined,
+    tag: undefined,
+    source: undefined,
+    reliability: undefined,
+    technicalRepresentativeness: undefined,
+    geographicRepresentativeness: undefined,
+    temporalRepresentativeness: undefined,
+    completeness: undefined,
+    comment: undefined,
+    feComment: undefined,
+    validated: undefined,
+    depreciationPeriod: undefined,
+    constructionYear: undefined,
+    ...overrides,
+  }) as Parameters<typeof resolveEmissionFactorRows>[0][number]
+
+describe('resolveEmissionFactorRows', () => {
+  beforeEach(() => {
+    mockFindMatch.mockReset()
+    mockFindById.mockReset()
+  })
+
+  it('returns resolved with efId/efName from exact match', async () => {
+    mockFindMatch.mockResolvedValue({
+      matchType: EmissionFactorMatchType.Exact,
+      id: 'prisma-1',
+      importedId: 'imported-1',
+      foundTitle: 'Acier recyclé',
+      foundValue: 2.5,
+      foundUnit: 'KG',
+    })
+
+    const result = await resolveEmissionFactorRows([makeRow()], undefined, Locale.FR, ORG_ID, VERSION_IDS)
+
+    expect(result.type).toBe('resolved')
+    if (result.type === 'resolved') {
+      expect(result.resolvedByLine.get(5)).toMatchObject({ efId: 'imported-1', efName: 'Acier recyclé' })
+    }
+  })
+
+  it('returns warnings with efMissing when no EF data and no match', async () => {
+    mockFindMatch.mockResolvedValue(null)
+
+    const result = await resolveEmissionFactorRows(
+      [makeRow({ emissionFactorName: '' })],
+      undefined,
+      Locale.FR,
+      ORG_ID,
+      VERSION_IDS,
+    )
+
+    expect(result.type).toBe('warnings')
+    if (result.type === 'warnings') {
+      expect(result.warnings[0]).toMatchObject({ type: 'efMissing', lineNumber: 5 })
+    }
+  })
+
+  it('returns warnings with efNotFound when EF data present but no match', async () => {
+    mockFindMatch.mockResolvedValue(null)
+
+    const result = await resolveEmissionFactorRows([makeRow()], undefined, Locale.FR, ORG_ID, VERSION_IDS)
+
+    expect(result.type).toBe('warnings')
+    if (result.type === 'warnings') {
+      expect(result.warnings[0]).toMatchObject({ type: 'efNotFound', lineNumber: 5 })
+    }
+  })
+
+  it('returns warnings with efNotFound and resolved when approximate match', async () => {
+    mockFindMatch.mockResolvedValue({
+      matchType: EmissionFactorMatchType.NameAndUnitOnly,
+      id: 'prisma-1',
+      importedId: 'imported-1',
+      foundTitle: 'Acier approx',
+      foundValue: 3,
+      foundUnit: 'KG',
+    })
+
+    const result = await resolveEmissionFactorRows([makeRow()], undefined, Locale.FR, ORG_ID, VERSION_IDS)
+
+    expect(result.type).toBe('warnings')
+    if (result.type === 'warnings') {
+      expect(result.warnings[0]).toMatchObject({ type: 'efNotFound', foundTitle: 'Acier approx' })
+      expect(result.ambiguousRows).toHaveLength(0)
+    }
+  })
+
+  it('returns ambiguous when NameAmbiguous and candidates <= MAX', async () => {
+    mockFindMatch.mockResolvedValue({
+      matchType: EmissionFactorMatchType.NameAmbiguous,
+      candidates: [
+        { id: 'ef-1', foundTitle: 'Acier A', foundValue: 2, foundUnit: 'KG' },
+        { id: 'ef-2', foundTitle: 'Acier B', foundValue: 3, foundUnit: 'KG' },
+      ],
+    })
+
+    const result = await resolveEmissionFactorRows([makeRow()], undefined, Locale.FR, ORG_ID, VERSION_IDS)
+
+    expect(result.type).toBe('ambiguous')
+    if (result.type === 'ambiguous') {
+      expect(result.ambiguousRows[0]).toMatchObject({ lineNumber: 5, tooMany: false })
+      expect(result.ambiguousRows[0].candidates).toHaveLength(2)
+    }
+  })
+
+  it('sets tooMany and empties candidates when > 10 candidates', async () => {
+    mockFindMatch.mockResolvedValue({
+      matchType: EmissionFactorMatchType.NameAmbiguous,
+      candidates: Array.from({ length: 11 }, (_, i) => ({
+        id: `ef-${i}`,
+        foundTitle: `FE ${i}`,
+        foundValue: i,
+        foundUnit: 'KG',
+      })),
+    })
+
+    const result = await resolveEmissionFactorRows([makeRow()], undefined, Locale.FR, ORG_ID, VERSION_IDS)
+
+    expect(result.type).toBe('ambiguous')
+    if (result.type === 'ambiguous') {
+      expect(result.ambiguousRows[0]).toMatchObject({ tooMany: true, candidates: [] })
+    }
+  })
+
+  it('returns warnings with unitMissingPrefix when unit has no kgCO2e/ prefix', async () => {
+    mockFindMatch.mockResolvedValue({
+      matchType: EmissionFactorMatchType.Exact,
+      id: 'prisma-1',
+      importedId: 'imported-1',
+      foundTitle: 'Acier',
+      foundValue: 2,
+      foundUnit: 'KG',
+    })
+
+    const result = await resolveEmissionFactorRows(
+      [makeRow({ emissionFactorUnit: Unit.TON, emissionFactorUnitRaw: 'tonne' })],
+      undefined,
+      Locale.FR,
+      ORG_ID,
+      VERSION_IDS,
+    )
+
+    expect(result.type).toBe('warnings')
+    if (result.type === 'warnings') {
+      expect(result.warnings[0]).toMatchObject({ type: 'unitMissingPrefix', foundUnit: 'tonne' })
+    }
+  })
+
+  it('skips findEmissionFactorMatch and uses chosen EF when choices provided', async () => {
+    mockFindById.mockResolvedValue({
+      id: 'prisma-1',
+      importedId: 'imported-1',
+      totalCo2: 4.2,
+      unit: 'KG',
+      customUnit: null,
+      metaData: [{ title: 'Acier choisi', attribute: null, frontiere: null, language: 'fr' }],
+    })
+
+    const result = await resolveEmissionFactorRows([makeRow()], { 5: 'prisma-1' }, Locale.FR, ORG_ID, VERSION_IDS)
+
+    expect(mockFindMatch).not.toHaveBeenCalled()
+    expect(result.type).toBe('resolved')
+    if (result.type === 'resolved') {
+      expect(result.resolvedByLine.get(5)).toMatchObject({ efId: 'imported-1', efName: 'Acier choisi', efValue: '4.2' })
+    }
+  })
+
+  it('does not generate warnings when resolvingChoices, even for lines not in choices', async () => {
+    mockFindMatch.mockResolvedValue(null)
+
+    const result = await resolveEmissionFactorRows(
+      [makeRow({ lineNumber: 5 }), makeRow({ lineNumber: 6 })],
+      { 5: null },
+      Locale.FR,
+      ORG_ID,
+      VERSION_IDS,
+    )
+
+    expect(result.type).toBe('resolved')
   })
 })

--- a/apps/bilan-carbone/src/utils/importEmissionSources.utils.test.ts
+++ b/apps/bilan-carbone/src/utils/importEmissionSources.utils.test.ts
@@ -1,5 +1,4 @@
 import { findEmissionFactorByIdForMatch } from '@/db/emissionFactors'
-import { Locale } from '@/i18n/config'
 import { SOURCE_IMPORT_COLUMNS } from '@/types/importEmissionSources.types'
 import {
   EmissionSourceCaracterisation,
@@ -7,6 +6,7 @@ import {
   SubPost,
   Unit,
 } from '@abc-transitionbascarbone/db-common/enums'
+import { Locale } from '@abc-transitionbascarbone/i18n/config'
 import xlsx from 'node-xlsx'
 import { EmissionFactorMatchType, findEmissionFactorMatch } from './findEmissionFactor.utils'
 import {

--- a/apps/bilan-carbone/src/utils/importEmissionSources.utils.test.ts
+++ b/apps/bilan-carbone/src/utils/importEmissionSources.utils.test.ts
@@ -404,10 +404,27 @@ describe('resolveEmissionFactorRows', () => {
     }
   })
 
-  it('returns warnings with efNotFound when EF data present but no match', async () => {
+  it('returns warnings with efMissingUnit when EF name present but no unit and no match', async () => {
     mockFindMatch.mockResolvedValue(null)
 
     const result = await resolveEmissionFactorRows([makeRow()], undefined, Locale.FR, ORG_ID, VERSION_IDS)
+
+    expect(result.type).toBe('warnings')
+    if (result.type === 'warnings') {
+      expect(result.warnings[0]).toMatchObject({ type: 'efMissingUnit', lineNumber: 5 })
+    }
+  })
+
+  it('returns warnings with efNotFound when EF name and unit present but no match', async () => {
+    mockFindMatch.mockResolvedValue(null)
+
+    const result = await resolveEmissionFactorRows(
+      [makeRow({ emissionFactorUnit: Unit.KG })],
+      undefined,
+      Locale.FR,
+      ORG_ID,
+      VERSION_IDS,
+    )
 
     expect(result.type).toBe('warnings')
     if (result.type === 'warnings') {

--- a/apps/bilan-carbone/src/utils/importEmissionSources.utils.ts
+++ b/apps/bilan-carbone/src/utils/importEmissionSources.utils.ts
@@ -353,6 +353,7 @@ function collectWarningsAndAmbiguities(
   }
 }
 
+// Match each row to an emission factor: use choices if provided, otherwise auto-match and collect warnings/ambiguities
 export async function resolveEmissionFactorRows(
   rows: ParsedEmissionSourceRow[],
   choices: FEChoices,

--- a/apps/bilan-carbone/src/utils/importEmissionSources.utils.ts
+++ b/apps/bilan-carbone/src/utils/importEmissionSources.utils.ts
@@ -6,6 +6,7 @@ import { ParsedEmissionSourceRow, SOURCE_IMPORT_COLUMNS } from '@/types/importEm
 import {
   EmissionSourceCaracterisation,
   EmissionSourceType,
+  Import,
   SubPost,
   Unit,
 } from '@abc-transitionbascarbone/db-common/enums'
@@ -373,7 +374,7 @@ export async function resolveEmissionFactorRows(
         const chosenEf = await findEmissionFactorByIdForMatch(chosenId)
         if (chosenEf) {
           resolvedByLine.set(lineNumber, {
-            efId: chosenEf.importedId ?? chosenId,
+            efId: chosenEf.importedFrom === Import.Manual ? '' : (chosenEf.importedId ?? ''),
             efName:
               getEmissionFactorFullName(
                 chosenEf.metaData.find((m) => m.language === locale) ??
@@ -404,7 +405,7 @@ export async function resolveEmissionFactorRows(
 
     if (ef && ef.matchType !== EmissionFactorMatchType.NameAmbiguous) {
       resolvedByLine.set(lineNumber, {
-        efId: ef.importedId ?? '',
+        efId: ef.importedFrom === 'Manual' ? '' : (ef.importedId ?? ''),
         efName: ef.foundTitle ?? '',
         efValue: String(ef.foundValue),
         efUnit: formatPrefixedUnitDisplayOptional(locale, ef.foundUnit),

--- a/apps/bilan-carbone/src/utils/importEmissionSources.utils.ts
+++ b/apps/bilan-carbone/src/utils/importEmissionSources.utils.ts
@@ -301,8 +301,9 @@ function collectWarningsAndAmbiguities(
   if (!ef) {
     const hasSomeEfData = !!(row.emissionFactorId || row.emissionFactorName)
     if (hasSomeEfData) {
+      const missingUnit = !!row.emissionFactorName && !row.emissionFactorUnit
       warnings.push({
-        type: 'efNotFound',
+        type: missingUnit ? 'efMissingUnit' : 'efNotFound',
         lineNumber,
         sourceName: row.name,
         searchedName: row.emissionFactorName,

--- a/apps/bilan-carbone/src/utils/importEmissionSources.utils.ts
+++ b/apps/bilan-carbone/src/utils/importEmissionSources.utils.ts
@@ -1,6 +1,5 @@
 import { KG_CO2E_PREFIX_REGEX } from '@/constants/import'
 import { findEmissionFactorByIdForMatch } from '@/db/emissionFactors'
-import { Locale, LocaleType } from '@/i18n/config'
 import { qualityKeys } from '@/services/uncertainty'
 import { AmbiguousRow, FEChoices, ImportError, ImportWarning } from '@/types/import.types'
 import { ParsedEmissionSourceRow, SOURCE_IMPORT_COLUMNS } from '@/types/importEmissionSources.types'
@@ -10,6 +9,7 @@ import {
   SubPost,
   Unit,
 } from '@abc-transitionbascarbone/db-common/enums'
+import { Locale, LocaleType } from '@abc-transitionbascarbone/i18n/config'
 import { getEmissionFactorFullName } from './emissionFactors'
 import { parseExcelSheet } from './excel.utils'
 import { EmissionFactorMatchType, findEmissionFactorMatch } from './findEmissionFactor.utils'

--- a/apps/bilan-carbone/src/utils/importEmissionSources.utils.ts
+++ b/apps/bilan-carbone/src/utils/importEmissionSources.utils.ts
@@ -1,6 +1,8 @@
 import { KG_CO2E_PREFIX_REGEX } from '@/constants/import'
+import { findEmissionFactorByIdForMatch } from '@/db/emissionFactors'
+import { Locale, LocaleType } from '@/i18n/config'
 import { qualityKeys } from '@/services/uncertainty'
-import { ImportError } from '@/types/import.types'
+import { AmbiguousRow, FEChoices, ImportError, ImportWarning } from '@/types/import.types'
 import { ParsedEmissionSourceRow, SOURCE_IMPORT_COLUMNS } from '@/types/importEmissionSources.types'
 import {
   EmissionSourceCaracterisation,
@@ -8,10 +10,12 @@ import {
   SubPost,
   Unit,
 } from '@abc-transitionbascarbone/db-common/enums'
-import { Locale, LocaleType } from '@abc-transitionbascarbone/i18n/config'
+import { getEmissionFactorFullName } from './emissionFactors'
 import { parseExcelSheet } from './excel.utils'
+import { EmissionFactorMatchType, findEmissionFactorMatch } from './findEmissionFactor.utils'
 import {
   buildLabelMap,
+  formatPrefixedUnitDisplayOptional,
   matchLabelFromMap,
   matchLabelFromTranslations,
   matchUnitLabelFromTranslations,
@@ -20,6 +24,7 @@ import { parseNumericValue } from './number'
 import { getBcTranslations, getCommonTranslations } from './translation.utils'
 
 export const SOURCE_IMPORT_HEADER_ROW_INDEX = 9
+const MAX_FE_CANDIDATES = 10
 
 type StudySiteForImport = { id: string; site: { name: string } | null }
 
@@ -253,4 +258,149 @@ export function parseEmissionSourcesFile(
   }
 
   return { success: true, rows: parsedRows }
+}
+
+type ResolvedEf = { efId: string; efName: string; efValue: string; efUnit: string }
+
+export type ResolveEfRowsResult =
+  | { type: 'warnings'; warnings: ImportWarning[]; ambiguousRows: AmbiguousRow[] }
+  | { type: 'ambiguous'; ambiguousRows: AmbiguousRow[] }
+  | { type: 'resolved'; resolvedByLine: Map<number, ResolvedEf> }
+
+export async function resolveEmissionFactorRows(
+  rows: ParsedEmissionSourceRow[],
+  choices: FEChoices | undefined,
+  locale: LocaleType,
+  organizationId: string,
+  versionIds: string[],
+): Promise<ResolveEfRowsResult> {
+  const resolvingChoices = choices !== undefined
+  const warnings: ImportWarning[] = []
+  const ambiguousRows: AmbiguousRow[] = []
+  const resolvedByLine = new Map<number, ResolvedEf>()
+
+  for (const row of rows) {
+    const lineNumber = row.lineNumber
+
+    if (
+      !resolvingChoices &&
+      row.emissionFactorUnitRaw &&
+      row.emissionFactorUnit &&
+      row.emissionFactorUnit !== Unit.CUSTOM &&
+      !KG_CO2E_PREFIX_REGEX.test(row.emissionFactorUnitRaw)
+    ) {
+      warnings.push({
+        type: 'unitMissingPrefix',
+        lineNumber,
+        sourceName: row.name,
+        foundUnit: row.emissionFactorUnitRaw,
+        resolvedValue: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
+      })
+    }
+
+    if (choices !== undefined && lineNumber in choices) {
+      const chosenId = choices[lineNumber]
+      if (chosenId) {
+        const chosenEf = await findEmissionFactorByIdForMatch(chosenId)
+        if (chosenEf) {
+          resolvedByLine.set(lineNumber, {
+            efId: chosenEf.importedId ?? chosenId,
+            efName:
+              getEmissionFactorFullName(
+                chosenEf.metaData.find((m) => m.language === locale) ??
+                  chosenEf.metaData[0] ?? { title: null, attribute: null, frontiere: null },
+              ) ||
+              (row.emissionFactorName ?? ''),
+            efValue: String(chosenEf.totalCo2),
+            efUnit: formatPrefixedUnitDisplayOptional(locale, chosenEf.customUnit ?? chosenEf.unit ?? undefined),
+          })
+        }
+      }
+      continue
+    }
+
+    const ef = await findEmissionFactorMatch(
+      row.emissionFactorId,
+      row.emissionFactorName,
+      row.emissionFactorValue,
+      row.emissionFactorUnit,
+      locale,
+      organizationId,
+      versionIds,
+    )
+
+    const hasSomeEfData = !!(row.emissionFactorId || row.emissionFactorName)
+
+    if (!ef) {
+      if (!resolvingChoices) {
+        if (hasSomeEfData) {
+          warnings.push({
+            type: 'efNotFound',
+            lineNumber,
+            sourceName: row.name,
+            searchedName: row.emissionFactorName,
+            searchedValue: row.emissionFactorValue,
+            searchedUnit: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
+          })
+        } else {
+          warnings.push({ type: 'efMissing', lineNumber, sourceName: row.name })
+        }
+      }
+    } else if (ef.matchType === EmissionFactorMatchType.NameAmbiguous) {
+      const tooMany = ef.candidates.length > MAX_FE_CANDIDATES
+      ambiguousRows.push({
+        lineNumber,
+        sourceName: row.name,
+        searchedName: row.emissionFactorName,
+        searchedValue: row.emissionFactorValue,
+        searchedUnit: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
+        tooMany,
+        candidates: tooMany
+          ? []
+          : ef.candidates.map((c) => ({
+              id: c.id,
+              foundTitle: c.foundTitle,
+              foundValue: c.foundValue,
+              foundUnit: formatPrefixedUnitDisplayOptional(locale, c.foundUnit),
+            })),
+      })
+    } else if (ef.matchType !== EmissionFactorMatchType.Exact) {
+      if (!resolvingChoices) {
+        warnings.push({
+          type: 'efNotFound',
+          lineNumber,
+          sourceName: row.name,
+          searchedName: row.emissionFactorName,
+          searchedValue: row.emissionFactorValue,
+          searchedUnit: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
+          foundTitle: ef.foundTitle,
+          foundValue: ef.foundValue,
+          foundUnit: formatPrefixedUnitDisplayOptional(locale, ef.foundUnit),
+        })
+      }
+      resolvedByLine.set(lineNumber, {
+        efId: ef.importedId ?? row.emissionFactorId ?? '',
+        efName: ef.foundTitle ?? row.emissionFactorName ?? '',
+        efValue: ef.foundValue !== undefined ? String(ef.foundValue) : '',
+        efUnit: formatPrefixedUnitDisplayOptional(locale, ef.foundUnit),
+      })
+    } else {
+      resolvedByLine.set(lineNumber, {
+        efId: ef.importedId ?? row.emissionFactorId ?? '',
+        efName: ef.foundTitle ?? row.emissionFactorName ?? '',
+        efValue: ef.foundValue !== undefined ? String(ef.foundValue) : '',
+        efUnit: formatPrefixedUnitDisplayOptional(locale, ef.foundUnit),
+      })
+    }
+  }
+
+  if (warnings.length > 0) {
+    return { type: 'warnings', warnings, ambiguousRows }
+  }
+
+  if (ambiguousRows.length > 0) {
+    return { type: 'ambiguous', ambiguousRows }
+  }
+
+  return { type: 'resolved', resolvedByLine }
 }

--- a/apps/bilan-carbone/src/utils/importEmissionSources.utils.ts
+++ b/apps/bilan-carbone/src/utils/importEmissionSources.utils.ts
@@ -355,12 +355,12 @@ function collectWarningsAndAmbiguities(
 
 export async function resolveEmissionFactorRows(
   rows: ParsedEmissionSourceRow[],
-  choices: FEChoices | undefined,
+  choices: FEChoices,
   locale: LocaleType,
   organizationId: string,
   versionIds: string[],
 ): Promise<ResolveEfRowsResult> {
-  const resolvingChoices = choices !== undefined
+  const hasChoices = Object.keys(choices).length > 0
   const warnings: ImportWarning[] = []
   const ambiguousRows: AmbiguousRow[] = []
   const resolvedByLine = new Map<number, ResolvedEf>()
@@ -368,7 +368,7 @@ export async function resolveEmissionFactorRows(
   for (const row of rows) {
     const lineNumber = row.lineNumber
 
-    if (choices !== undefined && lineNumber in choices) {
+    if (lineNumber in choices) {
       const chosenId = choices[lineNumber]
       if (chosenId) {
         const chosenEf = await findEmissionFactorByIdForMatch(chosenId)
@@ -399,13 +399,13 @@ export async function resolveEmissionFactorRows(
       versionIds,
     )
 
-    if (!resolvingChoices) {
+    if (!hasChoices) {
       collectWarningsAndAmbiguities(row, ef, warnings, ambiguousRows, locale)
     }
 
     if (ef && ef.matchType !== EmissionFactorMatchType.NameAmbiguous) {
       resolvedByLine.set(lineNumber, {
-        efId: ef.importedFrom === 'Manual' ? '' : (ef.importedId ?? ''),
+        efId: ef.importedFrom === Import.Manual ? '' : (ef.importedId ?? ''),
         efName: ef.foundTitle ?? '',
         efValue: String(ef.foundValue),
         efUnit: formatPrefixedUnitDisplayOptional(locale, ef.foundUnit),

--- a/apps/bilan-carbone/src/utils/importEmissionSources.utils.ts
+++ b/apps/bilan-carbone/src/utils/importEmissionSources.utils.ts
@@ -40,7 +40,7 @@ export function getExampleRowPrefixes(): string[] {
   })
 }
 
-function resolveStudySiteId(siteName: string, sites: StudySiteForImport[]): string | null {
+function buildStudySiteNameMap(sites: StudySiteForImport[]): Record<string, string> {
   const map: Record<string, string> = {}
   for (const studySite of sites) {
     const name = studySite.site?.name
@@ -48,7 +48,11 @@ function resolveStudySiteId(siteName: string, sites: StudySiteForImport[]): stri
       map[name.toLowerCase()] = studySite.id
     }
   }
-  return matchLabelFromMap(siteName, map)
+  return map
+}
+
+function resolveStudySiteId(siteName: string, siteMap: Record<string, string>): string | null {
+  return matchLabelFromMap(siteName, siteMap)
 }
 
 function matchTypeLabelFromTranslations(
@@ -143,6 +147,7 @@ export function parseEmissionSourcesFile(
   const errors: ImportError[] = []
   const parsedRows: ParsedEmissionSourceRow[] = []
   const exampleRowPrefixes = getExampleRowPrefixes()
+  const studySiteNameMap = buildStudySiteNameMap(studySites)
 
   for (let i = 0; i < dataRows.length; i++) {
     const row = dataRows[i] as unknown[]
@@ -157,7 +162,7 @@ export function parseEmissionSourcesFile(
     }
 
     const siteName = col('site')
-    const resolvedStudySiteId = siteName ? resolveStudySiteId(siteName, studySites) : null
+    const resolvedStudySiteId = siteName ? resolveStudySiteId(siteName, studySiteNameMap) : null
     if (!siteName) {
       rowErrors.push({ key: 'missingSite' })
     } else if (!resolvedStudySiteId) {
@@ -267,6 +272,85 @@ export type ResolveEfRowsResult =
   | { type: 'ambiguous'; ambiguousRows: AmbiguousRow[] }
   | { type: 'resolved'; resolvedByLine: Map<number, ResolvedEf> }
 
+type EmissionFactorMatch = NonNullable<Awaited<ReturnType<typeof findEmissionFactorMatch>>>
+
+function collectWarningsAndAmbiguities(
+  row: ParsedEmissionSourceRow,
+  ef: EmissionFactorMatch | null,
+  warnings: ImportWarning[],
+  ambiguousRows: AmbiguousRow[],
+  locale: LocaleType,
+): void {
+  const lineNumber = row.lineNumber
+
+  if (
+    row.emissionFactorUnitRaw &&
+    row.emissionFactorUnit &&
+    row.emissionFactorUnit !== Unit.CUSTOM &&
+    !KG_CO2E_PREFIX_REGEX.test(row.emissionFactorUnitRaw)
+  ) {
+    warnings.push({
+      type: 'unitMissingPrefix',
+      lineNumber,
+      sourceName: row.name,
+      foundUnit: row.emissionFactorUnitRaw,
+      resolvedValue: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
+    })
+  }
+
+  if (!ef) {
+    const hasSomeEfData = !!(row.emissionFactorId || row.emissionFactorName)
+    if (hasSomeEfData) {
+      warnings.push({
+        type: 'efNotFound',
+        lineNumber,
+        sourceName: row.name,
+        searchedName: row.emissionFactorName,
+        searchedValue: row.emissionFactorValue,
+        searchedUnit: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
+      })
+    } else {
+      warnings.push({ type: 'efMissing', lineNumber, sourceName: row.name })
+    }
+    return
+  }
+
+  if (ef.matchType === EmissionFactorMatchType.NameAmbiguous) {
+    const tooMany = ef.candidates.length > MAX_FE_CANDIDATES
+    ambiguousRows.push({
+      lineNumber,
+      sourceName: row.name,
+      searchedName: row.emissionFactorName,
+      searchedValue: row.emissionFactorValue,
+      searchedUnit: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
+      tooMany,
+      candidates: tooMany
+        ? []
+        : ef.candidates.map((c) => ({
+            id: c.id,
+            foundTitle: c.foundTitle,
+            foundValue: c.foundValue,
+            foundUnit: formatPrefixedUnitDisplayOptional(locale, c.foundUnit),
+          })),
+    })
+    return
+  }
+
+  if (ef.matchType !== EmissionFactorMatchType.Exact) {
+    warnings.push({
+      type: 'efNotFound',
+      lineNumber,
+      sourceName: row.name,
+      searchedName: row.emissionFactorName,
+      searchedValue: row.emissionFactorValue,
+      searchedUnit: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
+      foundTitle: ef.foundTitle,
+      foundValue: ef.foundValue,
+      foundUnit: formatPrefixedUnitDisplayOptional(locale, ef.foundUnit),
+    })
+  }
+}
+
 export async function resolveEmissionFactorRows(
   rows: ParsedEmissionSourceRow[],
   choices: FEChoices | undefined,
@@ -281,22 +365,6 @@ export async function resolveEmissionFactorRows(
 
   for (const row of rows) {
     const lineNumber = row.lineNumber
-
-    if (
-      !resolvingChoices &&
-      row.emissionFactorUnitRaw &&
-      row.emissionFactorUnit &&
-      row.emissionFactorUnit !== Unit.CUSTOM &&
-      !KG_CO2E_PREFIX_REGEX.test(row.emissionFactorUnitRaw)
-    ) {
-      warnings.push({
-        type: 'unitMissingPrefix',
-        lineNumber,
-        sourceName: row.name,
-        foundUnit: row.emissionFactorUnitRaw,
-        resolvedValue: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
-      })
-    }
 
     if (choices !== undefined && lineNumber in choices) {
       const chosenId = choices[lineNumber]
@@ -329,66 +397,15 @@ export async function resolveEmissionFactorRows(
       versionIds,
     )
 
-    const hasSomeEfData = !!(row.emissionFactorId || row.emissionFactorName)
+    if (!resolvingChoices) {
+      collectWarningsAndAmbiguities(row, ef, warnings, ambiguousRows, locale)
+    }
 
-    if (!ef) {
-      if (!resolvingChoices) {
-        if (hasSomeEfData) {
-          warnings.push({
-            type: 'efNotFound',
-            lineNumber,
-            sourceName: row.name,
-            searchedName: row.emissionFactorName,
-            searchedValue: row.emissionFactorValue,
-            searchedUnit: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
-          })
-        } else {
-          warnings.push({ type: 'efMissing', lineNumber, sourceName: row.name })
-        }
-      }
-    } else if (ef.matchType === EmissionFactorMatchType.NameAmbiguous) {
-      const tooMany = ef.candidates.length > MAX_FE_CANDIDATES
-      ambiguousRows.push({
-        lineNumber,
-        sourceName: row.name,
-        searchedName: row.emissionFactorName,
-        searchedValue: row.emissionFactorValue,
-        searchedUnit: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
-        tooMany,
-        candidates: tooMany
-          ? []
-          : ef.candidates.map((c) => ({
-              id: c.id,
-              foundTitle: c.foundTitle,
-              foundValue: c.foundValue,
-              foundUnit: formatPrefixedUnitDisplayOptional(locale, c.foundUnit),
-            })),
-      })
-    } else if (ef.matchType !== EmissionFactorMatchType.Exact) {
-      if (!resolvingChoices) {
-        warnings.push({
-          type: 'efNotFound',
-          lineNumber,
-          sourceName: row.name,
-          searchedName: row.emissionFactorName,
-          searchedValue: row.emissionFactorValue,
-          searchedUnit: formatPrefixedUnitDisplayOptional(locale, row.emissionFactorUnit),
-          foundTitle: ef.foundTitle,
-          foundValue: ef.foundValue,
-          foundUnit: formatPrefixedUnitDisplayOptional(locale, ef.foundUnit),
-        })
-      }
+    if (ef && ef.matchType !== EmissionFactorMatchType.NameAmbiguous) {
       resolvedByLine.set(lineNumber, {
-        efId: ef.importedId ?? row.emissionFactorId ?? '',
-        efName: ef.foundTitle ?? row.emissionFactorName ?? '',
-        efValue: ef.foundValue !== undefined ? String(ef.foundValue) : '',
-        efUnit: formatPrefixedUnitDisplayOptional(locale, ef.foundUnit),
-      })
-    } else {
-      resolvedByLine.set(lineNumber, {
-        efId: ef.importedId ?? row.emissionFactorId ?? '',
-        efName: ef.foundTitle ?? row.emissionFactorName ?? '',
-        efValue: ef.foundValue !== undefined ? String(ef.foundValue) : '',
+        efId: ef.importedId ?? '',
+        efName: ef.foundTitle ?? '',
+        efValue: String(ef.foundValue),
         efUnit: formatPrefixedUnitDisplayOptional(locale, ef.foundUnit),
       })
     }

--- a/packages/i18n/translations/en/common.json
+++ b/packages/i18n/translations/en/common.json
@@ -46,7 +46,8 @@
       "unselectAll": "Unselect all",
       "back": "Back",
       "import": "Import",
-      "export": "Export"
+      "export": "Export",
+      "continue": "Continue"
     },
     "questions": {
       "glossary": {

--- a/packages/i18n/translations/es/common.json
+++ b/packages/i18n/translations/es/common.json
@@ -45,7 +45,8 @@
       "unselectAll": "Deseleccionar todos",
       "back": "Volver",
       "import": "Importar",
-      "export": "Exportar"
+      "export": "Exportar",
+      "continue": "Continuar"
     },
     "questions": {
       "glossary": {

--- a/packages/i18n/translations/fr/common.json
+++ b/packages/i18n/translations/fr/common.json
@@ -46,7 +46,8 @@
       "unselectAll": "Tout désélectionner",
       "back": "Retour",
       "import": "Importer",
-      "export": "Exporter"
+      "export": "Exporter",
+      "continue": "Continuer"
     },
     "questions": {
       "glossary": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2008,10 +2008,10 @@
   dependencies:
     "@formatjs/fast-memoize" "3.1.2"
 
-"@hono/node-server@1.19.11":
-  version "1.19.11"
-  resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.11.tgz#dc419f0826dd2504e9fc86ad289d5636a0444e2f"
-  integrity sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==
+"@hono/node-server@1.19.11", "@hono/node-server@^1.19.13":
+  version "1.19.14"
+  resolved "https://registry.yarnpkg.com/@hono/node-server/-/node-server-1.19.14.tgz#e30f844bc77e3ce7be442aac3b1f73ad8b58d181"
+  integrity sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==
 
 "@hookform/resolvers@^5.2.1":
   version "5.2.2"
@@ -6733,12 +6733,12 @@ fast-levenshtein@^2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
-fast-uri@^3.0.1:
+fast-uri@^3.0.1, fast-uri@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
   integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
 
-fast-xml-builder@^1.1.5:
+fast-xml-builder@^1.1.5, fast-xml-builder@^1.1.6:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz#abd2363145a7625d9789ad96da375fabe3cff28c"
   integrity sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==
@@ -7223,10 +7223,10 @@ hoist-non-react-statics@^3.3.1:
   dependencies:
     react-is "^16.7.0"
 
-hono@^4.12.8:
-  version "4.12.18"
-  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.18.tgz#f6d301938868c3a8bdb639495f4e326a19181505"
-  integrity sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==
+hono@^4.12.18, hono@^4.12.8:
+  version "4.12.24"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.24.tgz#193c8d65ab463747fdde9d05c0d7a67859270da7"
+  integrity sha512-I36D1s+HgQc55KbhEr4iybfxv/9o1zdpw+XEM6dJa91LqQD0HCoSGdxpRJCZE+aavs87j4V3Ls2OJzq8C/U4iw==
 
 html-encoding-sniffer@^4.0.0:
   version "4.0.0"
@@ -8689,12 +8689,7 @@ named-placeholders@^1.1.3:
   dependencies:
     lru.min "^1.1.0"
 
-nanoid@^3.3.11:
-  version "3.3.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
-  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
-
-nanoid@^3.3.6:
+nanoid@^3.3.12:
   version "3.3.12"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.12.tgz#ab3d912e217a6d0a514f00a72a16543a28982c05"
   integrity sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==
@@ -9163,7 +9158,7 @@ pgpass@1.0.5:
   dependencies:
     split2 "^4.1.0"
 
-picocolors@1.1.1, picocolors@^1.0.0, picocolors@^1.1.1:
+picocolors@1.1.1, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -9540,21 +9535,12 @@ postcss-value-parser@^4.0.0, postcss-value-parser@^4.2.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@8.4.31:
-  version "8.4.31"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.31.tgz#92b451050a9f914da6755af352bdc0192508656d"
-  integrity sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==
+postcss@8.4.31, postcss@^8.5.12, postcss@^8.5.14:
+  version "8.5.15"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.15.tgz#d1eaf677a324e9ec02196da2d3fecf4a0b9a735c"
+  integrity sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==
   dependencies:
-    nanoid "^3.3.6"
-    picocolors "^1.0.0"
-    source-map-js "^1.0.2"
-
-postcss@^8.5.14:
-  version "8.5.14"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.14.tgz#a66c2d7808fadf69ebb5b84a03f8bafd76c4919c"
-  integrity sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==
-  dependencies:
-    nanoid "^3.3.11"
+    nanoid "^3.3.12"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
@@ -10234,7 +10220,7 @@ slice-ansi@^8.0.0:
     ansi-styles "^6.2.3"
     is-fullwidth-code-point "^5.1.0"
 
-source-map-js@^1.0.2, source-map-js@^1.2.1:
+source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==


### PR DESCRIPTION
### Fonctionnalités  
- étape de choix parmi plusieurs FEs matchés avec choix de laisser vide
- warnings placés avant la preview
- preview qui n'affiche que les vraies données qui seront importées

### Tests

- [X] J'ai bien testé ma PR sur tous les environnements concernés
- [X] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [X] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
