### PR TITLE
2868 fixes fe fullname

### DIFF
--- a/apps/bilan-carbone/src/components/emissionFactor/EmissionFactorsTable.tsx
+++ b/apps/bilan-carbone/src/components/emissionFactor/EmissionFactorsTable.tsx
@@ -79,7 +79,8 @@ export const EmissionFactorsTable = ({
       {
         id: 'name',
         header: t('name'),
-        accessorFn: (emissionFactor) => getEmissionFactorFullName(emissionFactor.metaData),
+        accessorFn: (emissionFactor) =>
+          getEmissionFactorFullName(emissionFactor.metaData, '', emissionFactor.importedFrom),
         cell: ({ getValue, row }) => <EmissionFactorNameCell expanded={row.getIsExpanded()} getValue={getValue} />,
       },
       {

--- a/apps/bilan-carbone/src/components/study/EmissionSourceFactor.tsx
+++ b/apps/bilan-carbone/src/components/study/EmissionSourceFactor.tsx
@@ -115,7 +115,7 @@ const EmissionSourceFactor = ({
   }, [])
 
   useEffect(() => {
-    setValue(getEmissionFactorFullName(selectedFactor?.metaData))
+    setValue(getEmissionFactorFullName(selectedFactor?.metaData, '', selectedFactor?.importedFrom))
   }, [selectedFactor])
 
   const fuse = useMemo(() => {
@@ -196,7 +196,7 @@ const EmissionSourceFactor = ({
             >
               <p className={styles.header}>
                 {displayOnlyExistingDataWithDash([
-                  getEmissionFactorFullName(result.metaData) || undefined,
+                  getEmissionFactorFullName(result.metaData, '', result.importedFrom) || undefined,
                   result.location,
                   result.metaData?.location,
                   formatEmissionFactorNumber(getEmissionFactorValue(result, environment)),

--- a/apps/bilan-carbone/src/components/study/EmissionSourceForm.tsx
+++ b/apps/bilan-carbone/src/components/study/EmissionSourceForm.tsx
@@ -382,7 +382,7 @@ const EmissionSourceForm = ({
             </p>
           )}
           <p className={classNames(emissionFactorStyles.header, 'align-end')}>
-            {getEmissionFactorFullName(selectedFactor.metaData)}
+            {getEmissionFactorFullName(selectedFactor.metaData, '', selectedFactor.importedFrom)}
             {selectedFactor.location ? ` - ${selectedFactor.location}` : ''}
             {selectedFactor.metaData?.location ? ` - ${selectedFactor.metaData.location}` : ''} -{' '}
             {formatEmissionFactorNumber(getEmissionFactorValue(selectedFactor, environment))}

--- a/apps/bilan-carbone/src/db/emissionFactors.ts
+++ b/apps/bilan-carbone/src/db/emissionFactors.ts
@@ -598,7 +598,6 @@ export const findEmissionFactorByImportedIdForMatch = (id: string, organizationI
   prismaClient.emissionFactor.findFirst({
     where: {
       importedId: id,
-      status: { not: EmissionFactorStatus.Archived },
       OR: getOrganizationAndImportedVersionsFilters(organizationId, versionIds),
     },
     select: {

--- a/apps/bilan-carbone/src/db/emissionFactors.ts
+++ b/apps/bilan-carbone/src/db/emissionFactors.ts
@@ -598,6 +598,7 @@ export const findEmissionFactorByImportedIdForMatch = (id: string, organizationI
   prismaClient.emissionFactor.findFirst({
     where: {
       importedId: id,
+      status: { not: EmissionFactorStatus.Archived },
       OR: getOrganizationAndImportedVersionsFilters(organizationId, versionIds),
     },
     select: {
@@ -620,6 +621,7 @@ export const findEmissionFactorsByNameAndUnit = (
     where: {
       ...(unit ? { AND: [{ OR: [{ unit }, { customUnit: unit }] }] } : {}),
       metaData: { some: { language: locale, title: { equals: title, mode: Prisma.QueryMode.insensitive } } },
+      status: { not: EmissionFactorStatus.Archived },
       OR: getOrganizationAndImportedVersionsFilters(organizationId, versionIds),
     },
     select: {
@@ -635,6 +637,7 @@ export const findEmissionFactorsByUnit = (organizationId: string, unit: Unit, ve
   prismaClient.emissionFactor.findMany({
     where: {
       AND: [{ OR: [{ unit }, { customUnit: unit }] }],
+      status: { not: EmissionFactorStatus.Archived },
       OR: getOrganizationAndImportedVersionsFilters(organizationId, versionIds),
     },
     select: {

--- a/apps/bilan-carbone/src/services/serverFunctions/importEmissionFactors.ts
+++ b/apps/bilan-carbone/src/services/serverFunctions/importEmissionFactors.ts
@@ -155,7 +155,7 @@ export async function exportManualEmissionFactorsToFile(): Promise<ArrayBuffer> 
   const rows: (string | number)[][] = emissionFactors.map((ef) => {
     const metaData = ef.metaData.find((m) => m.language === locale) ?? ef.metaData[0]
     return [
-      getEmissionFactorFullName(metaData),
+      getEmissionFactorFullName(metaData, '', Import.Manual),
       metaData?.attribute ?? '',
       ef.customUnit
         ? formatPrefixedUnitDisplay(locale, Unit.CUSTOM, ef.customUnit)

--- a/apps/bilan-carbone/src/services/serverFunctions/importEmissionSources.ts
+++ b/apps/bilan-carbone/src/services/serverFunctions/importEmissionSources.ts
@@ -516,7 +516,7 @@ function buildEmissionSourceRow(
   const typeLabel = es.type ? (typeTranslations[es.type] ?? es.type) : ''
   const unitRaw = ef?.unit ? (unitTranslations[ef.unit] ?? ef.unit) : ''
   const unitLabel = unitRaw ? getSingularForm(unitRaw) : ''
-  const efTitle = getEmissionFactorFullName(ef?.metaData)
+  const efTitle = getEmissionFactorFullName(ef?.metaData, '', ef?.importedFrom)
   const efValue = ef ? getEmissionFactorValue(ef, study.organizationVersion.environment) : ''
   const efUnitLabel = ef?.unit ? formatPrefixedUnitDisplay(locale, ef.unit) : ''
   const feSpecificQuality = ef ? getSpecificEmissionFactorQuality(es) : null

--- a/apps/bilan-carbone/src/services/study.ts
+++ b/apps/bilan-carbone/src/services/study.ts
@@ -160,7 +160,7 @@ const getEmissionSourcesRows = (
           emissionFactor?.unit ? tUnit(emissionFactor.unit, { count: 1 }) : '',
           getQuality(getQualitativeUncertaintyFromQuality(emissionSource), tQuality),
           emissionSource.comment || '',
-          getEmissionFactorFullName(emissionFactor?.metaData, t('noFactor')),
+          getEmissionFactorFullName(emissionFactor?.metaData, t('noFactor'), emissionFactor?.importedFrom),
           emissionFactor
             ? getEmissionFactorValue(emissionFactor, environment).toLocaleString('fr-FR', { useGrouping: false })
             : '',

--- a/apps/bilan-carbone/src/services/study.utils.ts
+++ b/apps/bilan-carbone/src/services/study.utils.ts
@@ -194,7 +194,7 @@ const getEmissionSourcesRows = (
           emissionFactor?.unit ? tUnit(emissionFactor.unit, { count: 1 }) : '',
           getQuality(getQualitativeUncertaintyFromQuality(emissionSource), tQuality),
           emissionSource.comment || '',
-          getEmissionFactorFullName(emissionFactor?.metaData, t('noFactor')),
+          getEmissionFactorFullName(emissionFactor?.metaData, t('noFactor'), emissionFactor?.importedFrom),
           emissionFactor
             ? getEmissionFactorValue(emissionFactor, environment).toLocaleString('fr-FR', { useGrouping: false })
             : '',

--- a/apps/bilan-carbone/src/utils/emissionFactors.ts
+++ b/apps/bilan-carbone/src/utils/emissionFactors.ts
@@ -27,9 +27,13 @@ export const emissionFactorDefautQualityStar = '☆'
 export function getEmissionFactorFullName(
   metaData: { title?: string | null; attribute?: string | null; frontiere?: string | null } | null | undefined,
   valueIfMissing = '',
+  importedFrom?: Import | null,
 ): string {
   if (!metaData) {
     return valueIfMissing
+  }
+  if (importedFrom === Import.Manual) {
+    return metaData.title || valueIfMissing
   }
   return [metaData.title, metaData.attribute, metaData.frontiere].filter(Boolean).join(' - ') || valueIfMissing
 }


### PR DESCRIPTION
Fixes :
- On ne matche que les FEs non archivés durant l'import
- On affiche plus les atributes et frontiere pour les FEs manuels (on ne montre que le nom)

### Tests

- [X] J'ai bien testé ma PR sur tous les environnements concernés
- [X] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
