### PR TITLE
fix: solve accuracy issue in compensation and filter past objectives out

### DIFF
--- a/apps/bilan-carbone/src/constants/trajectory.constants.ts
+++ b/apps/bilan-carbone/src/constants/trajectory.constants.ts
@@ -28,3 +28,5 @@ export const TARGET_YEAR = 2050
 export const OVERSHOOT_THRESHOLD = 0.05
 export const SNBC_REFERENCE_YEAR = 1990
 export const SNBC_FINAL_TARGET_YEAR = 2050
+
+export const BUDGET_PRECISION_TOLERANCE_PERCENT = 1 // 1%

--- a/apps/bilan-carbone/src/utils/customTrajectory.utils.ts
+++ b/apps/bilan-carbone/src/utils/customTrajectory.utils.ts
@@ -229,7 +229,9 @@ export const calculateCustomTrajectory = ({
     return dataPoints
   }
 
-  let sortedObjectives = [...objectives].sort((a, b) => a.targetYear - b.targetYear)
+  let sortedObjectives = [...objectives]
+    .sort((a, b) => a.targetYear - b.targetYear)
+    .filter((o) => o.targetYear > studyStartYear)
 
   if (overshootAdjustment) {
     sortedObjectives = getObjectivesWithOvershootCompensation(

--- a/apps/bilan-carbone/src/utils/snbc.test.ts
+++ b/apps/bilan-carbone/src/utils/snbc.test.ts
@@ -329,11 +329,11 @@ describe('SNBC Trajectory', () => {
     const expectBudgetsEqual = (actual: number, expected: number) => {
       const relativeDifference = Math.abs(actual - expected) / expected
       if (relativeDifference > 0.01) {
-        console.warn(`🚨 Budget precision of ${(relativeDifference * 100).toFixed(2)}% exceeds 5% threshold.`)
+        console.warn(`🚨 Budget precision of ${(relativeDifference * 100).toFixed(2)}% exceeds 1% threshold.`)
       } else {
-        console.log(`✅ Budget precision of ${(relativeDifference * 100).toFixed(2)}% is within 5% threshold.`)
+        console.log(`✅ Budget precision of ${(relativeDifference * 100).toFixed(2)}% is within 1% threshold.`)
       }
-      expect(relativeDifference).toBeLessThan(0.01) // 5% max
+      expect(relativeDifference).toBeLessThan(0.01) // 1% max
     }
 
     const testSNBCSectoralBudgetEquality = (

--- a/apps/bilan-carbone/src/utils/snbc.test.ts
+++ b/apps/bilan-carbone/src/utils/snbc.test.ts
@@ -328,7 +328,12 @@ describe('SNBC Trajectory', () => {
   describe('calculateCustomSNBCSectoralTrajectory - budget equality with overshoot', () => {
     const expectBudgetsEqual = (actual: number, expected: number) => {
       const relativeDifference = Math.abs(actual - expected) / expected
-      expect(relativeDifference).toBeLessThan(0.05) // 5% max
+      if (relativeDifference > 0.01) {
+        console.warn(`🚨 Budget precision of ${(relativeDifference * 100).toFixed(2)}% exceeds 5% threshold.`)
+      } else {
+        console.log(`✅ Budget precision of ${(relativeDifference * 100).toFixed(2)}% is within 5% threshold.`)
+      }
+      expect(relativeDifference).toBeLessThan(0.01) // 5% max
     }
 
     const testSNBCSectoralBudgetEquality = (

--- a/apps/bilan-carbone/src/utils/snbc.test.ts
+++ b/apps/bilan-carbone/src/utils/snbc.test.ts
@@ -1,4 +1,5 @@
 import {
+  BUDGET_PRECISION_TOLERANCE_PERCENT,
   SNBC_SECTOR_TARGET_EMISSIONS,
   TRAJECTORY_SNBC_ENERGY_ID,
   TRAJECTORY_SNBC_GENERAL_ID,
@@ -327,13 +328,17 @@ describe('SNBC Trajectory', () => {
 
   describe('calculateCustomSNBCSectoralTrajectory - budget equality with overshoot', () => {
     const expectBudgetsEqual = (actual: number, expected: number) => {
-      const relativeDifference = Math.abs(actual - expected) / expected
-      if (relativeDifference > 0.01) {
-        console.warn(`🚨 Budget precision of ${(relativeDifference * 100).toFixed(2)}% exceeds 1% threshold.`)
+      const relativeDifference = (Math.abs(actual - expected) / expected) * 100
+      if (relativeDifference > BUDGET_PRECISION_TOLERANCE_PERCENT) {
+        console.warn(
+          `🚨 Budget precision of ${relativeDifference.toFixed(2)}% exceeds ${BUDGET_PRECISION_TOLERANCE_PERCENT}% threshold.`,
+        )
       } else {
-        console.log(`✅ Budget precision of ${(relativeDifference * 100).toFixed(2)}% is within 1% threshold.`)
+        console.log(
+          `✅ Budget precision of ${relativeDifference.toFixed(2)}% is within ${BUDGET_PRECISION_TOLERANCE_PERCENT}% threshold.`,
+        )
       }
-      expect(relativeDifference).toBeLessThan(0.01) // 1% max
+      expect(relativeDifference).toBeLessThan(BUDGET_PRECISION_TOLERANCE_PERCENT) // 1% max
     }
 
     const testSNBCSectoralBudgetEquality = (

--- a/apps/bilan-carbone/src/utils/trajectory-shared.utils.ts
+++ b/apps/bilan-carbone/src/utils/trajectory-shared.utils.ts
@@ -405,20 +405,9 @@ export const getObjectivesWithOvershootCompensation = (
     return objectives
   }
 
-  const referenceEmissionsAtStudyYear = getTrajectoryEmissionsAtYear(referenceTrajectory, studyYear)
-  if (referenceEmissionsAtStudyYear === null) {
-    return objectives
-  }
-
-  // Calculate future budget if we were at reference emissions
-  // Use objectives directly since they represent the actual trajectory behavior
-  // (for SNBC_SECTORAL, objectives are derived from the combined sectoral trajectory)
-  const referenceFutureBudget = calculateBudgetWithObjectivesAndMultiplier(
-    referenceEmissionsAtStudyYear,
-    studyYear,
-    objectives,
-    1,
-  )
+  // Read the reference future budget directly from referenceTrajectory for accurate comparison
+  const lastObjectiveYear = objectives[objectives.length - 1].targetYear
+  const referenceFutureBudget = calculateTrajectoryIntegral(referenceTrajectory, studyYear, lastObjectiveYear)
 
   // Reduce future budget to compensate for past overshoot
   const remainingTotalBudget = referenceFutureBudget - pastOvershoot

--- a/apps/bilan-carbone/src/utils/trajectory.test.ts
+++ b/apps/bilan-carbone/src/utils/trajectory.test.ts
@@ -1,4 +1,9 @@
-import { SBTI_REDUCTION_RATE_15, SBTI_REDUCTION_RATE_WB2C, TARGET_YEAR } from '@/constants/trajectory.constants'
+import {
+  BUDGET_PRECISION_TOLERANCE_PERCENT,
+  SBTI_REDUCTION_RATE_15,
+  SBTI_REDUCTION_RATE_WB2C,
+  TARGET_YEAR,
+} from '@/constants/trajectory.constants'
 import type { BaseObjective, PastStudy, TrajectoryDataPoint, TrajectoryWithObjectives } from '@/types/trajectory.types'
 import { Action } from '@abc-transitionbascarbone/db-common'
 import { StudyResultUnit, TrajectoryType } from '@abc-transitionbascarbone/db-common/enums'
@@ -1523,8 +1528,6 @@ describe('calculateTrajectory', () => {
       })
     })
   })
-
-  const BUDGET_PRECISION_TOLERANCE_PERCENT = 1
 
   const expectBudgetsApproximatelyEqual = (actual: number, expected: number) => {
     const difference = Math.abs(actual - expected)

--- a/apps/bilan-carbone/src/utils/trajectory.test.ts
+++ b/apps/bilan-carbone/src/utils/trajectory.test.ts
@@ -1531,7 +1531,11 @@ describe('calculateTrajectory', () => {
     const relativeDifference = (difference / expected) * 100
     if (relativeDifference > BUDGET_PRECISION_TOLERANCE_PERCENT) {
       console.warn(
-        `WARNING: Budget precision exceeds ${BUDGET_PRECISION_TOLERANCE_PERCENT}% threshold. Actual precision: ${relativeDifference.toFixed(2)}%`,
+        `🚨 Budget precision of ${relativeDifference.toFixed(2)}% exceeds ${BUDGET_PRECISION_TOLERANCE_PERCENT}% threshold.`,
+      )
+    } else {
+      console.log(
+        `✅ Budget precision of ${relativeDifference.toFixed(2)}% is within ${BUDGET_PRECISION_TOLERANCE_PERCENT}% threshold.`,
       )
     }
     expect(relativeDifference).toBeLessThanOrEqual(BUDGET_PRECISION_TOLERANCE_PERCENT)
@@ -1617,6 +1621,55 @@ describe('calculateTrajectory', () => {
       testBudgetEqualityWithCompensation(2023, 2025, 1000, 1200, objectives, createPastStudies([2023, 1000]))
       testBudgetEqualityWithCompensation(2022, 2025, 1000, 1200, objectives, createPastStudies([2022, 1000]))
       testBudgetEqualityWithCompensation(2020, 2025, 1000, 1200, objectives, createPastStudies([2020, 1000]))
+    })
+
+    test('past objective: one objective in the past, two in the future — budget conserved within 1%', () => {
+      const objectives = [
+        { targetYear: 2023, reductionRate: 0.05 }, // past — already elapsed at study time
+        { targetYear: 2035, reductionRate: 0.05 },
+        { targetYear: 2050, reductionRate: 0.03 },
+      ]
+      testBudgetEqualityWithCompensation(
+        2020,
+        2026,
+        1000,
+        900,
+        objectives,
+        createPastStudies([2020, 1000], [2023, 850]),
+      )
+    })
+
+    test('past objective: stronger overshoot with past objective — budget conserved within 1%', () => {
+      const objectives = [
+        { targetYear: 2022, reductionRate: 0.04 }, // past
+        { targetYear: 2030, reductionRate: 0.06 },
+        { targetYear: 2045, reductionRate: 0.04 },
+      ]
+      testBudgetEqualityWithCompensation(
+        2020,
+        2025,
+        1000,
+        1100,
+        objectives,
+        createPastStudies([2020, 1000], [2022, 920]),
+      )
+    })
+
+    test('past objective: multiple past objectives, only future ones carry the compensation — budget conserved within 1%', () => {
+      const objectives = [
+        { targetYear: 2021, reductionRate: 0.03 }, // past
+        { targetYear: 2023, reductionRate: 0.04 }, // past
+        { targetYear: 2030, reductionRate: 0.05 },
+        { targetYear: 2050, reductionRate: 0.03 },
+      ]
+      testBudgetEqualityWithCompensation(
+        2020,
+        2026,
+        1000,
+        1000,
+        objectives,
+        createPastStudies([2020, 1000], [2021, 970], [2023, 892]),
+      )
     })
   })
 

--- a/apps/bilan-carbone/src/utils/trajectory.test.ts
+++ b/apps/bilan-carbone/src/utils/trajectory.test.ts
@@ -1623,6 +1623,24 @@ describe('calculateTrajectory', () => {
       testBudgetEqualityWithCompensation(2020, 2025, 1000, 1200, objectives, createPastStudies([2020, 1000]))
     })
 
+    test('budget equality with 10 year gap between referenceYear and currentYear', () => {
+      const objectives = [
+        { targetYear: 2030, reductionRate: 0.02 },
+        { targetYear: 2040, reductionRate: 0.04 },
+      ]
+
+      testBudgetEqualityWithCompensation(2015, 2025, 1000, 1200, objectives, createPastStudies([2015, 1000]))
+    })
+
+    test('budget equality with 20 year gap between referenceYear and currentYear', () => {
+      const objectives = [
+        { targetYear: 2030, reductionRate: 0.02 },
+        { targetYear: 2040, reductionRate: 0.04 },
+      ]
+
+      testBudgetEqualityWithCompensation(2005, 2025, 1000, 1200, objectives, createPastStudies([2005, 1000]))
+    })
+
     test('past objective: one objective in the past, two in the future — budget conserved within 1%', () => {
       const objectives = [
         { targetYear: 2023, reductionRate: 0.05 }, // past — already elapsed at study time


### PR DESCRIPTION
Il y avait en effet un bug sur le calcul de compensation et précisément sur le calcul du referenceFutureBudget lorsqu'on a des objectifs passés, mais pas que ! J'ai aussi trouvé une imprécision sur la compensation en général.

Avant : On récupérait la valeur de référence (referenceEmissionsAtStudyYear) de la trajectoire de référence directement, puis on y appliquait les objectifs non compensés pour trouver la pente mais c'est imprécis puisqu'il nous faut la pente depuis la référence et non depuis l'année de l'étude. En gros, plus les années de référence et de l'étude étaient éloignées, et moins la compensation était précise.
Maintenant : On calcule le budget de référence futur avec l'intégrale de la vraie courbe de référence et non pas avec une estimation imprécise depuis l'année de l'étude.

### Tests

- [X] J'ai bien testé ma PR sur tous les environnements concernés
- [ ] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [X] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
