### PR TITLE
refactor: removing useless tsconfig alias

### DIFF
--- a/apps/bilan-carbone/tsconfig.json
+++ b/apps/bilan-carbone/tsconfig.json
@@ -11,8 +11,6 @@
     "paths": {
       "@/*": ["./src/*"],
       "@abc-transitionbascarbone/css": ["../../packages/css/index.ts"],
-      "@abc-transitionbascarbone/lib": ["../../packages/lib/src/index.ts"],
-      "@abc-transitionbascarbone/i18n/*": ["../../packages/i18n/*"],
       "@abc-transitionbascarbone/publicodes-count": ["../../packages/publicodes-packages/publicodes-count"],
       "@abc-transitionbascarbone/publicodes-clickson": ["../../packages/publicodes-packages/publicodes-clickson"],
       "@abc-transitionbascarbone/publicodes-tilt": ["../../packages/publicodes-packages/publicodes-tilt"]

--- a/apps/mip/tsconfig.json
+++ b/apps/mip/tsconfig.json
@@ -9,9 +9,6 @@
     "paths": {
       "@/*": ["./src/*"],
       "@abc-transitionbascarbone/css": ["../../packages/css/index.ts"],
-      "@abc-transitionbascarbone/i18n/*": ["../../packages/i18n/*"],
-      "@abc-transitionbascarbone/survey": ["../../packages/survey/src/index.ts"],
-      "@abc-transitionbascarbone/publicodes": ["../../packages/publicodes/*"],
       "@abc-transitionbascarbone/publicodes-mip": ["../../packages/publicodes-packages/publicodes-mip"]
     }
   },

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -13,16 +13,6 @@
     "jsx": "react-jsx",
     "target": "ES2017",
     "incremental": true,
-    "types": ["node"],
-    "paths": {
-      "@abc-transitionbascarbone/db-common": ["packages/db-common/src/index.ts"],
-      "@abc-transitionbascarbone/db-common/enums": ["packages/db-common/src/enums.ts"],
-      "@abc-transitionbascarbone/db-common/types": ["packages/db-common/src/types.ts"],
-      "@abc-transitionbascarbone/css": ["packages/css/index.ts"],
-      "@abc-transitionbascarbone/survey": ["packages/survey/src/index.ts"],
-      "@abc-transitionbascarbone/lib": ["packages/lib/src/index.ts"],
-      "@abc-transitionbascarbone/publicodes/*": ["packages/publicodes/*"],
-      "@abc-transitionbascarbone/i18n/*": ["../../packages/i18n/*"]
-    }
+    "types": ["node"]
   }
 }


### PR DESCRIPTION
PR liée au(x) ticket(s) : https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/2908

Résumé :
- si le package à un package.json on l'ajoute aux dépendance des package.json des apps
- Si il n'a pas de package.json (exemple css) on l'ajoute aux tsconfig
- ajouter aux path tsconfig.base est inutile si il y a des path dans tsconfig des apps (car ça écrit par dessus)

### Tests

- [ ] J'ai bien testé ma PR sur tous les environnements concernés
- [ ] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
