### PR TITLE
fix: objective name and subobjective name saved and searchable

### DIFF
--- a/apps/bilan-carbone/src/components/study/trajectory/ObjectiveModal.tsx
+++ b/apps/bilan-carbone/src/components/study/trajectory/ObjectiveModal.tsx
@@ -71,11 +71,10 @@ const ObjectiveModal = ({
         ],
       }
     : {
-        name: '',
         siteIds: allSiteIds,
         tagIds: allTagIds,
         subPosts: allEnvSubPosts,
-        objectives: [{ startYear: '', targetYear: '', reductionRate: 0 }],
+        objectives: [{ name: '', startYear: '', targetYear: '', reductionRate: 0 }],
       }
 
   const { control, handleSubmit, watch, reset, setValue, formState } = useForm<ObjectiveModalFormData>({

--- a/apps/bilan-carbone/src/components/study/trajectory/ObjectivesExpandedRow.tsx
+++ b/apps/bilan-carbone/src/components/study/trajectory/ObjectivesExpandedRow.tsx
@@ -157,6 +157,7 @@ const ObjectivesExpandedRow = ({
 
     return {
       id: objective.id,
+      name: objective.name,
       period: getPeriod(prevYear, objective.targetYear),
       reductionRate: objective.reductionRate,
       correctedRate,

--- a/apps/bilan-carbone/src/components/study/trajectory/ObjectivesInnerTable.tsx
+++ b/apps/bilan-carbone/src/components/study/trajectory/ObjectivesInnerTable.tsx
@@ -14,6 +14,7 @@ import styles from './ObjectivesTable.module.css'
 
 export type ObjectiveRow = {
   id: string
+  name?: string | null
   period: string
   reductionRate: number
   correctedRate?: number

--- a/apps/bilan-carbone/src/components/study/trajectory/ObjectivesTable.tsx
+++ b/apps/bilan-carbone/src/components/study/trajectory/ObjectivesTable.tsx
@@ -85,7 +85,10 @@ interface Props {
 }
 
 const fuseOptions = {
-  keys: [{ name: 'name', weight: 1 }],
+  keys: [
+    { name: 'name', weight: 1 },
+    { name: 'objectives.name', weight: 0.5 },
+  ],
   ...DEFAULT_FUZZY_OPTIONS,
 }
 

--- a/apps/bilan-carbone/src/components/study/trajectory/TrajectoryCreationModal.tsx
+++ b/apps/bilan-carbone/src/components/study/trajectory/TrajectoryCreationModal.tsx
@@ -63,6 +63,7 @@ const getDefaultValues = (defaultSnbcSectoralPercentages?: SectorPercentages | n
   description: '',
   referenceYear: SBTI_START_YEAR.toString(),
   objectives: Array.from({ length: 2 }).map(() => ({
+    name: '',
     targetYear: null,
     reductionRate: null,
   })),
@@ -163,6 +164,7 @@ const TrajectoryCreationModal = ({
         description: trajectory.description || '',
         referenceYear: trajectory.referenceYear?.toString(),
         objectives: defaultObjectives.map((obj) => ({
+          name: obj.name ?? '',
           targetYear: obj.targetYear.toString(),
           reductionRate: Number((obj.reductionRate * 100).toFixed(2)),
         })),
@@ -350,6 +352,7 @@ const TrajectoryCreationModal = ({
           .filter((obj) => obj.targetYear && obj.reductionRate !== null && obj.reductionRate !== undefined)
           .map((obj, index) => ({
             id: defaultObjectives[index]?.id,
+            name: obj.name,
             targetYear: getYearFromDateStr(obj.targetYear!),
             reductionRate: Number((obj.reductionRate! / 100).toFixed(4)),
           }))
@@ -391,6 +394,7 @@ const TrajectoryCreationModal = ({
 
     if (data.trajectoryType === TrajectoryType.CUSTOM) {
       input.objectives = data.objectives.map((obj) => ({
+        name: obj.name,
         targetYear: getYearFromDateStr(obj.targetYear!),
         reductionRate: Number((obj.reductionRate! / 100).toFixed(4)), // Keep precision of 2 digits percentage so 0.01% = 0.0001 => 4 digits
       }))

--- a/apps/bilan-carbone/src/services/serverFunctions/objective.serverFunction.ts
+++ b/apps/bilan-carbone/src/services/serverFunctions/objective.serverFunction.ts
@@ -94,6 +94,7 @@ export const createSubObjectives = async (inputs: CreateObjectiveInput[]) =>
       const createdObjectives = await createManyObjectivesAndReturn(
         inputs.map((input) => ({
           trajectoryId: input.trajectoryId,
+          name: input.name,
           targetYear: input.targetYear,
           startYear: input.startYear,
           reductionRate: input.reductionRate,

--- a/apps/bilan-carbone/src/services/serverFunctions/trajectory.command.ts
+++ b/apps/bilan-carbone/src/services/serverFunctions/trajectory.command.ts
@@ -22,6 +22,7 @@ export const createObjectiveSchema = () =>
   z
     .object({
       id: z.string().optional(),
+      name: z.string().optional(),
       startYear: z.string().optional().nullable(),
       targetYear: z.string().optional().nullable(),
       reductionRate: z

--- a/apps/bilan-carbone/src/services/serverFunctions/trajectory.serverFunction.ts
+++ b/apps/bilan-carbone/src/services/serverFunctions/trajectory.serverFunction.ts
@@ -61,6 +61,7 @@ export interface CreateTrajectoryInput {
   sectorPercentages?: SectorPercentages | null
   isDefault?: boolean
   objectives?: {
+    name?: string
     targetYear: number
     reductionRate: number
   }[]
@@ -72,7 +73,7 @@ export interface UpdateTrajectoryInput {
   type?: TrajectoryType
   referenceYear?: number | null
   sectorPercentages?: SectorPercentages | null
-  objectives?: Array<{ id?: string; targetYear: number; reductionRate: number }>
+  objectives?: Array<{ id?: string; name?: string; targetYear: number; reductionRate: number }>
 }
 
 export const createTrajectoryWithObjectives = async (input: CreateTrajectoryInput) =>
@@ -230,6 +231,7 @@ export const updateTrajectory = async (id: string, data: UpdateTrajectoryInput) 
               return tx.objective.update({
                 where: { id: obj.id },
                 data: {
+                  name: obj.name,
                   targetYear: obj.targetYear,
                   reductionRate: obj.reductionRate,
                 },
@@ -238,6 +240,7 @@ export const updateTrajectory = async (id: string, data: UpdateTrajectoryInput) 
               return tx.objective.create({
                 data: {
                   trajectoryId: id,
+                  name: obj.name,
                   targetYear: obj.targetYear,
                   reductionRate: obj.reductionRate,
                   isDefault: true,


### PR DESCRIPTION
J'en ai profité pour rendre les noms d'objectifs et sous objectifs cherchables. Donc une partie de ce ticket est faite > https://github.com/ABC-TransitionBasCarbone/bilan-carbone/issues/1819

### Tests

- [X] J'ai bien testé ma PR sur tous les environnements concernés
- [X] J'ai bien testé que ca n'avait pas d'impact sur les environnements non concernés
- [ ] J'ai écrit les tests unitaires pour toutes les fonctions de logique

### Informations à remplir

- [ ] J'ai indiqué les informations sur le fichier de MEP
- [ ] J'ai indiqué les informations pour le déploiement sur staging ainsi que les fonctionnalités potentiellement impactées
