### PR TITLE
Fix/build size bc

### DIFF
--- a/.slugignore
+++ b/.slugignore
@@ -3,6 +3,7 @@
 apps/bilan-carbone/publicodes-packages/publicodes-clickson/node_modules
 apps/bilan-carbone/publicodes-packages/publicodes-count/node_modules
 apps/bilan-carbone/publicodes-packages/publicodes-tilt/node_modules
+apps/bilan-carbone/.next
 apps/bilan-carbone/.next/cache
 packages/*/node_modules
 node_modules/.cache

--- a/.slugignore
+++ b/.slugignore
@@ -8,3 +8,7 @@ packages/*/node_modules
 node_modules/.cache
 .cache
 cypress
+apps/mip/.next
+apps/mip/.next/cache
+packages/publicodes-packages/*/node_modules
+packages/publicodes-packages/publicodes-mip

--- a/.slugignore
+++ b/.slugignore
@@ -3,13 +3,11 @@
 apps/bilan-carbone/publicodes-packages/publicodes-clickson/node_modules
 apps/bilan-carbone/publicodes-packages/publicodes-count/node_modules
 apps/bilan-carbone/publicodes-packages/publicodes-tilt/node_modules
-apps/bilan-carbone/.next
 apps/bilan-carbone/.next/cache
 packages/*/node_modules
 node_modules/.cache
 .cache
 cypress
-apps/mip/.next
 apps/mip/.next/cache
 packages/publicodes-packages/*/node_modules
 packages/publicodes-packages/publicodes-mip

--- a/packages/i18n/publicodes/generate-translation-file.tsx
+++ b/packages/i18n/publicodes/generate-translation-file.tsx
@@ -29,7 +29,6 @@ const LOCALES_CLICKSON = [
 ] as const
 const LOCALES_TILT = [Locale.FR, Locale.EN]
 const LOCALES_CUT = [Locale.FR, Locale.EN, Locale.ES] as const
-const LOCALES_MIP = [Locale.FR, Locale.EN] as const
 const getLocales = () => {
   switch (model) {
     case 'clickson':
@@ -38,8 +37,6 @@ const getLocales = () => {
       return LOCALES_TILT
     case 'cut':
       return LOCALES_CUT
-    case 'mip':
-      return LOCALES_MIP
     default:
       throw new Error(`Unsupported model: ${model}`)
   }

--- a/packages/i18n/publicodes/utils.tsx
+++ b/packages/i18n/publicodes/utils.tsx
@@ -34,14 +34,13 @@ export const AVAILABLE_LOCALES: LocaleType[] = [
 ]
 // LocaleType already includes all supported locale codes as string values
 
-export const AVAILABLE_MODELS = ['cut', 'clickson', 'tilt', 'mip'] as const
+export const AVAILABLE_MODELS = ['cut', 'clickson', 'tilt'] as const
 export type Model = (typeof AVAILABLE_MODELS)[number]
 
 const MODEL_PACKAGES: Record<Model, string> = {
   cut: '@abc-transitionbascarbone/publicodes-count/publicodes-build/publicodes-count.model.json',
   clickson: '@abc-transitionbascarbone/publicodes-clickson/publicodes-build/publicodes-clickson.model.json',
   tilt: '@abc-transitionbascarbone/publicodes-tilt/publicodes-build/publicodes-tilt.model.json',
-  mip: '@abc-transitionbascarbone/publicodes-mip/publicodes-build/publicodes-mip.model.json',
 }
 
 // Helper to load publicodes rules from a given model


### PR DESCRIPTION
PR liée au(x) ticket(s) : https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/2976

Le vrai responsable était le **slugignore**, j'ai aussi retiré du code inutile lié aux traductions (qu'on a pas pour l'instant) de mip

J'ai aussi vu qu'on pouvait filtrer le build (mais pas possible de faire un build custom via scalingo)
`    "build": "turbo run build --filter=bilan-carbone...",`

Peut être à creuser une prochaine fois mais j'ai laissé de côté car ça n'a pas affecté la taille du build scalingo bizarrement

### Tests

- [ ] J'ai bien testé ma PR sur tous les environnements concernés
- [ ] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
